### PR TITLE
Delete FalkorDB graph when removing project

### DIFF
--- a/bin/flow.mjs
+++ b/bin/flow.mjs
@@ -48,6 +48,7 @@ import {
 } from "./lib/projects.mjs";
 import { probe, waitForHealth } from "./lib/health.mjs";
 import { ensureFalkordb } from "./lib/docker.mjs";
+import { deleteProjectGraph } from "./lib/falkordb.mjs";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -1046,7 +1047,35 @@ async function cmdRm(args) {
     }
   }
   console.log(`\n${c.bold("Flow")} ${c.dim("· removing " + name)}`);
+  const project = readProject(name);
+  const projectEnv = parseEnvFile(join(projectDir(name), ".env"));
   await downProject(name);
+
+  // FalkorDB is shared across projects, but each project normally owns one
+  // named graph. Delete that graph before removing project.json so a failed DB
+  // connection leaves enough metadata for the user to retry instead of
+  // creating a permanently orphaned graph. A custom graph may intentionally
+  // be shared; preserve it while another registered project still uses it.
+  const sharedWith = listProjects().find(
+    ({ name: otherName, project: other }) => otherName !== name && other.graph === project.graph,
+  );
+  if (sharedWith) {
+    console.log(`  ${c.dim(`· graph ${project.graph} kept (shared with ${sharedWith.name})`)}`);
+  } else {
+    const host = projectEnv.FALKOR_HOST ?? process.env.FALKOR_HOST ?? "localhost";
+    const port = Number(projectEnv.FALKOR_PORT ?? process.env.FALKOR_PORT ?? 6379);
+    let result;
+    try {
+      result = await deleteProjectGraph({ graph: project.graph, host, port });
+    } catch (err) {
+      throw new Error(
+        `Couldn't delete FalkorDB graph "${project.graph}" at ${host}:${port}; project files were kept so you can retry.\n` +
+          `  ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    console.log(`  ${result.existed ? OK : c.dim("·")} ${c.dim(result.existed ? `deleted graph ${project.graph}` : `graph ${project.graph} already empty`)}`);
+  }
+
   rmSync(projectDir(name), { recursive: true, force: true });
   console.log(`  ${OK} removed ${c.bold(name)}\n`);
 }

--- a/bin/lib/falkordb.mjs
+++ b/bin/lib/falkordb.mjs
@@ -1,0 +1,34 @@
+// FalkorDB lifecycle helpers used by the Flow CLI.
+
+import { FalkorDB } from "falkordb";
+
+/**
+ * Delete one project's named graph and its graph-scoped bookkeeping.
+ *
+ * FalkorDB is shared by every Flow project, so this deliberately deletes only
+ * the requested graph. Missing graphs are treated as already clean, which
+ * keeps `flow rm` safe to retry after a partially completed removal.
+ */
+export async function deleteProjectGraph({ graph, host = "localhost", port = 6379 }) {
+  const db = await FalkorDB.connect({
+    socket: {
+      host,
+      port: Number(port),
+      connectTimeout: 3000,
+      reconnectStrategy: false,
+    },
+  });
+
+  try {
+    const graphs = await db.list();
+    const existed = graphs.includes(graph);
+    if (existed) await db.selectGraph(graph).delete();
+
+    // Gateway migrations live in a plain Redis key rather than in the graph.
+    const connection = await db.connection;
+    await connection.del(`flow:graph-version:${graph}`);
+    return { existed };
+  } finally {
+    await db.close();
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,9 @@
         "graph-gateway",
         "dashboard"
       ],
+      "dependencies": {
+        "falkordb": "^6.2.0"
+      },
       "bin": {
         "flow": "bin/flow.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "engines": {
     "node": ">=22",
     "npm": ">=9"
+  },
+  "dependencies": {
+    "falkordb": "^6.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- delete a project’s named FalkorDB graph during `flow rm`
- remove the graph-scoped migration marker as part of cleanup
- preserve explicitly shared graphs while another project references them
- keep project metadata intact when FalkorDB cleanup fails so removal can be retried

## Verification
- `node --check bin/flow.mjs`
- `node --check bin/lib/falkordb.mjs`
- `npm run --workspace graph-gateway typecheck`
- live FalkorDB cleanup integration check
- end-to-end project create → seed graph → `flow rm` check
- shared-graph ownership check

## Test-suite note
The broader orchestrator suite could not run in this checkout because `better-sqlite3` has no native binding built for the bundled Node runtime. The failure occurs during test setup and is unrelated to the CLI removal path.