### PR TITLE
feat: add image attachment support to agent conversations

### DIFF
--- a/dashboard/src/components/AgentSession.tsx
+++ b/dashboard/src/components/AgentSession.tsx
@@ -11,6 +11,25 @@ import { MentionTextarea, type FileEntry } from "@/components/MentionTextarea";
 import { DiffView, type DiffFile } from "@/components/DiffView";
 
 // ---------------------------------------------------------------------------
+// Image helpers
+
+function readFileAsBase64(file: File): Promise<{ data: string; mimeType: string }> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result as string;
+      // strip the data:image/...;base64, prefix
+      const base64 = result.split(",")[1];
+      resolve({ data: base64, mimeType: file.type });
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
+const IMAGE_MIME_RE = /^image\//;
+
+// ---------------------------------------------------------------------------
 // Event → transcript reduction
 
 interface SessionEvent {
@@ -28,13 +47,18 @@ interface ToolCallRow {
 }
 
 type Block =
-  | { type: "user"; text: string; key: string }
+  | { type: "user"; text: string; key: string; images?: Array<{ data: string; mimeType: string }> }
   | { type: "agent"; text: string; key: string }
   | { type: "thought"; text: string; key: string }
   | { type: "tools"; calls: ToolCallRow[]; key: string }
   | { type: "graph"; verb: string; nodeIds: string[]; key: string }
   | { type: "plan"; entries: Array<{ content: string; status: string }>; key: string }
   | { type: "error"; text: string; key: string };
+
+interface ImageAttachment {
+  data: string; // base64-encoded
+  mimeType: string;
+}
 
 interface PermissionReq {
   requestId: string;
@@ -118,10 +142,11 @@ function reduceEvents(events: SessionEvent[]): {
     switch (ev.kind) {
       case "user_prompt": {
         const text = String(d.text ?? "");
+        const images = Array.isArray(d.images) ? (d.images as Array<{ data: string; mimeType: string }>) : undefined;
         // Hide the injected graph preamble — show only the human part.
         const idx = text.indexOf("\n\n");
         const shown = text.startsWith("You have access to") && idx > 0 ? text.slice(idx + 2) : text;
-        blocks.push({ type: "user", text: shown, key: `u${ev.seq}` });
+        blocks.push({ type: "user", text: shown, key: `u${ev.seq}`, images });
         break;
       }
       case "status": {
@@ -272,6 +297,7 @@ export function AgentSession({ id }: { id: string }) {
   const [meta, setMeta] = useState<{ backend?: string; repo?: string; title?: string; cwd?: string } | null>(null);
   const [openHint, setOpenHint] = useState("");
   const [input, setInput] = useState("");
+  const [attachments, setAttachments] = useState<ImageAttachment[]>([]);
   const [sendError, setSendError] = useState("");
   const [busy, setBusy] = useState(false);
   const [connected, setConnected] = useState(false);
@@ -478,8 +504,10 @@ export function AgentSession({ id }: { id: string }) {
 
   async function send() {
     const text = input.trim();
-    if (!text) return;
+    if (!text && attachments.length === 0) return;
+    const currentAttachments = [...attachments];
     setInput("");
+    setAttachments([]);
     setSendError("");
     setBusy(true);
     // Show it immediately and snap to the bottom — no waiting on the round-trip.
@@ -494,10 +522,12 @@ export function AgentSession({ id }: { id: string }) {
         return next;
       });
     try {
+      const body: { text: string; images?: ImageAttachment[] } = { text };
+      if (currentAttachments.length > 0) body.images = currentAttachments;
       const res = await fetch(`/api/agents/sessions/${id}/prompt`, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ text }),
+        body: JSON.stringify(body),
       });
       if (!res.ok) {
         const d = await res.json().catch(() => ({}));
@@ -515,6 +545,39 @@ export function AgentSession({ id }: { id: string }) {
     } finally {
       setBusy(false);
     }
+  }
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  async function handlePaste(e: React.ClipboardEvent<HTMLTextAreaElement>) {
+    const items = Array.from(e.clipboardData.items);
+    const imageItems = items.filter((item) => IMAGE_MIME_RE.test(item.type));
+    if (imageItems.length === 0) return; // let default paste behavior handle text
+    e.preventDefault();
+    const newAttachments: ImageAttachment[] = [];
+    for (const item of imageItems) {
+      const file = item.getAsFile();
+      if (!file) continue;
+      newAttachments.push(await readFileAsBase64(file));
+    }
+    if (newAttachments.length > 0) {
+      setAttachments((prev) => [...prev, ...newAttachments]);
+    }
+  }
+
+  async function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = Array.from(e.target.files ?? []);
+    const newAttachments: ImageAttachment[] = [];
+    for (const file of files) {
+      if (IMAGE_MIME_RE.test(file.type)) {
+        newAttachments.push(await readFileAsBase64(file));
+      }
+    }
+    if (newAttachments.length > 0) {
+      setAttachments((prev) => [...prev, ...newAttachments]);
+    }
+    // reset so re-selecting the same file works
+    if (fileInputRef.current) fileInputRef.current.value = "";
   }
 
   const pill = archived ? { kind: "idle" as const, label: "Archived" } : statusPill(view.status);
@@ -661,6 +724,18 @@ export function AgentSession({ id }: { id: string }) {
                 case "user":
                   return (
                     <div key={b.key} className="self-end max-w-[85%] rounded-lg px-3.5 py-2.5" style={{ background: "var(--accent)" }}>
+                      {b.images && b.images.length > 0 && (
+                        <div className="flex gap-2 flex-wrap mb-2">
+                          {b.images.map((img, i) => (
+                            <img
+                              key={i}
+                              src={`data:${img.mimeType};base64,${img.data}`}
+                              alt={`Attachment ${i + 1}`}
+                              className="max-h-40 max-w-[200px] object-contain rounded-md border border-line"
+                            />
+                          ))}
+                        </div>
+                      )}
                       <p className="text-ink text-[13.5px] whitespace-pre-wrap break-words">{b.text}</p>
                     </div>
                   );
@@ -849,34 +924,79 @@ export function AgentSession({ id }: { id: string }) {
               {sendError}
             </p>
           )}
-          <div className="border-t border-line px-4 py-3 flex gap-2 items-end" style={{ background: "var(--cream)" }}>
-            <MentionTextarea
-              value={input}
-              onChange={(v) => {
-                setInput(v);
-                if (sendError) setSendError("");
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && !e.shiftKey) {
-                  e.preventDefault();
-                  send();
+          <div className="border-t border-line px-4 py-3 flex flex-col gap-2" style={{ background: "var(--cream)" }}>
+            {/* Image previews */}
+            {attachments.length > 0 && (
+              <div className="flex gap-2 flex-wrap">
+                {attachments.map((img, i) => (
+                  <div key={i} className="relative group">
+                    <img
+                      src={`data:${img.mimeType};base64,${img.data}`}
+                      alt={`Attachment ${i + 1}`}
+                      className="h-16 w-16 object-cover rounded-md border border-line"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setAttachments((prev) => prev.filter((_, j) => j !== i))}
+                      className="absolute -top-1.5 -right-1.5 w-4 h-4 rounded-full bg-ink text-paper text-[10px] flex items-center justify-center opacity-0 group-hover:opacity-100 transition"
+                    >
+                      ×
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+            <div className="flex gap-2 items-end">
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                multiple
+                onChange={handleFileSelect}
+                className="hidden"
+              />
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={archived}
+                className="flex-shrink-0 w-8 h-8 flex items-center justify-center rounded-lg border border-line hover:bg-paper transition text-text-muted hover:text-ink disabled:opacity-50"
+                title="Attach image"
+              >
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                  <rect x="2" y="2" width="12" height="12" rx="2" />
+                  <circle cx="5.5" cy="5.5" r="1.5" />
+                  <path d="M14 10.5l-3.5-3.5L4 14" />
+                </svg>
+              </button>
+              <MentionTextarea
+                value={input}
+                onChange={(v) => {
+                  setInput(v);
+                  if (sendError) setSendError("");
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    send();
+                  }
+                }}
+                onPaste={handlePaste}
+                fetchFiles={fetchFiles}
+                placeholder={
+                  archived
+                    ? "This session ended before the last restart — start a new one to continue."
+                    : running
+                    ? "Steer the agent — this interrupts and redirects it… (@ to tag a file, paste images)"
+                    : "Send a follow-up… (@ to tag a file, paste images)"
                 }
-              }}
-              fetchFiles={fetchFiles}
-              placeholder={
-                archived
-                  ? "This session ended before the last restart — start a new one to continue."
-                  : running
-                  ? "Steer the agent — this interrupts and redirects it… (@ to tag a file)"
-                  : "Send a follow-up… (@ to tag a file)"
-              }
-              rows={1}
-              disabled={archived}
-              className="w-full rounded-lg border border-line bg-paper px-3 py-2 text-[13.5px] text-ink placeholder:text-text-muted/60 focus:outline-none resize-none disabled:opacity-50"
-            />
-            <Button onClick={send} disabled={archived || !input.trim() || busy}>
-              {running ? "Steer" : "Send"}
-            </Button>
+                rows={1}
+                disabled={archived}
+                className="w-full rounded-lg border border-line bg-paper px-3 py-2 text-[13.5px] text-ink placeholder:text-text-muted/60 focus:outline-none resize-none disabled:opacity-50"
+              />
+              <Button onClick={send} disabled={archived || (!input.trim() && attachments.length === 0) || busy}>
+                {running ? "Steer" : "Send"}
+              </Button>
+            </div>
           </div>
         </div>
 

--- a/dashboard/src/components/MentionTextarea.tsx
+++ b/dashboard/src/components/MentionTextarea.tsx
@@ -14,6 +14,7 @@ interface MentionTextareaProps {
   onChange: (value: string) => void;
   fetchFiles: (query: string) => Promise<FileEntry[]>;
   onKeyDown?: (e: KeyboardEvent<HTMLTextAreaElement>) => void;
+  onPaste?: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void;
   placeholder?: string;
   disabled?: boolean;
   rows?: number;
@@ -35,6 +36,7 @@ export function MentionTextarea({
   onChange,
   fetchFiles,
   onKeyDown,
+  onPaste,
   placeholder,
   disabled,
   rows = 1,
@@ -131,6 +133,7 @@ export function MentionTextarea({
         }}
         onKeyDown={handleKeyDown}
         onKeyUp={syncMention}
+        onPaste={onPaste}
         onClick={syncMention}
         onBlur={() => setTimeout(() => setOpen(false), 120)}
         placeholder={placeholder}

--- a/orchestrator/src/agents/routes.ts
+++ b/orchestrator/src/agents/routes.ts
@@ -123,9 +123,9 @@ export function registerAgentRoutes(app: FastifyInstance): void {
 
   app.post("/v1/agents/sessions/:id/prompt", async (req, reply) => {
     const { id } = req.params as { id: string };
-    const { text } = req.body as { text?: string };
+    const { text, images } = req.body as { text?: string; images?: Array<{ data: string; mimeType: string }> };
     if (!text?.trim()) return reply.code(400).send({ error: "text required" });
-    const r = await steer(id, text.trim());
+    const r = await steer(id, text.trim(), images);
     if ("error" in r) return reply.code(400).send(r);
     return r;
   });

--- a/orchestrator/src/agents/runtime.ts
+++ b/orchestrator/src/agents/runtime.ts
@@ -27,6 +27,11 @@ import { embedText } from "../embed.js";
 
 export type AgentBackend = "claude" | "codex" | "opencode";
 
+export interface ImageAttachment {
+  data: string; // base64-encoded
+  mimeType: string;
+}
+
 const FLOW_ROOT = fileURLToPath(new URL("../../..", import.meta.url)); // flow/
 const GATEWAY_MCP = path.join(FLOW_ROOT, "graph-gateway", "src", "mcp.ts");
 
@@ -228,7 +233,7 @@ export interface LiveSession {
   error?: string;
   seq: number;
   turnActive: boolean;
-  queue: string[]; // queued steering prompts
+  queue: Array<{ text: string; images?: ImageAttachment[] }>; // queued steering prompts
   pendingPermissions: Map<string, PendingPermission>;
   subscribers: Set<(ev: SessionEvent) => void>;
   createdAt: number;
@@ -841,7 +846,7 @@ async function writeWipNote(s: LiveSession): Promise<void> {
 // is where memory arrives: preamble (first turn only) + auto-retrieved memory
 // block + the user's text. Injection matches against the USER's words only,
 // never the preamble.
-async function runTurn(s: LiveSession, text: string, preamble = ""): Promise<void> {
+async function runTurn(s: LiveSession, text: string, preamble = "", images?: ImageAttachment[]): Promise<void> {
   const c = connections.get(s.backend);
   if (!c || !s.acpSessionId) throw new Error("session has no live connection");
   s.turnActive = true;
@@ -849,18 +854,25 @@ async function runTurn(s: LiveSession, text: string, preamble = ""): Promise<voi
   setStatus(s, "running");
   const memory = await buildMemoryInjection(s, text);
   const finalText = `${preamble}${memory}${text}`;
-  emit(s, "user_prompt", { text: finalText });
+  emit(s, "user_prompt", { text: finalText, images });
+  // Build ACP content blocks: text + optional images.
+  const promptBlocks: acp.ContentBlock[] = [{ type: "text", text: finalText }];
+  if (images) {
+    for (const img of images) {
+      promptBlocks.push({ type: "image", data: img.data, mimeType: img.mimeType });
+    }
+  }
   try {
     const result = await c.conn.prompt({
       sessionId: s.acpSessionId,
-      prompt: [{ type: "text", text: finalText }],
+      prompt: promptBlocks,
     });
     s.turnActive = false;
     void writeWipNote(s);
     // Steering queued during the turn? Run it next.
     const next = s.queue.shift();
     if (next !== undefined && s.status !== "closed") {
-      await runTurn(s, next);
+      await runTurn(s, next.text, "", next.images);
       return;
     }
     if (s.status !== "closed") setStatus(s, "idle", { stopReason: result.stopReason });
@@ -889,7 +901,7 @@ function describeError(backend: AgentBackend, e: unknown): string {
 
 // Steering: when idle → new turn immediately. When a turn is active → cancel
 // the current turn and run the steer prompt next (the user changed their mind).
-export async function steer(id: string, text: string): Promise<{ ok: true } | { error: string }> {
+export async function steer(id: string, text: string, images?: ImageAttachment[]): Promise<{ ok: true } | { error: string }> {
   const s = liveSession(id);
   if (!s || !s.acpSessionId) return { error: "Session is not live (reload-only or closed)" };
   let c: Connection;
@@ -899,11 +911,11 @@ export async function steer(id: string, text: string): Promise<{ ok: true } | { 
     return { error: (e as Error).message };
   }
   if (s.turnActive) {
-    s.queue.push(text);
+    s.queue.push({ text, images });
     await c.conn.cancel({ sessionId: s.acpSessionId });
     return { ok: true };
   }
-  void runTurn(s, text).catch(() => {});
+  void runTurn(s, text, "", images).catch(() => {});
   return { ok: true };
 }
 


### PR DESCRIPTION
- Paste images from clipboard (Ctrl/Cmd+V) in the steer bar
- Upload images via file picker button
- Image previews with hover-to-remove before sending
- Images forwarded as ACP ImageContent blocks to the agent backend
- Transcript renders images in user message blocks