### PR TITLE
Prefer local agent CLIs and open worktree PRs

### DIFF
--- a/dashboard/src/app/api/agents/worktrees/[action]/route.ts
+++ b/dashboard/src/app/api/agents/worktrees/[action]/route.ts
@@ -4,10 +4,10 @@ import { orcFetch } from "@/lib/orchestrator";
 
 // Proxy the separate-copy exits:
 //   GET  /api/agents/worktrees/diff?path=…        base-scope diff of a copy
-//   POST /api/agents/worktrees/{remove|apply|push}  {path, force?}
+//   POST /api/agents/worktrees/{remove|pr|open}     {path, ...}
 // Status is passed through so the client sees the orchestrator's honest error
 // bodies verbatim.
-const POST_ACTIONS = new Set(["remove", "apply", "push"]);
+const POST_ACTIONS = new Set(["remove", "pr", "open", "apply", "push"]);
 
 export async function GET(
   req: Request,

--- a/dashboard/src/components/AgentSession.tsx
+++ b/dashboard/src/components/AgentSession.tsx
@@ -299,18 +299,21 @@ export function AgentSession({ id }: { id: string }) {
     repo?: string;
     title?: string;
     cwd?: string;
-    separateCopy?: boolean;
-    worktreePath?: string | null;
-    worktreeGithub?: boolean;
-  } | null>(null);
-  // Exit banner state (separate-copy sessions). Applied/pushed results and any
-  // server error render inline; dismiss hides it for this pageview only.
-  const [exitDismissed, setExitDismissed] = useState(false);
-  const [exitBusy, setExitBusy] = useState(false);
-  const [exitError, setExitError] = useState("");
-  const [exitApplied, setExitApplied] = useState(false);
-  const [exitCompareUrl, setExitCompareUrl] = useState("");
-  const [openHint, setOpenHint] = useState("");
+	    separateCopy?: boolean;
+	    worktreePath?: string | null;
+	    worktreeGithub?: boolean;
+	    worktreeBase?: string;
+	  } | null>(null);
+	  // Exit banner state (separate-copy sessions). PR result/conflict/server
+	  // errors render inline; dismiss hides it for this pageview only.
+	  const [exitDismissed, setExitDismissed] = useState(false);
+	  const [exitBusy, setExitBusy] = useState(false);
+	  const [exitError, setExitError] = useState("");
+	  const [exitNotice, setExitNotice] = useState("");
+	  const [exitTargetBranch, setExitTargetBranch] = useState("");
+	  const [exitPrUrl, setExitPrUrl] = useState("");
+	  const [exitConflict, setExitConflict] = useState<{ targetBranch: string; files: string[] } | null>(null);
+	  const [openHint, setOpenHint] = useState("");
   const [input, setInput] = useState("");
   const [attachments, setAttachments] = useState<ImageAttachment[]>([]);
   const [sendError, setSendError] = useState("");
@@ -341,19 +344,20 @@ export function AgentSession({ id }: { id: string }) {
         }
         return r.json();
       })
-      .then(
-        (d) =>
-          d &&
-          setMeta({
-            backend: d.backend,
-            repo: d.repo,
-            title: d.title,
-            cwd: d.cwd,
-            separateCopy: d.separateCopy,
-            worktreePath: d.worktreePath ?? null,
-            worktreeGithub: Boolean(d.worktreeGithub),
-          })
-      )
+	      .then((d) => {
+	        if (!d) return;
+	        setMeta({
+	          backend: d.backend,
+	          repo: d.repo,
+	          title: d.title,
+	          cwd: d.cwd,
+	          separateCopy: d.separateCopy,
+	          worktreePath: d.worktreePath ?? null,
+	          worktreeGithub: Boolean(d.worktreeGithub),
+	          worktreeBase: String(d.worktreeBase ?? "main"),
+	        });
+	        setExitTargetBranch((prev) => prev || String(d.worktreeBase ?? "main"));
+	      })
       .catch(() => {});
   }, [id]);
 
@@ -606,32 +610,96 @@ export function AgentSession({ id }: { id: string }) {
     }
   }
 
-  // Exit actions for a separate-copy session — same endpoints as the copies
-  // list, targeting this session's own worktree path.
-  async function exitAct(action: "apply" | "push") {
-    const path = meta?.worktreePath;
-    if (!path) return;
-    setExitBusy(true);
-    setExitError("");
-    try {
-      const res = await fetch(`/api/agents/worktrees/${action}`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ path }),
-      });
-      const data = await res.json().catch(() => ({}));
-      if (!res.ok) {
-        setExitError(data.error ?? `Couldn't ${action} — status ${res.status}`);
-        return;
-      }
-      if (action === "apply") setExitApplied(true);
-      if (action === "push" && data.compareUrl) setExitCompareUrl(data.compareUrl);
-    } catch {
-      setExitError("Couldn't reach the server.");
-    } finally {
-      setExitBusy(false);
-    }
-  }
+	  // Exit action for a separate-copy session: open a PR to the selected target
+	  // branch. The server packages dirty work into a commit before pushing, so the
+	  // PR never opens as an empty diff just because the agent left edits unstaged.
+	  async function openExitPr() {
+	    const path = meta?.worktreePath;
+	    if (!path) return;
+	    setExitBusy(true);
+	    setExitError("");
+	    setExitNotice("");
+	    setExitConflict(null);
+	    try {
+	      const res = await fetch("/api/agents/worktrees/pr", {
+	        method: "POST",
+	        headers: { "content-type": "application/json" },
+	        body: JSON.stringify({ path, targetBranch: exitTargetBranch || meta?.worktreeBase || "main" }),
+	      });
+	      const data = await res.json().catch(() => ({}));
+	      if (res.status === 409 && data.conflict) {
+	        const fallbackTarget = exitTargetBranch || meta?.worktreeBase || "main";
+	        setExitConflict({
+	          targetBranch: String(data.targetBranch ?? fallbackTarget),
+	          files: Array.isArray(data.files) ? data.files.map(String) : [],
+	        });
+	        return;
+	      }
+	      if (!res.ok) {
+	        setExitError(data.error ?? `Couldn't open PR — status ${res.status}`);
+	        return;
+	      }
+	      if (data.compareUrl) {
+	        setExitPrUrl(data.compareUrl);
+	        window.open(data.compareUrl, "_blank", "noopener,noreferrer");
+	      }
+	    } catch {
+	      setExitError("Couldn't reach the server.");
+	    } finally {
+	      setExitBusy(false);
+	    }
+	  }
+
+	  async function openExitCopyInVsCode() {
+	    const path = meta?.worktreePath;
+	    if (!path) return;
+	    setExitBusy(true);
+	    setExitError("");
+	    try {
+	      const res = await fetch("/api/agents/worktrees/open", {
+	        method: "POST",
+	        headers: { "content-type": "application/json" },
+	        body: JSON.stringify({ path, target: "vscode" }),
+	      });
+	      const data = await res.json().catch(() => ({}));
+	      if (!res.ok) setExitError(data.error ?? `Couldn't open VS Code — status ${res.status}`);
+	    } catch {
+	      setExitError("Couldn't reach the server.");
+	    } finally {
+	      setExitBusy(false);
+	    }
+	  }
+
+	  async function resolveExitConflictWithAi() {
+	    const target = exitConflict?.targetBranch || exitTargetBranch || meta?.worktreeBase || "main";
+	    const text =
+	      `Resolve the merge conflicts blocking this worktree from opening a PR into ${target}.\n\n` +
+	      `Work in the current checkout only. Fetch the target branch, inspect the conflict, edit the conflicting files, commit the resolution, and then tell me when it is ready to open the PR again.`;
+	    setExitBusy(true);
+	    setExitError("");
+	    setExitNotice("");
+	    stickToBottom.current = true;
+	    setPending((p) => [...p, text]);
+	    try {
+	      const res = await fetch(`/api/agents/sessions/${id}/prompt`, {
+	        method: "POST",
+	        headers: { "content-type": "application/json" },
+	        body: JSON.stringify({ text }),
+	      });
+	      const data = await res.json().catch(() => ({}));
+	      if (!res.ok) {
+	        setExitError(data.error ?? `Couldn't ask the agent — status ${res.status}`);
+	        setPending((p) => p.filter((x) => x !== text));
+	        return;
+	      }
+	      setExitNotice("Asked the agent to resolve the conflicts in this copy.");
+	    } catch {
+	      setExitError("Couldn't reach the server.");
+	      setPending((p) => p.filter((x) => x !== text));
+	    } finally {
+	      setExitBusy(false);
+	    }
+	  }
 
   // The banner appears once a separate-copy session has settled (idle), so the
   // user is prompted to bring the work home rather than leaving it stranded.
