### PR TITLE
fix: brain index fails — missing @opencode-ai/plugin in workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Flow is early and moving fast. See [`CHANGELOG.md`](CHANGELOG.md) for dated hist
 - **Port 6379 already in use** — another Redis/FalkorDB holds it. Free it, or reuse that instance with `FALKOR_HOST` / `FALKOR_PORT` as above.
 - **"Unable to find image 'falkordb/falkordb:latest'" / image download fails** — the first-run image pull failed. `flow up` prints the real cause; if it mentions a rate limit, `docker login` (a free Docker Hub account raises the anonymous pull limit) or wait an hour. Otherwise check connectivity/VPN and re-run `flow up`.
 - **A service "didn't start"** — read `data/projects/<name>/logs/{gateway,orchestrator,dashboard}.log`, and run `flow doctor` for a health summary.
+- **Brain stuck on "Building…" / index job `opencode exited 1`** — the graph tools need `@opencode-ai/plugin` in the project workspace. `flow up` installs it; if an older project predates that, run `npm install --prefix data/projects/<name>/workspace/.opencode` then reindex from the dashboard. Job logs under `data/projects/<name>/job-logs/` show `Cannot find module '@opencode-ai/plugin'` when this is the cause.
 - **Connecting a repo fails** — cloning needs `git` on your PATH.
 - **"still starting up" when you save your key** — the orchestrator takes a few seconds on first boot; wait and retry.
 - **Don't `docker compose up` for local dev** — use `flow up`. The compose file under `deploy/` is an experimental full-container path, not the local one.

--- a/bin/flow.mjs
+++ b/bin/flow.mjs
@@ -330,13 +330,6 @@ function nodeBin(subdir, name) {
   return found;
 }
 
-// Probe the orchestrator's native module (better-sqlite3) the same way the
-// orchestrator will load it — from orchestratorDir, nearest-node_modules-first.
-// Catches the "pulled the fix but node_modules is poisoned" clone: an install
-// attempted on another Node leaves a nested copy built for the wrong ABI, which
-// SHADOWS the fresh root install and crashes the orchestrator at startup with a
-// cryptic NODE_MODULE_VERSION error buried in a log file. Fail up front, with
-// the exact fix, instead.
 // Sync the indexer .opencode template into a project workspace and ensure
 // `@opencode-ai/plugin` is installed there. The graph/notify tools import that
 // package; OpenCode's background `npm install` is flaky (engine checks) and a
