### PR TITLE
Fix manual reindex repo payload

### DIFF
--- a/dashboard/scripts/smoke.mjs
+++ b/dashboard/scripts/smoke.mjs
@@ -40,6 +40,7 @@ const POLICIES_RESPONSE = {
 };
 
 const ASK_JOB_ID = "smoke-job-001";
+const receivedEvents = [];
 const ASK_RESPONSE = {
   id: ASK_JOB_ID,
   status: "done",
@@ -199,7 +200,13 @@ function startStubOrchestrator() {
       return sendJson({ rows: [], count: 0 });
     }
     if (req.url?.startsWith("/v1/events")) {
-      return sendJson({ id: "stub-evt", status: "accepted" }, 202);
+      let body = "";
+      req.on("data", (chunk) => { body += chunk; });
+      req.on("end", () => {
+        try { receivedEvents.push(JSON.parse(body)); } catch { /* malformed bodies are tested elsewhere */ }
+        sendJson({ id: "stub-evt", status: "accepted" }, 202);
+      });
+      return;
     }
     if (req.url === "/v1/mode") {
       return sendJson(MODE_RESPONSE);
@@ -587,6 +594,19 @@ async function main() {
       "/api/repos repo entries have name field (displayed in Home GitHub card)"
     );
   }
+
+  const reindexRes = await httpPost(
+    `${DASH_BASE}/api/repos`,
+    { action: "reindex", repoName: "owner/manual-reindex-repo" },
+    { Cookie: sessionCookie }
+  );
+  assert(reindexRes.status === 200, `/api/repos reindex returns 200 (got ${reindexRes.status})`);
+  const reindexEvent = receivedEvents.find((event) => event.type === "reindex_request");
+  assert(reindexEvent !== undefined, "/api/repos reindex posts a reindex_request event");
+  assert(
+    reindexEvent.payload?.repo === "owner/manual-reindex-repo",
+    "/api/repos reindex sends the repo field expected by the orchestrator"
+  );
 
   // ── Check 23: /api/repos endpoint returns the registry (used by HomeGitHubCard)
   // Already verified above in Check 22 that /api/repos returns repos with name fields.

--- a/dashboard/src/app/api/repos/route.ts
+++ b/dashboard/src/app/api/repos/route.ts
@@ -61,7 +61,7 @@ export async function POST(req: NextRequest) {
         source: "dashboard",
         type: "reindex_request",
         ts: Date.now(),
-        payload: { repoName: body.repoName, jobType: "index_repo" },
+        payload: { repo: body.repoName, jobType: "index_repo" },
       });
       return NextResponse.json({
         ok: true,
@@ -112,7 +112,7 @@ export async function POST(req: NextRequest) {
           source: "dashboard",
           type: "reindex_request",
           ts: Date.now(),
-          payload: { repoName: body.repoName, jobType: "index_repo" },
+          payload: { repo: body.repoName, branch: body.branch, jobType: "index_repo" },
         });
       } catch {
         // best-effort


### PR DESCRIPTION
## Summary

- send the orchestrator-compatible `repo` field for dashboard reindex events
- include the selected branch when branch changes enqueue a reindex
- cover the dashboard-to-orchestrator payload contract in the smoke harness

## Verification

- `npm run build --workspace dashboard`
- `node --import tsx/esm --test test/fake-opencode.ts test/outbox-approve.test.ts` (6 tests passed)
- targeted ESLint on the changed files (0 errors; 4 pre-existing warnings in smoke.mjs)

The full dashboard smoke currently stops before this new assertion at its existing unauthenticated-root check: local `FLOW_ADMIN_TOKEN` mode auto-authenticates `/`, while the harness expects a redirect.