@@ -986,59 +1054,84 @@ export function AgentSession({ id }: { id: string }) {
           </div>
 
 
-          {/* Exit banner — the changes live on a separate copy; offer to bring
-              them home (or push), so a finished session isn't a dead end. */}
-          {showExitBanner && (
-            <div className="border-t border-line px-4 py-2.5 flex items-center gap-3 flex-wrap" style={{ background: "var(--cream)" }}>
-              {exitApplied ? (
-                <span className="text-[12.5px]" style={{ color: "var(--ok)" }}>
-                  Applied to your folder ✓
-                </span>
-              ) : (
-                <>
-                  <span className="text-[12.5px] text-text">These changes live on a separate copy.</span>
-                  <div className="flex-1" />
-                  <button
-                    onClick={() => exitAct("apply")}
-                    disabled={exitBusy}
-                    className="rounded-md border border-line bg-paper px-2.5 py-1 text-[11.5px] text-text hover:bg-cream transition disabled:opacity-50"
-                  >
-                    Apply to my folder
-                  </button>
-                  {meta?.worktreeGithub && (
-                    <button
-                      onClick={() => exitAct("push")}
-                      disabled={exitBusy}
-                      className="rounded-md border border-line bg-paper px-2.5 py-1 text-[11.5px] text-text hover:bg-cream transition disabled:opacity-50"
-                    >
-                      Push
-                    </button>
-                  )}
-                  <button
-                    onClick={() => setExitDismissed(true)}
-                    className="text-[11px] text-text-muted hover:text-ink transition"
-                  >
-                    Dismiss
-                  </button>
-                </>
-              )}
-            </div>
-          )}
-          {showExitBanner && exitCompareUrl && (
-            <div className="px-4 pt-1" style={{ background: "var(--cream)" }}>
-              <a
-                href={exitCompareUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-[11.5px] text-ink underline hover:opacity-80"
-              >
-                Open pull request ↗
-              </a>
-            </div>
-          )}
-          {showExitBanner && exitError && (
-            <p className="px-4 pt-1 text-[11.5px]" style={{ background: "var(--cream)", color: "var(--danger)" }}>
-              {exitError}
+	          {/* Exit banner — the changes live on a separate copy; open a PR from
+	              that branch instead of merging into the user's folder. */}
+	          {showExitBanner && (
+	            <div className="border-t border-line px-4 py-2.5 flex items-center gap-3 flex-wrap" style={{ background: "var(--cream)" }}>
+	              <span className="text-[12.5px] text-text">These changes live on a separate copy.</span>
+	              <div className="flex-1" />
+	              {meta?.worktreeGithub ? (
+	                <>
+	                  <label className="inline-flex items-center gap-1.5 text-[11px] text-text-muted">
+	                    PR to
+	                    <input
+	                      value={exitTargetBranch}
+	                      onChange={(e) => setExitTargetBranch(e.target.value)}
+	                      className="w-[110px] rounded-md border border-line bg-paper px-2 py-1 text-[11.5px] text-ink"
+	                      style={{ fontFamily: "var(--font-mono)" }}
+	                    />
+	                  </label>
+	                  <button
+	                    onClick={openExitPr}
+	                    disabled={exitBusy || !exitTargetBranch.trim()}
+	                    className="rounded-md border border-line bg-paper px-2.5 py-1 text-[11.5px] text-text hover:bg-cream transition disabled:opacity-50"
+	                  >
+	                    Open PR to {exitTargetBranch || meta?.worktreeBase || "base"}
+	                  </button>
+	                </>
+	              ) : (
+	                <span className="text-[11.5px] text-text-muted">This repo is not connected to GitHub.</span>
+	              )}
+	              <button
+	                onClick={() => setExitDismissed(true)}
+	                className="text-[11px] text-text-muted hover:text-ink transition"
+	              >
+	                Dismiss
+	              </button>
+	            </div>
+	          )}
+	          {showExitBanner && exitPrUrl && (
+	            <div className="px-4 pt-1" style={{ background: "var(--cream)" }}>
+	              <a
+	                href={exitPrUrl}
+	                target="_blank"
+	                rel="noopener noreferrer"
+	                className="text-[11.5px] text-ink underline hover:opacity-80"
+	              >
+	                Pull request page opened ↗
+	              </a>
+	            </div>
+	          )}
+	          {showExitBanner && exitConflict && (
+	            <div className="px-4 pt-2 flex items-center gap-2 flex-wrap" style={{ background: "var(--cream)" }}>
+	              <span className="text-[11.5px]" style={{ color: "var(--danger)" }}>
+	                Merge conflicts against {exitConflict.targetBranch}
+	                {exitConflict.files.length ? `: ${exitConflict.files.slice(0, 3).join(", ")}${exitConflict.files.length > 3 ? "…" : ""}` : "."}
+	              </span>
+	              <button
+	                onClick={openExitCopyInVsCode}
+	                disabled={exitBusy}
+	                className="rounded-md border border-line bg-paper px-2.5 py-1 text-[11px] text-text hover:bg-cream transition disabled:opacity-50"
+	              >
+	                Review in VS Code
+	              </button>
+	              <button
+	                onClick={resolveExitConflictWithAi}
+	                disabled={exitBusy}
+	                className="rounded-md border border-line bg-paper px-2.5 py-1 text-[11px] text-text hover:bg-cream transition disabled:opacity-50"
+	              >
+	                Resolve using AI
+	              </button>
+	            </div>
+	          )}
+	          {showExitBanner && exitNotice && (
+	            <p className="px-4 pt-1 text-[11.5px]" style={{ background: "var(--cream)", color: "var(--ok)" }}>
+	              {exitNotice}
+	            </p>
+	          )}
+	          {showExitBanner && exitError && (
+	            <p className="px-4 pt-1 text-[11.5px]" style={{ background: "var(--cream)", color: "var(--danger)" }}>
+	              {exitError}
             </p>
           )}
 

--- a/dashboard/src/components/AgentsView.tsx
+++ b/dashboard/src/components/AgentsView.tsx
@@ -13,6 +13,7 @@ interface DetectedAgent {
   name: string;
   installed: boolean;
   version?: string;
+  source?: "explicit" | "local" | "bundled";
   installHint: string;
 }
 interface RepoOption {
@@ -300,9 +301,9 @@ export function AgentsView() {
 
 // ---------------------------------------------------------------------------
 // Separate copies — the isolated branch checkouts the collision flow creates.
-// Visibility + exits: see the diff, apply back into your folder, push to
-// GitHub, or remove. Progressive disclosure: the whole section is absent until
-// at least one copy exists. UI copy never says "worktree".
+// Visibility + exits: see the diff, open a PR, review conflicts, or remove.
+// Progressive disclosure: the whole section is absent until at least one copy
+// exists. UI copy never says "worktree".
 
 interface WorktreeSession {
   id: string;
@@ -328,9 +329,11 @@ function SeparateCopies({ onNavigate }: { onNavigate: (sessionId: string) => voi
   // Per-copy UI state, keyed by the copy's path.
   const [busy, setBusy] = useState<Record<string, boolean>>({});
   const [errors, setErrors] = useState<Record<string, string>>({});
+  const [notices, setNotices] = useState<Record<string, string>>({});
   const [confirmRemove, setConfirmRemove] = useState<Record<string, boolean>>({});
-  const [pushed, setPushed] = useState<Record<string, string>>({}); // path → compareUrl
-  const [applied, setApplied] = useState<Record<string, string>>({}); // path → "merged into <branch>"
+  const [prUrls, setPrUrls] = useState<Record<string, string>>({}); // path → compareUrl
+  const [targetBranches, setTargetBranches] = useState<Record<string, string>>({});
+  const [conflicts, setConflicts] = useState<Record<string, { targetBranch: string; files: string[] } | undefined>>({});
   const [openDiff, setOpenDiff] = useState<Record<string, boolean>>({});
   const [diffs, setDiffs] = useState<Record<string, { files: DiffFile[]; diff: string; truncated: boolean } | null>>({});
 
@@ -354,10 +357,13 @@ function SeparateCopies({ onNavigate }: { onNavigate: (sessionId: string) => voi
 
   const setError = (path: string, msg: string) => setErrors((e) => ({ ...e, [path]: msg }));
   const clearError = (path: string) => setErrors((e) => ({ ...e, [path]: "" }));
+  const setNotice = (path: string, msg: string) => setNotices((n) => ({ ...n, [path]: msg }));
+  const clearNotice = (path: string) => setNotices((n) => ({ ...n, [path]: "" }));
 
-  async function act(path: string, action: "apply" | "push" | "remove", body: Record<string, unknown> = {}) {
+  async function act(path: string, action: "remove", body: Record<string, unknown> = {}) {
     setBusy((b) => ({ ...b, [path]: true }));
     clearError(path);
+    clearNotice(path);
     try {
       const res = await fetch(`/api/agents/worktrees/${action}`, {
         method: "POST",
@@ -369,14 +375,101 @@ function SeparateCopies({ onNavigate }: { onNavigate: (sessionId: string) => voi
         setError(path, data.error ?? `Couldn't ${action} — status ${res.status}`);
         return;
       }
-      if (action === "apply") setApplied((a) => ({ ...a, [path]: `Applied to your folder ✓` }));
-      if (action === "push" && data.compareUrl) setPushed((p) => ({ ...p, [path]: data.compareUrl }));
       if (action === "remove") setConfirmRemove((c) => ({ ...c, [path]: false }));
       await refresh();
     } catch {
       setError(path, "Couldn't reach the server.");
     } finally {
       setBusy((b) => ({ ...b, [path]: false }));
+    }
+  }
+
+  async function openPr(path: string, targetBranch: string) {
+    setBusy((b) => ({ ...b, [path]: true }));
+    clearError(path);
+    clearNotice(path);
+    setConflicts((c) => ({ ...c, [path]: undefined }));
+    try {
+      const res = await fetch("/api/agents/worktrees/pr", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ path, targetBranch }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (res.status === 409 && data.conflict) {
+        setConflicts((c) => ({
+          ...c,
+          [path]: {
+            targetBranch: String(data.targetBranch ?? targetBranch),
+            files: Array.isArray(data.files) ? data.files.map(String) : [],
+          },
+        }));
+        return;
+      }
+      if (!res.ok) {
+        setError(path, data.error ?? `Couldn't open PR — status ${res.status}`);
+        return;
+      }
+      if (data.compareUrl) {
+        setPrUrls((p) => ({ ...p, [path]: data.compareUrl }));
+        window.open(data.compareUrl, "_blank", "noopener,noreferrer");
+      }
+      await refresh();
+    } catch {
+      setError(path, "Couldn't reach the server.");
+    } finally {
+      setBusy((b) => ({ ...b, [path]: false }));
+    }
+  }
+
+  async function openCopyInVsCode(path: string) {
+    setBusy((b) => ({ ...b, [path]: true }));
+    clearError(path);
+    try {
+      const res = await fetch("/api/agents/worktrees/open", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ path, target: "vscode" }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) setError(path, data.error ?? `Couldn't open VS Code — status ${res.status}`);
+    } catch {
+      setError(path, "Couldn't reach the server.");
+    } finally {
+      setBusy((b) => ({ ...b, [path]: false }));
+    }
+  }
+
+  async function resolveConflictWithAi(wt: Worktree) {
+    const session = wt.sessions.find((s) => s.status !== "closed" && s.status !== "error") ?? wt.sessions[0];
+    if (!session) {
+      setError(wt.path, "No session is attached to this copy. Open it in VS Code to resolve manually.");
+      return;
+    }
+    const target = conflicts[wt.path]?.targetBranch ?? targetBranches[wt.path] ?? wt.base;
+    setBusy((b) => ({ ...b, [wt.path]: true }));
+    clearError(wt.path);
+    clearNotice(wt.path);
+    try {
+      const text =
+        `Resolve the merge conflicts blocking this worktree from opening a PR into ${target}.\n\n` +
+        `Work in the current checkout only. Fetch the target branch, inspect the conflict, edit the conflicting files, commit the resolution, and then tell me when it is ready to open the PR again.`;
+      const res = await fetch(`/api/agents/sessions/${session.id}/prompt`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ text }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(wt.path, data.error ?? `Couldn't ask the agent — status ${res.status}`);
+        return;
+      }
+      setNotice(wt.path, "Asked the agent to resolve the conflicts in this copy.");
+      onNavigate(session.id);
+    } catch {
+      setError(wt.path, "Couldn't reach the server.");
+    } finally {
+      setBusy((b) => ({ ...b, [wt.path]: false }));
     }
   }
 
@@ -401,15 +494,17 @@ function SeparateCopies({ onNavigate }: { onNavigate: (sessionId: string) => voi
     <div className="mb-10">
       <Kicker>Separate copies</Kicker>
       <p className="text-text-muted text-[12.5px] mt-1 mb-3 max-w-xl">
-        Isolated copies of a branch, made when two agents would otherwise share one folder. Bring their
-        work back into your folder, push it, or clear the copy away.
+        Isolated copies of a branch, made when two agents would otherwise share one folder. Open a PR
+        from the copy, review conflicts, or clear the copy away.
       </p>
       <div className="flex flex-col gap-2">
         {trees.map((wt) => {
           const b = busy[wt.path];
           const err = errors[wt.path];
-          const compareUrl = pushed[wt.path];
-          const appliedMsg = applied[wt.path];
+          const notice = notices[wt.path];
+          const compareUrl = prUrls[wt.path];
+          const targetBranch = targetBranches[wt.path] ?? wt.base;
+          const conflict = conflicts[wt.path];
 
           // Broken: the folder is gone. Offer only a way to clean it up.
           if (wt.health === "broken") {
@@ -478,22 +573,25 @@ function SeparateCopies({ onNavigate }: { onNavigate: (sessionId: string) => voi
                 >
                   {openDiff[wt.path] ? "Hide changes" : "View changes"}
                 </button>
-                <button
-                  onClick={() => act(wt.path, "apply")}
-                  disabled={b || wt.dirty || Boolean(appliedMsg)}
-                  title={wt.dirty ? "Commit or discard changes in the copy first" : "Merge this copy back into your folder"}
-                  className="rounded-md border border-line bg-paper px-2.5 py-1 text-[11.5px] text-text hover:bg-cream transition disabled:opacity-50"
-                >
-                  Apply to my folder
-                </button>
                 {wt.github && (
-                  <button
-                    onClick={() => act(wt.path, "push")}
-                    disabled={b}
-                    className="rounded-md border border-line bg-paper px-2.5 py-1 text-[11.5px] text-text hover:bg-cream transition disabled:opacity-50"
-                  >
-                    Push
-                  </button>
+                  <>
+                    <label className="inline-flex items-center gap-1.5 text-[11px] text-text-muted">
+                      PR to
+                      <input
+                        value={targetBranch}
+                        onChange={(e) => setTargetBranches((m) => ({ ...m, [wt.path]: e.target.value }))}
+                        className="w-[110px] rounded-md border border-line bg-paper px-2 py-1 text-[11.5px] text-ink"
+                        style={{ fontFamily: "var(--font-mono)" }}
+                      />
+                    </label>
+                    <button
+                      onClick={() => openPr(wt.path, targetBranch)}
+                      disabled={b || !targetBranch.trim()}
+                      className="rounded-md border border-line bg-paper px-2.5 py-1 text-[11.5px] text-text hover:bg-cream transition disabled:opacity-50"
+                    >
+                      Open PR to {targetBranch || wt.base}
+                    </button>
+                  </>
                 )}
                 {/* Remove — inline confirm when the copy has uncommitted work. */}
                 {confirmRemove[wt.path] ? (
@@ -528,7 +626,6 @@ function SeparateCopies({ onNavigate }: { onNavigate: (sessionId: string) => voi
               </div>
 
               {/* Results / errors — rendered verbatim. */}
-              {appliedMsg && <p className="text-[11.5px] mt-2" style={{ color: "var(--ok)" }}>{appliedMsg}</p>}
               {compareUrl && (
                 <a
                   href={compareUrl}
@@ -536,9 +633,32 @@ function SeparateCopies({ onNavigate }: { onNavigate: (sessionId: string) => voi
                   rel="noopener noreferrer"
                   className="inline-block text-[11.5px] mt-2 text-ink underline hover:opacity-80"
                 >
-                  Open pull request ↗
+                  Pull request page opened ↗
                 </a>
               )}
+              {conflict && (
+                <div className="flex items-center gap-2 flex-wrap mt-2">
+                  <span className="text-[11.5px]" style={{ color: "var(--danger)" }}>
+                    Merge conflicts against {conflict.targetBranch}
+                    {conflict.files.length ? `: ${conflict.files.slice(0, 3).join(", ")}${conflict.files.length > 3 ? "…" : ""}` : "."}
+                  </span>
+                  <button
+                    onClick={() => openCopyInVsCode(wt.path)}
+                    disabled={b}
+                    className="rounded-md border border-line bg-paper px-2.5 py-1 text-[11px] text-text hover:bg-cream transition disabled:opacity-50"
+                  >
+                    Review in VS Code
+                  </button>
+                  <button
+                    onClick={() => resolveConflictWithAi(wt)}
+                    disabled={b}
+                    className="rounded-md border border-line bg-paper px-2.5 py-1 text-[11px] text-text hover:bg-cream transition disabled:opacity-50"
+                  >
+                    Resolve using AI
+                  </button>
+                </div>
+              )}
+              {notice && <p className="text-[11.5px] mt-2" style={{ color: "var(--ok)" }}>{notice}</p>}
               {err && <p className="text-[11.5px] mt-2" style={{ color: "var(--danger)" }}>{err}</p>}
 
               {/* Inline diff */}

--- a/orchestrator/src/agents/routes.ts
+++ b/orchestrator/src/agents/routes.ts
@@ -14,8 +14,8 @@
 //   GET  /v1/agents/worktrees             the separate copies (optionally ?repo=)
 //   GET  /v1/agents/worktrees/diff        {path} — base-scope diff of a copy
 //   POST /v1/agents/worktrees/remove      {path, force?} — delete a copy
-//   POST /v1/agents/worktrees/apply       {path} — merge a copy into your folder
-//   POST /v1/agents/worktrees/push        {path} — push a copy's branch to origin
+//   POST /v1/agents/worktrees/pr          {path, targetBranch?} — push branch and open PR flow
+//   POST /v1/agents/worktrees/open        {path, target} — open a copy in Finder/VS Code
 //   POST /v1/agents/graph-activity        (from the injected MCP subprocess)
 
 import type { FastifyInstance } from "fastify";
@@ -32,9 +32,12 @@ import {
   sessionDiff,
   listManagedWorktrees,
   repoHasGithubUrl,
+  repoBaseBranch,
   removeManagedWorktree,
   applyManagedWorktree,
   pushManagedWorktree,
+  openPullRequestForManagedWorktree,
+  openWorktreeLocation,
   worktreeDiffAt,
   listSessions,
   readTranscript,
@@ -97,11 +100,11 @@ export function registerAgentRoutes(app: FastifyInstance): void {
       // checkout — the UI shows a muted chip for it. Derived from worktree_id.
       separateCopy: Boolean((meta as { worktree_id?: string }).worktree_id ?? live?.worktreeId),
       // The worktree path, when this session runs on a separate copy — the exit
-      // banner (apply/push) targets it directly. null for in-place sessions.
+      // banner targets it directly. null for in-place sessions.
       worktreePath: (meta as { worktree_id?: string }).worktree_id ?? live?.worktreeId ?? null,
-      // Whether the copy's repo has a GitHub url — gates the banner's Push
-      // button (a local-only repo has nowhere to push).
+      // Whether the copy's repo has a GitHub url — gates the banner's PR action.
       worktreeGithub: repoHasGithubUrl(String((meta as { repo?: string }).repo ?? "")),
+      worktreeBase: repoBaseBranch(String((meta as { repo?: string }).repo ?? "")),
       live: Boolean(live),
       modes: live?.modes ?? null,
       configOptions: live?.configOptions ?? null,
@@ -281,9 +284,8 @@ export function registerAgentRoutes(app: FastifyInstance): void {
     return r;
   });
 
-  // Merge a copy's branch back into the user's checkout — THE one action that
-  // writes to their folder. Guards (dirty copy / dirty folder / conflict) each
-  // return a distinct {error}; success → {ok, mergedInto}.
+  // Legacy/internal escape hatch: merge a copy's branch back into the user's
+  // checkout. The dashboard no longer offers this because PR-first is safer.
   app.post("/v1/agents/worktrees/apply", async (req, reply) => {
     const { path } = req.body as { path?: string };
     if (!path) return reply.code(400).send({ error: "path required" });
@@ -292,12 +294,31 @@ export function registerAgentRoutes(app: FastifyInstance): void {
     return r;
   });
 
-  // Push a copy's branch to origin (GitHub repos only) using ambient
-  // credentials. Success → {ok, compareUrl}; failure → git's stderr as {error}.
+  // Legacy/internal push. The PR action below is the dashboard path because it
+  // commits dirty work, checks conflicts, verifies the remote ref, and returns
+  // the GitHub PR URL.
   app.post("/v1/agents/worktrees/push", async (req, reply) => {
     const { path } = req.body as { path?: string };
     if (!path) return reply.code(400).send({ error: "path required" });
     const r = await pushManagedWorktree(path);
+    if ("error" in r) return reply.code(400).send(r);
+    return r;
+  });
+
+  app.post("/v1/agents/worktrees/pr", async (req, reply) => {
+    const { path, targetBranch } = req.body as { path?: string; targetBranch?: string };
+    if (!path) return reply.code(400).send({ error: "path required" });
+    const r = await openPullRequestForManagedWorktree(path, targetBranch);
+    if ("error" in r) return reply.code(400).send(r);
+    if ("conflict" in r) return reply.code(409).send(r);
+    return r;
+  });
+
+  app.post("/v1/agents/worktrees/open", async (req, reply) => {
+    const { path, target } = req.body as { path?: string; target?: "finder" | "vscode" };
+    if (!path) return reply.code(400).send({ error: "path required" });
+    if (target !== "finder" && target !== "vscode") return reply.code(400).send({ error: "target must be finder or vscode" });
+    const r = openWorktreeLocation(path, target);
     if ("error" in r) return reply.code(400).send(r);
     return r;
   });

--- a/orchestrator/src/agents/runtime.ts
+++ b/orchestrator/src/agents/runtime.ts
@@ -12,7 +12,7 @@
 // the same API in front of containers instead of local processes.
 
 import { spawn, execFile, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { accessSync, appendFileSync, constants, existsSync, mkdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import path from "node:path";
 import { Readable, Writable } from "node:stream";
 import { fileURLToPath } from "node:url";
@@ -33,6 +33,7 @@ import {
   removeWorktree,
   applyWorktree,
   pushWorktree,
+  openPullRequestWorktree,
 } from "./worktrees.js";
 
 // ---------------------------------------------------------------------------
@@ -72,6 +73,9 @@ interface BackendDescriptor {
   name: string;
   executable: string; // the agent CLI users install/authenticate
   spawn: { command: string; args: string[]; bundled?: boolean };
+  localCli?:
+    | { mode: "env"; envVar: string } // run the bundled ACP adapter, pointing it at the local CLI
+    | { mode: "command" }; // run the local CLI itself as the ACP adapter
   installHint: string;
 }
 
@@ -82,6 +86,7 @@ export const BACKENDS: Record<AgentBackend, BackendDescriptor> = {
     executable: "claude",
     // Bundled adapters (installed as orchestrator deps) — no npx cold start.
     spawn: { command: "claude-agent-acp", args: [], bundled: true },
+    localCli: { mode: "env", envVar: "CLAUDE_CODE_EXECUTABLE" },
     installHint: "npm i -g @anthropic-ai/claude-code",
   },
   codex: {
@@ -89,6 +94,7 @@ export const BACKENDS: Record<AgentBackend, BackendDescriptor> = {
     name: "Codex",
     executable: "codex",
     spawn: { command: "codex-acp", args: [], bundled: true },
+    localCli: { mode: "env", envVar: "CODEX_PATH" },
     installHint: "npm i -g @openai/codex",
   },
   opencode: {
@@ -96,9 +102,182 @@ export const BACKENDS: Record<AgentBackend, BackendDescriptor> = {
     name: "OpenCode",
     executable: "opencode",
     spawn: { command: "opencode", args: ["acp"] },
+    localCli: { mode: "command" },
     installHint: "curl -fsSL https://opencode.ai/install | bash",
   },
 };
+
+export type RuntimeSource = "explicit" | "local" | "bundled";
+
+interface SpawnAttempt {
+  source: RuntimeSource;
+  command: string;
+  args: string[];
+  env: NodeJS.ProcessEnv;
+  localPath?: string;
+  envVar?: string;
+}
+
+const FLOW_MANAGED_DIRS = [path.join(FLOW_ROOT, "node_modules"), path.join(FLOW_ROOT, "orchestrator", "node_modules")];
+
+function isUnder(parent: string, child: string): boolean {
+  const rel = path.relative(parent, child);
+  return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+}
+
+function isExecutable(file: string): boolean {
+  try {
+    if (!statSync(file).isFile()) return false;
+    accessSync(file, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function commandNames(command: string): string[] {
+  if (process.platform !== "win32" || path.extname(command)) return [command];
+  const exts = (process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";").filter(Boolean);
+  return [command, ...exts.map((ext) => `${command}${ext}`)];
+}
+
+function executableCandidates(command: string): string[] {
+  if (path.isAbsolute(command) || command.includes(path.sep) || command.includes(path.win32.sep)) {
+    return [command];
+  }
+  const dirs = (process.env.PATH ?? "").split(path.delimiter).filter(Boolean);
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const dir of dirs) {
+    for (const name of commandNames(command)) {
+      const candidate = path.join(dir, name);
+      if (seen.has(candidate)) continue;
+      seen.add(candidate);
+      out.push(candidate);
+    }
+  }
+  return out;
+}
+
+function isFlowManagedExecutable(file: string): boolean {
+  let realFile: string;
+  try {
+    realFile = realpathSync(file);
+  } catch {
+    return false;
+  }
+  for (const dir of FLOW_MANAGED_DIRS) {
+    try {
+      if (existsSync(dir) && isUnder(realpathSync(dir), realFile)) return true;
+    } catch {
+      /* try next managed dir */
+    }
+  }
+  return false;
+}
+
+function localExecutableCandidates(command: string): string[] {
+  const out: string[] = [];
+  for (const candidate of executableCandidates(command)) {
+    if (isExecutable(candidate) && !isFlowManagedExecutable(candidate)) {
+      out.push(candidate);
+    }
+  }
+  return out;
+}
+
+function parseVersionText(version: string | null): number[] | null {
+  const match = version?.match(/(\d+)\.(\d+)\.(\d+)(?:[.-](\d+))?/);
+  return match ? match.slice(1).filter(Boolean).map(Number) : null;
+}
+
+function compareVersionParts(a: number[] | null, b: number[] | null): number {
+  if (!a && !b) return 0;
+  if (a && !b) return 1;
+  if (!a && b) return -1;
+  for (let i = 0; i < Math.max(a!.length, b!.length); i++) {
+    const diff = (a![i] ?? 0) - (b![i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+async function resolveLocalExecutable(command: string): Promise<string | null> {
+  const candidates = localExecutableCandidates(command);
+  if (candidates.length <= 1) return candidates[0] ?? null;
+
+  const scored = await Promise.all(
+    candidates.map(async (candidate, index) => ({
+      candidate,
+      index,
+      version: parseVersionText(await execVersion(candidate)),
+    }))
+  );
+  scored.sort((a, b) => compareVersionParts(b.version, a.version) || a.index - b.index);
+  return scored[0]?.candidate ?? null;
+}
+
+function bundledSpawn(desc: BackendDescriptor): Omit<SpawnAttempt, "source" | "env"> | null {
+  if (!desc.spawn.bundled) return null;
+  try {
+    return {
+      command: binPath(desc.spawn.command),
+      args: desc.spawn.args,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function requireBundledSpawn(desc: BackendDescriptor): SpawnAttempt {
+  const spawnConfig = bundledSpawn(desc);
+  if (!spawnConfig) {
+    throw new Error(`${desc.name} is not installed. Install it with: ${desc.installHint}`);
+  }
+  return { source: "bundled", ...spawnConfig, env: { ...process.env } };
+}
+
+async function spawnAttempts(desc: BackendDescriptor): Promise<SpawnAttempt[]> {
+  const local = desc.localCli;
+  if (!local) return [requireBundledSpawn(desc)];
+
+  if (local.mode === "env") {
+    const explicit = process.env[local.envVar]?.trim();
+    if (explicit) {
+      const bundled = requireBundledSpawn(desc);
+      return [{ ...bundled, source: "explicit", envVar: local.envVar }];
+    }
+
+    const localPath = await resolveLocalExecutable(desc.executable);
+    if (!localPath) return [requireBundledSpawn(desc)];
+    return [
+      {
+        ...requireBundledSpawn(desc),
+        source: "local",
+        env: { ...process.env, [local.envVar]: localPath },
+        localPath,
+        envVar: local.envVar,
+      },
+      requireBundledSpawn(desc),
+    ];
+  }
+
+  const localPath = await resolveLocalExecutable(desc.executable);
+  if (localPath) {
+    return [
+      {
+        source: "local",
+        command: localPath,
+        args: desc.spawn.args,
+        env: { ...process.env },
+        localPath,
+      },
+    ];
+  }
+  const bundled = bundledSpawn(desc);
+  if (bundled) return [{ source: "bundled", ...bundled, env: { ...process.env } }];
+  throw new Error(`${desc.name} is not installed. Install it with: ${desc.installHint}`);
+}
 
 // ---------------------------------------------------------------------------
 // Detection — which agents are installed on this machine
@@ -108,6 +287,7 @@ export interface DetectedAgent {
   name: string;
   installed: boolean;
   version?: string;
+  source?: RuntimeSource;
   installHint: string;
 }
 
@@ -125,12 +305,18 @@ export async function detectAgents(): Promise<DetectedAgent[]> {
   if (detectCache && Date.now() - detectCache.at < 60_000) return detectCache.agents;
   const agents = await Promise.all(
     Object.values(BACKENDS).map(async (b) => {
-      const version = await execVersion(b.executable);
+      const explicitEnv = b.localCli?.mode === "env" ? process.env[b.localCli.envVar]?.trim() : undefined;
+      const localPath = explicitEnv || (await resolveLocalExecutable(b.executable));
+      const version = localPath ? await execVersion(localPath) : null;
+      const bundled = bundledSpawn(b) !== null;
+      const installed = explicitEnv ? version !== null : version !== null || bundled;
+      const source: RuntimeSource | undefined = explicitEnv ? "explicit" : version !== null ? "local" : bundled ? "bundled" : undefined;
       return {
         id: b.id,
         name: b.name,
-        installed: version !== null,
-        version: version ?? undefined,
+        installed,
+        version: version ?? (bundled && !explicitEnv ? "Bundled fallback" : undefined),
+        source,
         installHint: b.installHint,
       };
     })
@@ -481,10 +667,30 @@ interface Connection {
   process: ChildProcessWithoutNullStreams;
   conn: acp.ClientSideConnection;
   init: acp.InitializeResponse;
+  source: RuntimeSource;
+  command: string;
+  localPath?: string;
   sessionsByAcpId: Map<string, string>; // acp session id → flow session id
 }
 
 const connections = new Map<AgentBackend, Connection>();
+
+function adapterLog(backend: AgentBackend, message: string): void {
+  try {
+    mkdirSync(SESSIONS_DIR, { recursive: true });
+    appendFileSync(path.join(SESSIONS_DIR, `adapter-${backend}.stderr.log`), `[${new Date().toISOString()}] ${message}\n`);
+  } catch {
+    /* best-effort */
+  }
+}
+
+function runtimeInfo(c: Connection): Record<string, unknown> {
+  return {
+    source: c.source,
+    command: c.command,
+    ...(c.localPath ? { localPath: c.localPath } : {}),
+  };
+}
 
 function makeClientHandler(backend: AgentBackend): acp.Client {
   return {
@@ -549,17 +755,22 @@ function makeClientHandler(backend: AgentBackend): acp.Client {
   };
 }
 
-async function ensureConnection(backend: AgentBackend): Promise<Connection> {
-  const existing = connections.get(backend);
-  if (existing && existing.process.exitCode === null) return existing;
-  connections.delete(backend);
-
+async function startConnectionAttempt(backend: AgentBackend, attempt: SpawnAttempt): Promise<Connection> {
   const desc = BACKENDS[backend];
   mkdirSync(SESSIONS_DIR, { recursive: true });
-  const command = desc.spawn.bundled ? binPath(desc.spawn.command) : desc.spawn.command;
-  const proc = spawn(command, desc.spawn.args, {
+  const via =
+    attempt.source === "local" && attempt.envVar
+      ? `${attempt.envVar}=${attempt.localPath}`
+      : attempt.source === "local"
+        ? attempt.localPath
+        : attempt.source === "explicit" && attempt.envVar
+          ? `${attempt.envVar}=<env>`
+          : "bundled";
+  adapterLog(backend, `starting ${desc.name} ACP adapter via ${attempt.source}: ${attempt.command} ${attempt.args.join(" ")} (${via})`);
+
+  const proc = spawn(attempt.command, attempt.args, {
     stdio: ["pipe", "pipe", "pipe"],
-    env: { ...process.env },
+    env: attempt.env,
   });
   proc.stderr.on("data", (chunk: Buffer) => {
     try {
@@ -575,21 +786,57 @@ async function ensureConnection(backend: AgentBackend): Promise<Connection> {
   );
   const conn = new acp.ClientSideConnection(() => makeClientHandler(backend), stream);
 
-  const init = await Promise.race([
-    conn.initialize({
-      protocolVersion: acp.PROTOCOL_VERSION,
-      // Advertise session config-option support so agents send their model
-      // selector (and thought-level toggles) as configOptions we can drive.
-      clientCapabilities: {
-        fs: { readTextFile: false, writeTextFile: false },
-        terminal: false,
-        session: { configOptions: { boolean: {} } },
-      },
-    }),
-    new Promise<never>((_, rej) => setTimeout(() => rej(new Error(`${backend} adapter did not initialize in 60s`)), 60_000)),
-  ]);
+  const initializePromise = conn.initialize({
+    protocolVersion: acp.PROTOCOL_VERSION,
+    // Advertise session config-option support so agents send their model
+    // selector (and thought-level toggles) as configOptions we can drive.
+    clientCapabilities: {
+      fs: { readTextFile: false, writeTextFile: false },
+      terminal: false,
+      session: { configOptions: { boolean: {} } },
+    },
+  });
+  initializePromise.catch(() => {
+    /* handled by the race below */
+  });
 
-  const c: Connection = { backend, process: proc, conn, init, sessionsByAcpId: new Map() };
+  let onProcError: ((err: Error) => void) | undefined;
+  let onEarlyExit: ((code: number | null, signal: NodeJS.Signals | null) => void) | undefined;
+  const procError = new Promise<never>((_, reject) => {
+    onProcError = reject;
+    onEarlyExit = (code, signal) => {
+      reject(new Error(`${backend} adapter exited before initialize (code ${code ?? "null"}${signal ? `, signal ${signal}` : ""})`));
+    };
+    proc.once("error", onProcError);
+    proc.once("exit", onEarlyExit);
+  });
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => reject(new Error(`${backend} adapter did not initialize in 60s`)), 60_000);
+  });
+
+  let init: acp.InitializeResponse;
+  try {
+    init = await Promise.race([initializePromise, procError, timeout]);
+  } catch (e) {
+    if (proc.exitCode === null) proc.kill();
+    throw e;
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+    if (onProcError) proc.off("error", onProcError);
+    if (onEarlyExit) proc.off("exit", onEarlyExit);
+  }
+
+  const c: Connection = {
+    backend,
+    process: proc,
+    conn,
+    init,
+    source: attempt.source,
+    command: attempt.command,
+    localPath: attempt.localPath,
+    sessionsByAcpId: new Map(),
+  };
   proc.on("exit", (code) => {
     connections.delete(backend);
     for (const flowId of c.sessionsByAcpId.values()) {
@@ -602,8 +849,34 @@ async function ensureConnection(backend: AgentBackend): Promise<Connection> {
       }
     }
   });
-  connections.set(backend, c);
   return c;
+}
+
+async function ensureConnection(backend: AgentBackend): Promise<Connection> {
+  const existing = connections.get(backend);
+  if (existing && existing.process.exitCode === null) return existing;
+  connections.delete(backend);
+
+  const attempts = await spawnAttempts(BACKENDS[backend]);
+  let lastError: unknown;
+  for (let i = 0; i < attempts.length; i++) {
+    const attempt = attempts[i];
+    try {
+      const c = await startConnectionAttempt(backend, attempt);
+      connections.set(backend, c);
+      return c;
+    } catch (e) {
+      lastError = e;
+      const canFallback = attempt.source === "local" && i < attempts.length - 1;
+      adapterLog(
+        backend,
+        `${attempt.source} ACP adapter failed to initialize: ${(e as Error).message}${canFallback ? "; retrying bundled fallback" : ""}`
+      );
+      if (!canFallback) break;
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(`${backend} adapter failed to initialize`);
 }
 
 // Re-attach a session to a live connection after its adapter process died (or
@@ -639,7 +912,7 @@ async function resumeConnection(s: LiveSession): Promise<Connection> {
     s.configOptions = resp.configOptions ?? s.configOptions;
     s.error = undefined;
     c.sessionsByAcpId.set(acpSessionId, s.id);
-    emit(s, "status", { modes: s.modes, configOptions: s.configOptions });
+    emit(s, "status", { modes: s.modes, configOptions: s.configOptions, runtime: runtimeInfo(c) });
     return c;
   } catch (e) {
     setStatus(s, "error", { error: (e as Error).message });
@@ -947,7 +1220,7 @@ export async function createSession(opts: {
       // any thought/reasoning-level toggles — surfaced to the UI verbatim.
       s.configOptions = resp.configOptions ?? null;
       c.sessionsByAcpId.set(s.acpSessionId, id);
-      emit(s, "status", { modes: s.modes, configOptions: s.configOptions });
+      emit(s, "status", { modes: s.modes, configOptions: s.configOptions, runtime: runtimeInfo(c) });
       await runTurn(s, opts.prompt, `${GRAPH_PREAMBLE}\n\n`);
     } catch (e) {
       setStatus(s, "error", { error: (e as Error).message });
@@ -1532,7 +1805,7 @@ export function subscribe(id: string, fn: (ev: SessionEvent) => void): (() => vo
 // the "no live session attached" remove guard.
 
 // The repo's GitHub owner/repo parsed from its registry url (null for
-// local-only repos). Push and the compare URL depend on this.
+// local-only repos). PR opening and compare URLs depend on this.
 function repoGithub(repoName: string): { owner: string; repo: string } | null {
   const reposJson = process.env.REPOS_JSON_PATH;
   if (!reposJson || !existsSync(reposJson)) return null;
@@ -1547,10 +1820,14 @@ function repoGithub(repoName: string): { owner: string; repo: string } | null {
   }
 }
 
-// Does this repo have a GitHub url? Gates the Push action in the UI (the
-// session exit banner and the copies list both ask).
+// Does this repo have a GitHub url? Gates PR actions in the UI (the session
+// exit banner and the copies list both ask).
 export function repoHasGithubUrl(repo: string): boolean {
   return repoGithub(repo) !== null;
+}
+
+export function repoBaseBranch(repo: string): string {
+  return listRepoOptions().find((r) => r.name === repo)?.branch ?? "main";
 }
 
 // Sessions recorded against a worktree path (worktree_id). Realpath both sides:
@@ -1580,7 +1857,7 @@ export interface ManagedWorktree {
   merged: boolean;
   health: "ok" | "broken";
   sessions: Array<{ id: string; title: string; status: SessionStatus }>;
-  github: boolean; // repo has a GitHub url → Push is available
+  github: boolean; // repo has a GitHub url → PR action is available
 }
 
 // Every flow-managed separate copy (optionally filtered to one repo). For each
@@ -1664,6 +1941,63 @@ export async function pushManagedWorktree(
   const gh = repoGithub(t.repo);
   if (!gh) return { error: "This repository isn't connected to GitHub." };
   return pushWorktree({ treePath, branch: t.branch, base: t.base, owner: gh.owner, repo: gh.repo });
+}
+
+export async function openPullRequestForManagedWorktree(
+  treePath: string,
+  targetBranch?: string
+): Promise<
+  | { ok: true; compareUrl: string; branch: string; targetBranch: string; committed: boolean }
+  | { conflict: true; branch: string; targetBranch: string; files: string[] }
+  | { error: string }
+> {
+  if (!isManagedWorktree(treePath)) return { error: "That path isn't a Flow-managed copy." };
+  const t = await resolveTree(treePath);
+  if (!t || !t.branch) return { error: "Couldn't find the branch for this copy." };
+  const gh = repoGithub(t.repo);
+  if (!gh) return { error: "This repository isn't connected to GitHub." };
+  return openPullRequestWorktree({
+    treePath,
+    branch: t.branch,
+    targetBranch: targetBranch?.trim() || t.base,
+    owner: gh.owner,
+    repo: gh.repo,
+  });
+}
+
+export function openWorktreeLocation(
+  treePath: string,
+  target: "finder" | "vscode"
+): { ok: true } | { error: string } {
+  if (!isManagedWorktree(treePath)) return { error: "That path isn't a Flow-managed copy." };
+  if (!existsSync(treePath)) return { error: `Folder not found: ${treePath}` };
+
+  let cmd: string;
+  let args: string[];
+  if (target === "vscode") {
+    cmd = "code";
+    args = [treePath];
+  } else {
+    cmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "explorer.exe" : "xdg-open";
+    args = [treePath];
+  }
+
+  try {
+    const child = spawn(cmd, args, { stdio: "ignore", detached: true });
+    child.on("error", () => {
+      if (target === "vscode" && process.platform === "darwin") {
+        try {
+          spawn("open", ["-a", "Visual Studio Code", treePath], { stdio: "ignore", detached: true }).unref();
+        } catch {
+          /* best-effort fallback */
+        }
+      }
+    });
+    child.unref();
+    return { ok: true };
+  } catch (e) {
+    return { error: (e as Error).message };
+  }
 }
 
 // Diff a managed tree that has NO session of its own: working dir vs the

--- a/orchestrator/src/agents/worktrees.ts
+++ b/orchestrator/src/agents/worktrees.ts
@@ -471,7 +471,7 @@ export async function applyWorktree(opts: {
   return { ok: true, mergedInto };
 }
 
-// Push the copy's branch to origin using the user's AMBIENT git credentials.
+// Legacy helper: push a copy's branch to origin using the user's AMBIENT git credentials.
 // Deliberately NO token injection into the remote here — this is an interactive
 // push the user initiated, not the indexer's background fetch. owner/repo come
 // from the registry url (parsed by the caller) so we can build the compare URL.
@@ -493,6 +493,130 @@ export async function pushWorktree(opts: {
   const enc = (ref: string) => ref.split("/").map(encodeURIComponent).join("/");
   const compareUrl = `https://github.com/${owner}/${repo}/compare/${enc(base)}...${enc(branch)}`;
   return { ok: true, compareUrl };
+}
+
+export interface OpenPullRequestResult {
+  ok: true;
+  compareUrl: string;
+  branch: string;
+  targetBranch: string;
+  committed: boolean;
+}
+
+export interface OpenPullRequestConflict {
+  conflict: true;
+  branch: string;
+  targetBranch: string;
+  files: string[];
+}
+
+async function commitDirtyWorktree(treePath: string): Promise<boolean> {
+  if (!(await isDirty(treePath))) return false;
+  await git(treePath, ["add", "-A"]);
+  const staged = (await git(treePath, ["diff", "--cached", "--name-only"])).trim();
+  if (!staged) return false;
+  await git(treePath, ["commit", "-m", "Flow agent changes"]);
+  return true;
+}
+
+async function fetchTargetBranch(treePath: string, targetBranch: string): Promise<string | { error: string }> {
+  try {
+    await git(treePath, ["fetch", "origin", `+refs/heads/${targetBranch}:refs/remotes/origin/${targetBranch}`]);
+    return `origin/${targetBranch}`;
+  } catch (e) {
+    return { error: `Couldn't find target branch "${targetBranch}" on origin: ${gitErrLine(e)}` };
+  }
+}
+
+function parseConflictFiles(text: string): string[] {
+  const out = new Set<string>();
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || /^CONFLICT\b/.test(line) || /^Auto-merging\b/.test(line) || /^[a-f0-9]{40}$/.test(line)) continue;
+    if (/^[\w.-]+\s+/.test(line) && line.includes("\t")) {
+      const parts = line.split("\t");
+      if (parts[parts.length - 1]) out.add(parts[parts.length - 1]);
+      continue;
+    }
+    if (!line.includes(":")) out.add(line);
+  }
+  return [...out].slice(0, 20);
+}
+
+async function mergeConflicts(
+  treePath: string,
+  targetRef: string
+): Promise<{ conflict: false } | { conflict: true; files: string[] } | { error: string }> {
+  try {
+    await git(treePath, ["merge-tree", "--write-tree", targetRef, "HEAD"]);
+    return { conflict: false };
+  } catch (e) {
+    const err = e as { stdout?: string; stderr?: string; message?: string };
+    const text = [err.stdout, err.stderr, err.message].filter(Boolean).join("\n");
+    if (!/CONFLICT\b|conflict/i.test(text)) return { error: gitErrLine(e) };
+    let files = parseConflictFiles(text);
+    try {
+      await execFileP("git", ["-C", treePath, "merge-tree", "--write-tree", "--name-only", targetRef, "HEAD"], {
+        timeout: GIT_TIMEOUT_MS,
+        maxBuffer: MAX_BUFFER,
+      });
+    } catch (nameOnlyErr) {
+      const ne = nameOnlyErr as { stdout?: string; stderr?: string; message?: string };
+      const parsed = parseConflictFiles([ne.stdout, ne.stderr, ne.message].filter(Boolean).join("\n"));
+      if (parsed.length) files = parsed;
+    }
+    return { conflict: true, files };
+  }
+}
+
+// PR-first exit for a separate copy:
+//   1. package dirty work into a commit so GitHub has an actual diff,
+//   2. check mergeability against the chosen target branch,
+//   3. push the exact local HEAD to origin/branch and verify it exists,
+//   4. return the GitHub compare URL that opens the PR flow.
+export async function openPullRequestWorktree(opts: {
+  treePath: string;
+  branch: string;
+  targetBranch: string;
+  owner: string;
+  repo: string;
+}): Promise<OpenPullRequestResult | OpenPullRequestConflict | { error: string }> {
+  const { treePath, branch, targetBranch, owner, repo } = opts;
+  if (!isManagedWorktree(treePath)) return { error: "That path isn't a Flow-managed copy." };
+  if (!targetBranch.trim()) return { error: "Choose a target branch." };
+
+  let committed = false;
+  try {
+    committed = await commitDirtyWorktree(treePath);
+  } catch (e) {
+    return { error: `Couldn't commit this copy's changes: ${gitErrLine(e)}` };
+  }
+
+  const targetRef = await fetchTargetBranch(treePath, targetBranch);
+  if (typeof targetRef !== "string") return targetRef;
+
+  const ahead = parseInt((await git(treePath, ["rev-list", "--count", `${targetRef}..HEAD`])).trim(), 10);
+  if (!Number.isFinite(ahead) || ahead === 0) {
+    return { error: `No changes to open a PR against ${targetBranch}.` };
+  }
+
+  const conflicts = await mergeConflicts(treePath, targetRef);
+  if ("error" in conflicts) return { error: conflicts.error };
+  if (conflicts.conflict) {
+    return { conflict: true, branch, targetBranch, files: conflicts.files };
+  }
+
+  try {
+    await git(treePath, ["push", "-u", "origin", `HEAD:refs/heads/${branch}`]);
+    const remoteRef = (await git(treePath, ["ls-remote", "--heads", "origin", branch])).trim();
+    if (!remoteRef) return { error: `Pushed, but origin/${branch} was not found afterwards.` };
+  } catch (e) {
+    return { error: gitErrLine(e) };
+  }
+
+  const enc = (ref: string) => ref.split("/").map(encodeURIComponent).join("/");
+  const compareUrl = `https://github.com/${owner}/${repo}/compare/${enc(targetBranch)}...${enc(branch)}?expand=1`;
+  return { ok: true, compareUrl, branch, targetBranch, committed };
 }
 
 // Cheap hygiene before listing: drop dangling worktree metadata (folders the

--- a/orchestrator/test/worktrees.test.ts
+++ b/orchestrator/test/worktrees.test.ts
@@ -27,6 +27,7 @@ let listWorktrees: typeof import("../src/agents/worktrees.js").listWorktrees;
 let inspectWorktree: typeof import("../src/agents/worktrees.js").inspectWorktree;
 let removeWorktree: typeof import("../src/agents/worktrees.js").removeWorktree;
 let applyWorktree: typeof import("../src/agents/worktrees.js").applyWorktree;
+let openPullRequestWorktree: typeof import("../src/agents/worktrees.js").openPullRequestWorktree;
 let isManagedWorktree: typeof import("../src/agents/worktrees.js").isManagedWorktree;
 let managedRepoOf: typeof import("../src/agents/worktrees.js").managedRepoOf;
 let collidingSession: typeof import("../src/agents/runtime.js").collidingSession;
@@ -56,6 +57,15 @@ function makeCheckout(): string {
   return dir;
 }
 
+function makeCheckoutWithOrigin(): { src: string; remote: string } {
+  const src = makeCheckout();
+  const remote = join(TMP, `remote-${++counter}.git`);
+  execFileSync("git", ["init", "--bare", "-q", remote]);
+  git(src, ["remote", "add", "origin", remote]);
+  git(src, ["push", "-u", "origin", "main"]);
+  return { src, remote };
+}
+
 // Point REPOS_JSON_PATH at a temp file so worktrees land under
 // dirname(REPOS_JSON_PATH)/worktrees/<repo>/<slug> — i.e. inside TMP.
 function setWorkspace(): void {
@@ -73,6 +83,7 @@ before(async () => {
   inspectWorktree = wt.inspectWorktree;
   removeWorktree = wt.removeWorktree;
   applyWorktree = wt.applyWorktree;
+  openPullRequestWorktree = wt.openPullRequestWorktree;
   isManagedWorktree = wt.isManagedWorktree;
   managedRepoOf = wt.managedRepoOf;
   const rt = await import("../src/agents/runtime.js");
@@ -441,5 +452,63 @@ describe("applyWorktree — merge back into the user's folder", () => {
     // The user's folder is exactly as we found it: clean, on their own version.
     assert.equal(git(src, ["status", "--porcelain"]).trim(), "", "src clean after abort");
     assert.equal(readFileSync(join(src, "README.md"), "utf8"), "changed-by-user\n", "src content preserved");
+  });
+});
+
+describe("openPullRequestWorktree — PR-first handoff", () => {
+  test("dirty copy is committed and pushed to the exact origin branch", async () => {
+    const { src, remote } = makeCheckoutWithOrigin();
+    const r = await createSessionWorktree({ repoName: "prrepo", srcCheckout: src, baseBranch: "main", title: "open pr dirty copy" });
+    assert.ok(!("error" in r), "error" in r ? r.error : "");
+    if ("error" in r) return;
+
+    writeFileSync(join(r.path, "feature.txt"), "ready for review\n");
+    const pr = await openPullRequestWorktree({
+      treePath: r.path,
+      branch: r.branch,
+      targetBranch: "main",
+      owner: "acme",
+      repo: "prrepo",
+    });
+
+    assert.ok(!("error" in pr) && !("conflict" in pr), JSON.stringify(pr));
+    if ("error" in pr || "conflict" in pr) return;
+    assert.equal(pr.committed, true);
+    assert.match(pr.compareUrl, /github\.com\/acme\/prrepo\/compare\/main\.\.\.flow\/open-pr-dirty-copy-/);
+    assert.equal(git(r.path, ["status", "--porcelain"]).trim(), "", "copy is clean after auto-commit");
+    assert.ok(git(r.path, ["log", "--oneline", "-1"]).includes("Flow agent changes"), "auto-commit created");
+    assert.ok(
+      execFileSync("git", ["ls-remote", "--heads", remote, r.branch], { encoding: "utf8" }).includes(`refs/heads/${r.branch}`),
+      "remote branch exists after push"
+    );
+  });
+
+  test("merge conflicts are reported before opening a PR", async () => {
+    const { src, remote } = makeCheckoutWithOrigin();
+    const r = await createSessionWorktree({ repoName: "conflictrepo", srcCheckout: src, baseBranch: "main", title: "conflict pr" });
+    assert.ok(!("error" in r), "error" in r ? r.error : "");
+    if ("error" in r) return;
+
+    writeFileSync(join(r.path, "README.md"), "changed-by-copy\n");
+    commit(src, "README.md", "changed-by-main\n", "main edits readme");
+    git(src, ["push", "origin", "main"]);
+
+    const pr = await openPullRequestWorktree({
+      treePath: r.path,
+      branch: r.branch,
+      targetBranch: "main",
+      owner: "acme",
+      repo: "conflictrepo",
+    });
+
+    assert.ok("conflict" in pr, JSON.stringify(pr));
+    if (!("conflict" in pr)) return;
+    assert.equal(pr.targetBranch, "main");
+    assert.ok(pr.files.length === 0 || pr.files.includes("README.md"), `conflict files: ${pr.files.join(", ")}`);
+    assert.equal(
+      execFileSync("git", ["ls-remote", "--heads", remote, r.branch], { encoding: "utf8" }).trim(),
+      "",
+      "conflicting branch is not pushed before resolution"
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Prefer local installed agent CLIs for ACP backends when available, with bundled fallback.
- Replace separate-copy Apply/Push UI with PR-first handoff and target branch selection.
- Add worktree PR backend flow that auto-commits dirty edits, checks conflicts, pushes the exact branch ref, and verifies the remote branch.

## Validation
- dashboard: npx tsc --noEmit --pretty false
- orchestrator: npx tsc --noEmit --pretty false (still fails only on pre-existing unrelated errors in slack/corpus/index/pollers)
- orchestrator: /Users/samyakjain/.nvm/versions/node/v22.22.3/bin/node --import tsx/esm --test test/worktrees.test.ts --test-name-pattern="openPullRequestWorktree"