@@ -344,13 +337,23 @@ function nodeBin(subdir, name) {
 // before any graph nodes are written — leaving the dashboard stuck on
 // "Building your brain…" because lastIndexedCommit stays null.
 function bundledOpencodeVersion() {
-  try {
-    const pkg = JSON.parse(readFileSync(join(orchestratorDir(), "package.json"), "utf8"));
-    const raw = pkg.dependencies?.["opencode-ai"];
-    if (typeof raw === "string" && raw.length) return raw.replace(/^[^\d]*/, "") || raw;
-  } catch {
-    /* fall through */
+  // The plugin must match the opencode binary that loads it, and that binary
+  // comes from the orchestrator's opencode-ai dependency — so that's the
+  // source of truth. Fall back to the template's own package.json (which
+  // exists so the index-workspace works standalone), then a last-resort pin.
+  const candidates = [
+    [join(orchestratorDir(), "package.json"), "opencode-ai"],
+    [join(indexWorkspaceDir(), ".opencode", "package.json"), "@opencode-ai/plugin"],
+  ];
+  for (const [pkgPath, depName] of candidates) {
+    try {
+      const raw = JSON.parse(readFileSync(pkgPath, "utf8")).dependencies?.[depName];
+      if (typeof raw === "string" && raw.length) return raw.replace(/^[^\d]*/, "") || raw;
+    } catch {
+      /* try next */
+    }
   }
+  console.log(c.dim("  could not resolve the bundled opencode version; pinning @opencode-ai/plugin@1.17.14"));
   return "1.17.14";
 }
 
@@ -399,6 +402,13 @@ function syncOpencodeWorkspace(workspaceDir, { quiet = false } = {}) {
   }
 }
 
+// Probe the orchestrator's native module (better-sqlite3) the same way the
+// orchestrator will load it — from orchestratorDir, nearest-node_modules-first.
+// Catches the "pulled the fix but node_modules is poisoned" clone: an install
+// attempted on another Node leaves a nested copy built for the wrong ABI, which
+// SHADOWS the fresh root install and crashes the orchestrator at startup with a
+// cryptic NODE_MODULE_VERSION error buried in a log file. Fail up front, with
+// the exact fix, instead.
 function preflightNativeDeps() {
   const probe = spawnSync(process.execPath, ["-e", "require('better-sqlite3')"], {
     cwd: orchestratorDir(),

--- a/bin/flow.mjs
+++ b/bin/flow.mjs
@@ -337,6 +337,68 @@ function nodeBin(subdir, name) {
 // SHADOWS the fresh root install and crashes the orchestrator at startup with a
 // cryptic NODE_MODULE_VERSION error buried in a log file. Fail up front, with
 // the exact fix, instead.
+// Sync the indexer .opencode template into a project workspace and ensure
+// `@opencode-ai/plugin` is installed there. The graph/notify tools import that
+// package; OpenCode's background `npm install` is flaky (engine checks) and a
+// missing plugin makes every index_repo job die with "Unexpected server error"
+// before any graph nodes are written — leaving the dashboard stuck on
+// "Building your brain…" because lastIndexedCommit stays null.
+function bundledOpencodeVersion() {
+  try {
+    const pkg = JSON.parse(readFileSync(join(orchestratorDir(), "package.json"), "utf8"));
+    const raw = pkg.dependencies?.["opencode-ai"];
+    if (typeof raw === "string" && raw.length) return raw.replace(/^[^\d]*/, "") || raw;
+  } catch {
+    /* fall through */
+  }
+  return "1.17.14";
+}
+
+function syncOpencodeWorkspace(workspaceDir, { quiet = false } = {}) {
+  mkdirSync(workspaceDir, { recursive: true });
+  const templateOpencode = join(indexWorkspaceDir(), ".opencode");
+  const dest = join(workspaceDir, ".opencode");
+  if (existsSync(templateOpencode)) {
+    cpSync(templateOpencode, dest, { recursive: true });
+  } else {
+    mkdirSync(dest, { recursive: true });
+  }
+
+  // Keep package.json convergent with the bundled opencode-ai version even if
+  // the template on disk drifts (older projects, partial checkouts).
+  const version = bundledOpencodeVersion();
+  const pkgPath = join(dest, "package.json");
+  writeFileSync(
+    pkgPath,
+    JSON.stringify({ private: true, dependencies: { "@opencode-ai/plugin": version } }, null, 2) + "\n",
+    "utf8"
+  );
+
+  const pluginPkg = join(dest, "node_modules", "@opencode-ai", "plugin", "package.json");
+  let installed = null;
+  if (existsSync(pluginPkg)) {
+    try {
+      installed = JSON.parse(readFileSync(pluginPkg, "utf8")).version ?? null;
+    } catch {
+      installed = null;
+    }
+  }
+  if (installed === version) return;
+
+  if (!quiet) console.log(c.dim("  installing @opencode-ai/plugin for graph tools…"));
+  const res = spawnSync("npm", ["install", "--no-audit", "--no-fund"], {
+    cwd: dest,
+    stdio: quiet ? "ignore" : ["ignore", "ignore", "inherit"],
+    timeout: 180000,
+  });
+  if (res.status !== 0) {
+    console.log(
+      `  ${FAIL} could not install @opencode-ai/plugin in ${relative(flowRoot, dest) || dest}\n` +
+        `      Indexing will fail until you run:  npm install --prefix ${relative(flowRoot, dest) || dest}`
+    );
+  }
+}
+
 function preflightNativeDeps() {
   const probe = spawnSync(process.execPath, ["-e", "require('better-sqlite3')"], {
     cwd: orchestratorDir(),
@@ -442,12 +504,7 @@ FLOW_ADMIN_TOKEN=${adminToken}
     { encoding: "utf-8", mode: 0o600 }
   );
 
-  const templateOpencode = join(indexWorkspaceDir(), ".opencode");
-  if (existsSync(templateOpencode)) {
-    cpSync(templateOpencode, join(workspaceDir, ".opencode"), { recursive: true });
-  } else {
-    mkdirSync(join(workspaceDir, ".opencode"), { recursive: true });
-  }
+  syncOpencodeWorkspace(workspaceDir, { quiet: true });
   const templateAgentsMd = join(indexWorkspaceDir(), "AGENTS.md");
   if (existsSync(templateAgentsMd)) {
     writeFileSync(join(workspaceDir, "AGENTS.md"), readFileSync(templateAgentsMd, "utf-8"), "utf-8");
@@ -640,13 +697,10 @@ async function upProject(name, { rebuilt = false } = {}) {
   // they talk to: when the gateway started requiring bearer auth, every
   // pre-existing workspace kept a tokenless graph tool and reindex jobs 401'd
   // on every write. Convergent and idempotent on each full start, same
-  // philosophy as the gateway's boot reconcilers; cpSync overwrites template
-  // files and leaves any extra workspace files alone.
+  // philosophy as the gateway's boot reconcilers; also installs
+  // @opencode-ai/plugin so index jobs don't die on a missing module.
   if (existsSync(workspaceDir)) {
-    const templateOpencode = join(indexWorkspaceDir(), ".opencode");
-    if (existsSync(templateOpencode)) {
-      cpSync(templateOpencode, join(workspaceDir, ".opencode"), { recursive: true });
-    }
+    syncOpencodeWorkspace(workspaceDir);
     const templateAgentsMd = join(indexWorkspaceDir(), "AGENTS.md");
     if (existsSync(templateAgentsMd)) {
       writeFileSync(join(workspaceDir, "AGENTS.md"), readFileSync(templateAgentsMd, "utf-8"), "utf-8");

--- a/graph-gateway/README.md
+++ b/graph-gateway/README.md
@@ -56,7 +56,9 @@ npm run mcp    # stdio server, e.g. `claude mcp add graph-gateway -- npm run mcp
 ## OpenCode
 
 Copy or symlink `opencode-tools/graph.ts` into your workspace's
-`.opencode/tools/`. Tools appear as `graph_find`, `graph_upsert`,
+`.opencode/tools/`, and add a `.opencode/package.json` that depends on
+`@opencode-ai/plugin` (same version as your `opencode` / `opencode-ai`
+install). Tools appear as `graph_find`, `graph_upsert`,
 `graph_relate`, `graph_get`, `graph_read`, `graph_schema`, and stamp the
 calling session's identity into provenance automatically. Point
 `GRAPH_GATEWAY_URL` at the gateway if it isn't on the default port.

--- a/index-workspace/.opencode/.gitignore
+++ b/index-workspace/.opencode/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+bun.lock

--- a/index-workspace/.opencode/package.json
+++ b/index-workspace/.opencode/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "dependencies": {
+    "@opencode-ai/plugin": "1.17.14"
+  }
+}

--- a/index-workspace/.opencode/package.json
+++ b/index-workspace/.opencode/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "//": "The plugin version must match the opencode-ai release Flow bundles (orchestrator/package.json — the source of truth). `flow up` rewrites this file in each project workspace from that source; this copy is the fallback and serves standalone index-workspace runs.",
   "dependencies": {
     "@opencode-ai/plugin": "1.17.14"
   }

--- a/index-workspace/.opencode/tools/graph.ts
+++ b/index-workspace/.opencode/tools/graph.ts
@@ -1,7 +1,9 @@
 import { tool } from "@opencode-ai/plugin";
 
 // OpenCode code-file tools for the memory graph. Copy or symlink this file
-// into your workspace's .opencode/tools/ directory; tool names become
+// into your workspace's .opencode/tools/ directory (and install
+// `@opencode-ai/plugin` via the sibling package.json — `flow up` does this);
+// tool names become
 // graph_find, graph_upsert, graph_relate, graph_get, graph_read, graph_schema.
 //
 // These are deliberately thin: every call goes over HTTP to the graph-gateway

--- a/index-workspace/README.md
+++ b/index-workspace/README.md
@@ -19,7 +19,9 @@ node scripts/update.mjs [repo-name]
 - Indexing runs as the `graph-builder` opencode agent (`.opencode/agents/`),
   which writes through the graph-gateway `graph_*` tools — find-before-create
   dedup is what keeps later repos enriching earlier ones instead of
-  duplicating them.
+  duplicating them. Those tools import `@opencode-ai/plugin`; the dependency
+  is declared in `.opencode/package.json` and `flow up` installs it into each
+  project workspace (do not rely on OpenCode's background install alone).
 - Model: `GRAPH_BUILDER_MODEL` env var, default `opencode/claude-sonnet-4-6`.
 - Watch what the builder writes live: `curl -s localhost:7433/v1/journal | jq`
   or `tail -f ../graph-gateway/data/journal.jsonl`.


### PR DESCRIPTION
## Summary

Fresh projects can get stuck forever on **“Building your brain…”** because the first `index_repo` job fails immediately. This PR documents that failure mode and fixes the root cause.

### What goes wrong today

1. Connecting a repo queues an `index_repo` job that runs OpenCode as the `graph-builder` agent.
2. That agent loads `.opencode/tools/graph.ts` / `notify.ts`, which import `@opencode-ai/plugin`.
3. `flow project create` / `flow up` only copy the tool/agent **files** — they never ship a `package.json` or install that dependency into the project workspace.
4. OpenCode’s background install is supposed to rescue this, but it can fail (`Unsupported engine`). When it does, tool loading dies with `Cannot find module '@opencode-ai/plugin'`.
5. The job collapses that into `Unexpected server error` → `opencode exited 1`.
6. **UX trap:** the dashboard treats `lastIndexedCommit == null` as “still indexing”, so a *failed* index looks like progress forever. Graph stays at 0 nodes. Coding-agent sessions still work (they don’t load these tools).

OpenRouter key / model are red herrings — failure happens before useful LLM work.

### Fix

- Ship `index-workspace/.opencode/package.json` declaring `@opencode-ai/plugin`.
- On project create and every full `flow up`, sync the template and `npm install` into the project workspace when the plugin is missing/mismatched.
- Document the failure mode in README troubleshooting + index/gateway docs.

### Follow-up (not in this PR)

- Dashboard should treat a failed `index_repo` as failure, not “building”.

## Test plan

- [ ] `flow up <new-project>` installs plugin under `workspace/.opencode/node_modules`
- [ ] Connect a repo → index gets past tool load (no instant `opencode exited 1`)
- [ ] Job log has no `Cannot find module '@opencode-ai/plugin'`
- [ ] Older project: `flow up` heals workspace; reindex works


Made with [Cursor](https://cursor.com)