### PR TITLE
Make GitHub push → reindex deterministic

### DIFF
--- a/orchestrator/src/actions/index.ts
+++ b/orchestrator/src/actions/index.ts
@@ -70,9 +70,13 @@ export async function executeAction(ctx: ActionContext): Promise<void> {
   // Confidence floor (scenario S029): a low-confidence classification must not
   // auto-execute — one sarcastic message should never poison the graph. Below
   // the floor, auto downgrades to propose so a human sees it first.
+  // Exception: github.index_worthy is a safe, deterministic reindex trigger;
+  // requiring human approval for every push to main creates too much friction
+  // and lets the graph fall behind.
   const floor = Number(getSetting("FLOW_CONFIDENCE_FLOOR") ?? process.env.FLOW_CONFIDENCE_FLOOR ?? "0.75");
+  const isSafeAuto = event.source === "github" && classification.classification === "index_worthy";
   const effectivePolicy =
-    policy === "auto" && classification.confidence < floor ? "propose" : policy;
+    policy === "auto" && !isSafeAuto && classification.confidence < floor ? "propose" : policy;
 
   // Propose mode: write to outbox (DM the controller), no direct action
   if (effectivePolicy === "propose") {
@@ -215,12 +219,21 @@ async function handleGithubAuto(event: NormalizedEvent, cls: ClassificationResul
     return;
   }
 
-  // index_worthy: enqueue index job
+  // index_worthy: enqueue index job. The poller names repos as "owner/repo"
+  // but the job runner and workspace registry address checkouts by short name
+  // (repos/<name>), so resolve through the registry by URL — otherwise
+  // ensureRepoClone throws "no checkout and no url" and the job dies.
   const p = event.payload as Record<string, string | undefined>;
+  const { listWorkspaceRepos } = await import("../opencode.js");
+  const { ownerRepoFromUrl } = await import("../adapters/github.js");
+  const entry = listWorkspaceRepos().find(
+    (r) => r.url && ownerRepoFromUrl(r.url) === p.repo
+  );
+  const repoName = entry?.name ?? p.repo ?? "";
   const job = await enqueueJob({
     type: "index_repo",
-    input: { repo: p.repo ?? "", branch: p.branch ?? "main", commit: p.commit },
-    repo: p.repo,
+    input: { repo: repoName, url: entry?.url, branch: p.branch ?? entry?.branch ?? "main", commit: p.commit },
+    repo: repoName,
   });
   audit(event.id, c, cls.confidence, "index_job", job.id, "ok");
 }

--- a/orchestrator/src/events.ts
+++ b/orchestrator/src/events.ts
@@ -162,6 +162,19 @@ export async function processEvent(event: NormalizedEvent): Promise<void> {
     return;
   }
 
+  // A push to a watched base branch is a fact, not language — never classify
+  // it. The poller already filters to registered {repo, branch}, so every
+  // github push event is index-worthy by definition. Routing it through the
+  // LLM added failure modes (skip verdicts, low confidence, missing API key)
+  // that silently broke the merge → reindex → note-promotion loop.
+  if (event.source === "github" && event.type === "push") {
+    const classification = { classification: "index_worthy", confidence: 1.0, extracted: {} };
+    updateEventClassification.run({ id: event.id, classification_json: JSON.stringify(classification) });
+    const policy = policyFor("github_merge", "index_worthy");
+    await executeAction({ event, classification, policy });
+    return;
+  }
+
   // 2. Classify
   const classification = await classify(event);
   updateEventClassification.run({ id: event.id, classification_json: JSON.stringify(classification) });

--- a/orchestrator/src/opencode.ts
+++ b/orchestrator/src/opencode.ts
@@ -104,6 +104,7 @@ export interface RepoEntry {
   url: string;
   branch: string;
   lastIndexedCommit?: string | null;
+  lastIndexedAt?: string;
   addedAt?: string;
   // Sources front door. A source plays up to two roles: BRAIN (indexed) and
   // WORK (where coding-agent sessions run). `kind` distinguishes an indexed


### PR DESCRIPTION
## Problem

Pushes to main were not reliably triggering reindexing. Two root causes beyond the confidence floor:

1. **Push events went through the LLM classifier** (`skip` | `index_worthy`), making indexing probabilistic — the model could answer `skip`, return low confidence (downgraded to propose, stuck in Inbox), or fail outright when `OPENROUTER_API_KEY` was unset.
2. **Name mismatch killed the job even when approved**: the poller emits `repo: "owner/repo"` but the job runner addresses checkouts as `repos/<short-name>`, so `ensureRepoClone` threw "no checkout and no url". The poller-triggered auto-index path had never worked end-to-end.

## Fix

- `events.ts` — github push events short-circuit to deterministic `index_worthy` / confidence 1.0, same as `reindex_request` and `repo_added`. A push to a watched base branch is a fact, not language.
- `actions/index.ts` — resolve `owner/repo` → registry short name (by URL match) before enqueueing `index_repo`; pass the clone URL so a missing checkout can be recreated. `github.index_worthy` also exempted from the confidence floor as defense in depth.
- `opencode.ts` — add `lastIndexedAt` to `RepoEntry` (written by `updateRepoIndexCommit` but missing from the type).

## Testing

- `tsc --noEmit`: no new errors (pre-existing errors in slack.ts/corpus.ts/engine.ts/index.ts untouched)
- All 40 simulator scenarios pass, including `12-github-index-worthy` and `20-confidence-floor-downgrade`

## After merge

Restart the orchestrator (`flow down && flow up`) to load the new code. The merge of this PR itself should then be picked up by the poller and auto-indexed — a live test of the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)