### PR TITLE
Fix brain overview dropping subgraphs: fetch all nodes/edges, remove row LIMIT

### DIFF
--- a/dashboard/src/app/api/graph/overview/route.ts
+++ b/dashboard/src/app/api/graph/overview/route.ts
@@ -3,18 +3,15 @@ import { getSessionToken } from "@/lib/auth";
 import { FLOW_ADMIN_TOKEN, GATEWAY_URL } from "@/lib/config";
 
 // GET /api/graph/overview
-// Calls the graph-gateway POST /v1/verbs/read_query with a safe read-only Cypher
-// and returns cytoscape-ready nodes + edges (up to LIMIT).
+// Calls the graph-gateway POST /v1/verbs/read_query with safe read-only Cypher
+// and returns cytoscape-ready nodes + edges — the complete graph, fetched as
+// two queries (all nodes, then all relationships). A single joined
+// `MATCH (n) OPTIONAL MATCH (n)-[r]->(m)` query multiplies rows by out-degree,
+// so any row LIMIT silently drops whole subgraphs once the graph grows.
 // We omit `graph` from the body so the gateway uses its configured default graph.
 
-const LIMIT = 300;
-
-const CYPHER = `
-MATCH (n)
-OPTIONAL MATCH (n)-[r]->(m)
-RETURN n, r, m
-LIMIT ${LIMIT}
-`.trim();
+const NODES_CYPHER = `MATCH (n) RETURN n`;
+const EDGES_CYPHER = `MATCH ()-[r]->() RETURN r`;
 
 // FalkorDB's native node/edge shape as the gateway returns it: `id` is an
 // INTERNAL integer, the real id + name live in `properties`, the label in
@@ -32,15 +29,9 @@ interface GwRel {
   type?: string;
   properties?: Record<string, unknown>;
 }
-interface GatewayRow {
-  n?: GwNode | null;
-  r?: GwRel | null;
-  m?: GwNode | null;
-}
-
 interface GatewayQueryResult {
   status: string;
-  rows?: GatewayRow[];
+  rows?: Record<string, unknown>[];
   columns?: string[];
   error?: string;
 }
@@ -61,38 +52,35 @@ export async function GET() {
   if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   try {
-    const res = await fetch(`${GATEWAY_URL}/v1/verbs/read_query`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", ...(FLOW_ADMIN_TOKEN ? { authorization: `Bearer ${FLOW_ADMIN_TOKEN}` } : {}) },
-      body: JSON.stringify({ cypher: CYPHER }),
-      signal: AbortSignal.timeout(8000),
-    });
+    const runQuery = async (cypher: string): Promise<Record<string, unknown>[]> => {
+      const res = await fetch(`${GATEWAY_URL}/v1/verbs/read_query`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...(FLOW_ADMIN_TOKEN ? { authorization: `Bearer ${FLOW_ADMIN_TOKEN}` } : {}) },
+        body: JSON.stringify({ cypher }),
+        signal: AbortSignal.timeout(15000),
+      });
+      if (!res.ok) throw new Error(`Gateway responded ${res.status}`);
+      const result = (await res.json()) as GatewayQueryResult;
+      if (result.status !== "ok" && result.status !== "success") {
+        throw new Error(result.error ?? result.status);
+      }
+      return result.rows ?? [];
+    };
 
-    if (!res.ok) {
-      return NextResponse.json(
-        { error: `Gateway responded ${res.status}`, nodes: [], edges: [] },
-        { status: 502 }
-      );
-    }
-
-    const result = (await res.json()) as GatewayQueryResult;
-
-    if (result.status !== "ok" && result.status !== "success") {
-      return NextResponse.json({ nodes: [], edges: [], error: result.error ?? result.status });
-    }
-
-    const rows = result.rows ?? [];
+    const [nodeRows, edgeRows] = await Promise.all([
+      runQuery(NODES_CYPHER),
+      runQuery(EDGES_CYPHER),
+    ]);
 
     const nodesMap = new Map<string, CyNode>();          // display id → node
     const internalToDisplay = new Map<number, string>(); // FalkorDB int id → display id
-    const edgesSet = new Set<string>();
-    const edges: CyEdge[] = [];
 
     const displayId = (nd: GwNode): string =>
       String(nd.properties?.id ?? nd.properties?.name ?? `node-${nd.id}`);
 
-    const addNode = (nd?: GwNode | null): string | null => {
-      if (!nd) return null;
+    for (const row of nodeRows) {
+      const nd = row.n as GwNode | null | undefined;
+      if (!nd) continue;
       const did = displayId(nd);
       internalToDisplay.set(nd.id, did);
       if (!nodesMap.has(did)) {
@@ -105,20 +93,21 @@ export async function GET() {
           },
         });
       }
-      return did;
-    };
+    }
 
-    for (const row of rows) {
-      const s = addNode(row.n);
-      const t = addNode(row.m);
-      const r = row.r;
-      if (s && t && r) {
-        const label = r.relationshipType ?? r.type ?? "";
-        const key = `${s}→${label}→${t}`;
-        if (!edgesSet.has(key)) {
-          edgesSet.add(key);
-          edges.push({ source: s, target: t, label });
-        }
+    const edgesSet = new Set<string>();
+    const edges: CyEdge[] = [];
+    for (const row of edgeRows) {
+      const r = row.r as GwRel | null | undefined;
+      if (!r) continue;
+      const s = internalToDisplay.get(r.sourceId);
+      const t = internalToDisplay.get(r.destinationId);
+      if (!s || !t) continue;
+      const label = r.relationshipType ?? r.type ?? "";
+      const key = `${s}→${label}→${t}`;
+      if (!edgesSet.has(key)) {
+        edgesSet.add(key);
+        edges.push({ source: s, target: t, label });
       }
     }
 


### PR DESCRIPTION
## Problem

The brain viz's `/api/graph/overview` ran a single joined query:

```cypher
MATCH (n) OPTIONAL MATCH (n)-[r]->(m) RETURN n, r, m LIMIT 300
```

`LIMIT 300` caps **traversal rows** (node × outgoing-edge pairs), not nodes. Once a graph's total rows exceed 300, every node later in FalkorDB scan order silently vanishes from the viz while the API still returns 200 with a plausible-looking graph.

Observed on the landinghero project: after the 2026-07-12 re-index grew the graph to 867 traversal rows, all 19 app-landinghero nodes (starting at row ~395) disappeared from the brain — reported as "my graph is gone" even though the data was fully intact in FalkorDB.

## Fix

Fetch the complete graph as two unbounded queries — `MATCH (n) RETURN n` and `MATCH ()-[r]->() RETURN r` — and join edges to nodes via FalkorDB internal ids. No limit: the two-query shape is a smaller payload than the old row-multiplied join, and a viz-layer cap that silently drops data is worse than no cap.

## Verification

Deployed to the running landinghero dashboard: overview went from 295 nodes / 270 edges (0 app-landinghero) to 355 nodes / 646 edges with all 20 app-landinghero nodes rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)