### PR TITLE
Memory v1: passive session distillation, evidence-based store, pull-only retrieval

### DIFF
--- a/graph-gateway/package.json
+++ b/graph-gateway/package.json
@@ -10,7 +10,7 @@
     "start": "tsx src/server.ts",
     "mcp": "tsx src/mcp.ts",
     "typecheck": "tsc --noEmit",
-    "test": "node --experimental-test-module-mocks --import tsx/esm --test test/verbs-batch.test.ts"
+    "test": "node --experimental-test-module-mocks --import tsx/esm --test test/verbs-batch.test.ts test/verbs-memory.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",

--- a/graph-gateway/package.json
+++ b/graph-gateway/package.json
@@ -9,7 +9,8 @@
     "dev": "tsx watch src/server.ts",
     "start": "tsx src/server.ts",
     "mcp": "tsx src/mcp.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --experimental-test-module-mocks --import tsx/esm --test test/verbs-batch.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",

--- a/graph-gateway/src/mcp.ts
+++ b/graph-gateway/src/mcp.ts
@@ -43,6 +43,8 @@ const SESSION_VERBS = new Set([
   "correct_graph",
   // Ungated branch-scoped working memory.
   "note",
+  // Retrieve-only cross-session memory (distilled decisions/gotchas + corpus).
+  "search_memory",
 ]);
 // The graph-builder surface: exactly what the old .opencode/tools/graph.ts
 // plugin exposed, now served over MCP so workspaces need no npm install.

--- a/graph-gateway/src/memory-client.ts
+++ b/graph-gateway/src/memory-client.ts
@@ -1,0 +1,133 @@
+// memory-client.ts — the gateway's thin HTTP client to the orchestrator's
+// memory surface (flow.db-backed). The gateway never touches flow.db directly;
+// it proxies, matching the FLOW_NOTES_URL / search_memory precedent.
+//
+// IMPLEMENTATION CHOICE (Sections B/C/D): rather than PROJECT memories into
+// FalkorDB (which would make the graph a second source of truth and require
+// writes on every consolidation), the gateway MERGES memory data at read time by
+// calling the orchestrator. flow.db stays primary; the graph stays a
+// code-structure projection. These calls are best-effort: a null base URL or an
+// unreachable orchestrator degrades gracefully (get_entity returns the node
+// WITHOUT attachments; card lookups return not_found; find_entity merges nothing).
+
+function base(): string | null {
+  // FLOW_MEMORY_URL points at .../v1/memory/search; strip the trailing verb to
+  // get the memory root. Fall back to ORCHESTRATOR_URL + /v1/memory.
+  const memUrl = process.env.FLOW_MEMORY_URL;
+  if (memUrl) return memUrl.replace(/\/search$/, "");
+  const orch = process.env.ORCHESTRATOR_URL;
+  if (orch) return `${orch.replace(/\/$/, "")}/v1/memory`;
+  return null;
+}
+
+function token(): string {
+  return process.env.FLOW_ACTIVITY_TOKEN || process.env.FLOW_ADMIN_TOKEN || "";
+}
+
+function authHeaders(): Record<string, string> {
+  const t = token();
+  return { "content-type": "application/json", ...(t ? { authorization: `Bearer ${t}` } : {}) };
+}
+
+export interface HeadlineResult {
+  node_id: string;
+  rendered: string;
+  hasAttachments: boolean;
+  counts: { memories: number; tickets: number; threads: number };
+}
+
+// Node headline index (Section B). Returns null when memory is unreachable — the
+// caller (get_entity) then serves the node WITHOUT attachments, gracefully.
+export async function fetchHeadline(nodeId: string, timeoutMs = 3000): Promise<HeadlineResult | null> {
+  const root = base();
+  if (!root) return null;
+  try {
+    const res = await fetch(`${root}/headline/${encodeURIComponent(nodeId)}`, {
+      headers: authHeaders(),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as HeadlineResult;
+  } catch {
+    return null;
+  }
+}
+
+export interface CardResult {
+  status: "found" | "not_found";
+  type: string;
+  id: string;
+  card?: Record<string, unknown>;
+}
+
+// Drill-down card (Section C) for a mem:/obs:/lin:/slackthread: id. Returns a
+// not_found sentinel on any failure so batch get_entity can slot an explicit
+// not_found entry rather than dropping the id.
+export async function fetchCard(type: string, id: string, timeoutMs = 3000): Promise<CardResult> {
+  const root = base();
+  if (!root) return { status: "not_found", type, id };
+  try {
+    const res = await fetch(`${root}/card/${encodeURIComponent(type)}/${encodeURIComponent(id)}`, {
+      headers: authHeaders(),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (res.status === 404) return { status: "not_found", type, id };
+    if (!res.ok) return { status: "not_found", type, id };
+    return (await res.json()) as CardResult;
+  } catch {
+    return { status: "not_found", type, id };
+  }
+}
+
+export interface MemoryHitLine {
+  type: "memory";
+  kind: string;
+  headline: string;
+  tier: string;
+  id: string;
+  line: string;
+}
+
+export interface MemoryHitGroup {
+  query: string;
+  hits: MemoryHitLine[];
+}
+
+// find_entity memory merge (Section D). Single or batch. Returns [] on failure
+// (find_entity then just shows graph nodes — no memory rows blended in).
+export async function fetchMemoryHits(
+  queries: string[],
+  repo: string | null,
+  timeoutMs = 4000,
+): Promise<MemoryHitGroup[]> {
+  const root = base();
+  if (!root || queries.length === 0) return [];
+  try {
+    const single = queries.length === 1;
+    const res = await fetch(`${root}/hits`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify(single ? { query: queries[0], repo } : { queries, repo }),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!res.ok) return [];
+    const body = (await res.json()) as { hits?: MemoryHitLine[]; groups?: MemoryHitGroup[] };
+    if (single) return [{ query: queries[0], hits: body.hits ?? [] }];
+    return body.groups ?? [];
+  } catch {
+    return [];
+  }
+}
+
+// A card id namespace is one of these prefixes. get_entity dispatches an id to
+// the orchestrator when it matches; otherwise it's a graph node id.
+const CARD_TYPES = new Set(["mem", "obs", "lin", "slackthread"]);
+export function parseCardId(raw: string): { type: string; id: string } | null {
+  const i = raw.indexOf(":");
+  if (i <= 0) return null;
+  const type = raw.slice(0, i);
+  if (!CARD_TYPES.has(type)) return null;
+  const id = raw.slice(i + 1);
+  if (!id) return null;
+  return { type, id };
+}

--- a/graph-gateway/src/verbs.ts
+++ b/graph-gateway/src/verbs.ts
@@ -3,6 +3,13 @@ import { DEFAULT_GRAPH, run } from "./graph.js";
 import { record } from "./journal.js";
 import { EDGE_TYPES, NODE_TYPES, isEdgeType, isNodeType } from "./schema.js";
 import { embedQuery, embedText, embeddingsEnabled, entityText } from "./embed.js";
+import {
+  fetchHeadline,
+  fetchCard,
+  fetchMemoryHits,
+  parseCardId,
+  type MemoryHitGroup,
+} from "./memory-client.js";
 
 // Cosine-distance ceiling for semantic matches. Tuned on the flow graph (156
 // nodes) by sweeping a 24-query labelled set: recall climbs steeply up to ~0.65
@@ -203,13 +210,32 @@ async function findEntityOne(graph: string, q: string, type: string | undefined,
   };
 }
 
+// The repo scope for memory hits — session env, since find_entity has no repo
+// param. The orchestrator's family gate is lenient (same product family) so a
+// missing repo just widens eligibility.
+function memoryRepo(): string | null {
+  return process.env.FLOW_REPO || null;
+}
+
 async function findEntity(input: z.infer<z.ZodObject<typeof findEntityInput>>) {
   if (input.q === undefined && input.qs === undefined) {
     return { status: "error", error: "Pass `q` (single) or `qs` (batch, up to 10)." };
   }
-  // Single form stays byte-for-byte compatible: {status, matches, warning?}.
+  // UNIFIED find_entity (Section D): graph nodes AND memory hits in one result.
+  // Memory hits are fetched from the orchestrator (family gate + 0.55 silence
+  // gate + meaningful-token FTS reused, not forked) with the type QUOTA applied
+  // there; the gateway just splices them in as `memory_hits`. Graph node search
+  // is unchanged — memory is additive, never replaces code nodes.
+
+  // Single form stays byte-for-byte compatible for graph fields ({status,
+  // matches, warning?}); `memory_hits` is an additive field.
   if (input.q !== undefined) {
-    return findEntityOne(input.graph, input.q, input.type, input.limit);
+    const [graphRes, hitGroups] = await Promise.all([
+      findEntityOne(input.graph, input.q, input.type, input.limit),
+      fetchMemoryHits([input.q], memoryRepo()),
+    ]);
+    const hits = hitGroups[0]?.hits ?? [];
+    return hits.length ? { ...graphRes, memory_hits: hits.map((h) => h.line) } : graphRes;
   }
 
   // Batch: one group per query, in REQUEST ORDER. Cross-group duplicate node
@@ -217,13 +243,17 @@ async function findEntity(input: z.infer<z.ZodObject<typeof findEntityInput>>) {
   // entry — the first group to surface an id owns the full match; later groups
   // just point back. A per-query failure is isolated to that group.
   const qs = input.qs as string[];
-  const settled = await mapWithConcurrency(qs, BATCH_CONCURRENCY, (q) =>
-    findEntityOne(input.graph, q, input.type, input.limit),
-  );
+  const [settled, hitGroups] = await Promise.all([
+    mapWithConcurrency(qs, BATCH_CONCURRENCY, (q) => findEntityOne(input.graph, q, input.type, input.limit)),
+    fetchMemoryHits(qs, memoryRepo()),
+  ]);
+  const hitsByQuery = memoryHitsByQuery(qs, hitGroups);
 
   const firstSeenIn = new Map<string, number>(); // node id → group index that owns the full entry
   const groups = settled.map((r, i) => {
-    if (!r.ok) return { query: qs[i], status: "error" as const, error: r.error };
+    const memHits = hitsByQuery[i] ?? [];
+    const memField = memHits.length ? { memory_hits: memHits.map((h) => h.line) } : {};
+    if (!r.ok) return { query: qs[i], status: "error" as const, error: r.error, ...memField };
     const res = r.value;
     const matches = res.matches.map((m) => {
       const id = String(m.id);
@@ -235,10 +265,18 @@ async function findEntity(input: z.infer<z.ZodObject<typeof findEntityInput>>) {
       // Terse cross-group dedup note — full entry lives in the owning group.
       return { id: m.id, note: `(also matched q${owner + 1})` };
     });
-    return { query: qs[i], status: res.status, matches, ...("warning" in res ? { warning: res.warning } : {}) };
+    return { query: qs[i], status: res.status, matches, ...("warning" in res ? { warning: res.warning } : {}), ...memField };
   });
 
   return { status: "batch", count: groups.length, groups };
+}
+
+// Align memory-hit groups to the query list by index; the orchestrator returns
+// them in request order, but be defensive (match by query text as a fallback).
+function memoryHitsByQuery(qs: string[], groups: MemoryHitGroup[]): Array<MemoryHitGroup["hits"]> {
+  if (groups.length === qs.length) return groups.map((g) => g.hits);
+  const byQuery = new Map(groups.map((g) => [g.query, g.hits]));
+  return qs.map((q) => byQuery.get(q) ?? []);
 }
 
 // ---------------------------------------------------------------------------
@@ -411,7 +449,21 @@ function stripEmbedding<T extends { props?: unknown }>(row: T): T {
 }
 
 // Single-node fetch — the one code path both the single and batch forms reuse.
+// Also the dispatch point for the memory id NAMESPACES (mem:/obs:/lin:/
+// slackthread:): those aren't graph nodes, so we resolve them to drill-down
+// cards via the orchestrator (Section C). Everything else is a graph node, and
+// after its relations we append the HEADLINE INDEX (Section B) — memories/
+// tickets/threads anchored to it, headlines only. If memory is unreachable the
+// node returns WITHOUT attachments (graceful; a note says so).
 async function getEntityOne(graph: string, id: string) {
+  // Card namespace? Resolve a drill-down card instead of a graph lookup.
+  const card = parseCardId(id);
+  if (card) {
+    const c = await fetchCard(card.type, card.id);
+    if (c.status === "not_found") return { status: "not_found" as const, id };
+    return { status: "found" as const, id, card: c.card, card_type: c.type };
+  }
+
   const node = await run(graph, `MATCH (n {id: $id}) RETURN labels(n)[0] AS type, properties(n) AS props`, { id });
   if (node.length === 0) return { status: "not_found" as const, id };
   stripEmbedding(node[0] as { props?: unknown });
@@ -425,7 +477,15 @@ async function getEntityOne(graph: string, id: string) {
     `MATCH ({id: $id})<-[r]-(m) RETURN type(r) AS rel, labels(m)[0] AS type, m.id AS id, m.name AS name, properties(r) AS props`,
     { id },
   );
-  return { status: "found" as const, id, node: node[0], outgoing: out, incoming: inc };
+
+  // Headline index (Section B). Best-effort + fast (in-process cache on the
+  // orchestrator, <20ms target). Only attach when there's something to show;
+  // an unreachable source yields a terse "attachments unavailable" note.
+  const base = { status: "found" as const, id, node: node[0], outgoing: out, incoming: inc };
+  const headline = await fetchHeadline(id);
+  if (headline === null) return { ...base, attachments: "unavailable" };
+  if (!headline.hasAttachments) return base;
+  return { ...base, attachments: headline.rendered, attachment_counts: headline.counts };
 }
 
 async function getEntity(input: z.infer<z.ZodObject<typeof getEntityInput>>) {
@@ -1148,10 +1208,16 @@ async function orient(input: z.infer<z.ZodObject<typeof orientInput>>) {
     out.push(
       `MEMORY: ${memStats.memories} distilled ${memStats.memories === 1 ? "memory" : "memories"}` +
         (srcBits ? ` from ${srcBits} observations` : "") +
-        `. Search it like you grep — symptoms, identifiers, file paths work best (search_memory).`,
+        `. Search it like you grep — symptoms, identifiers, file paths work best (search_memory). ` +
+        `get_entity on a node also shows a headline index of the memories/tickets/threads anchored to it. ` +
+        `Drill into any [mem:…]/[obs:…]/[lin:…] with get_entity (batch ids[] works). ` +
+        `Scope a search to a node with search_memory node:<node_id> (composes with type:memory|ticket|thread).`,
     );
   } else {
-    out.push("MEMORY: none yet — it fills as sessions end. Query with search_memory (symptoms, identifiers, file paths work best).");
+    out.push(
+      "MEMORY: none yet — it fills as sessions end. Query with search_memory (symptoms, identifiers, file paths work best); " +
+        "get_entity shows a per-node headline index once memories anchor to nodes.",
+    );
   }
   out.push("");
   out.push(
@@ -1182,7 +1248,7 @@ export const verbs = {
   },
   find_entity: {
     description:
-      "Look up graph entities by id, name, alias — or by INTENT: describe what the code does ('list git branches of a repo') and semantic search returns the matching nodes with their file:line anchors. Use this to find where behavior lives before grepping. Always check here before creating. BATCH: pass qs:[…] (up to 10) to look up several phrases at once — results come back grouped per query, in order; prefer one batched call over sequential single searches.",
+      "Look up graph entities by id, name, alias — or by INTENT: describe what the code does ('list git branches of a repo') and semantic search returns the matching nodes with their file:line anchors. Use this to find where behavior lives before grepping. Always check here before creating. Relevant distilled memories are blended in as `memory_hits` (typed terse lines, capped at 3 unless the query says type:memory). BATCH: pass qs:[…] (up to 10) to look up several phrases at once — results come back grouped per query, in order; prefer one batched call over sequential single searches.",
     shape: findEntityInput,
     handler: findEntity,
   },
@@ -1198,7 +1264,7 @@ export const verbs = {
   },
   get_entity: {
     description:
-      "Fetch a node with all its incoming and outgoing relationships. BATCH: pass ids:[…] (up to 15) to fetch several nodes in one call — sections come back in request order, one per id, with an explicit not-found entry for any missing id; prefer one batched call over sequential single lookups.",
+      "Fetch a node with all its incoming and outgoing relationships, plus a headline INDEX of the memories/tickets/threads anchored to it (headlines only, ~300 tokens; a '+N more' line is a working search_memory node:<id> query). Also resolves memory drill-down ids — mem:<id> (memory card: strength breakdown, anchors, evidence), obs:<id>, lin:<identifier>, slackthread:<ts>. BATCH: pass ids:[…] (up to 15) to fetch several nodes/cards in one call — sections come back in request order, one per id, with an explicit not-found entry for any missing id; prefer one batched call over sequential single lookups.",
     shape: getEntityInput,
     handler: getEntity,
   },
@@ -1249,7 +1315,7 @@ export const verbs = {
   },
   search_memory: {
     description:
-      "Search Flow's cross-session memory (distilled decisions, constraints, gotchas, how-tos, preferences) plus the slack/linear corpus. Retrieve-only. Search it like you grep — verbatim error snippets, identifiers, command names, and file paths work best. Call it when a failure surprises you or before making a decision that a past session may have already settled. BATCH: pass queries:[…] (up to 10) to search several things at once — results come back grouped per query, in order; prefer one batched call over sequential single searches.",
+      "Search Flow's cross-session memory (distilled decisions, constraints, gotchas, how-tos, preferences) plus the slack/linear corpus. Retrieve-only. Search it like you grep — verbatim error snippets, identifiers, command names, and file paths work best. Call it when a failure surprises you or before making a decision that a past session may have already settled. Scope to a graph node with a `node:<node_id>` token (filters to items anchored to that node — this is what get_entity's '+N more' line runs); narrow by kind with `type:memory|ticket|thread`; both compose with keywords. BATCH: pass queries:[…] (up to 10) to search several things at once — results come back grouped per query, in order; prefer one batched call over sequential single searches.",
     shape: searchMemoryInput,
     handler: searchMemory,
   },

--- a/graph-gateway/src/verbs.ts
+++ b/graph-gateway/src/verbs.ts
@@ -54,6 +54,42 @@ interface ScoredRow extends EntityRow {
 
 const clampLimit = (limit: number) => Math.max(1, Math.min(50, Math.floor(limit)));
 
+// Run `fn` over `items` with a small concurrency bound, preserving input order
+// in the result. Used by the batched read verbs so a model can fetch several
+// entities/queries in one call without us firing an unbounded fan-out at the
+// graph. Errors are captured per item (Promise.allSettled semantics), never
+// propagated — a batch is a set of independent reads and one bad item must not
+// sink the rest.
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<Array<{ ok: true; value: R } | { ok: false; error: string }>> {
+  const out: Array<{ ok: true; value: R } | { ok: false; error: string }> = new Array(items.length);
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    for (;;) {
+      const i = cursor++;
+      if (i >= items.length) return;
+      try {
+        out[i] = { ok: true, value: await fn(items[i], i) };
+      } catch (err) {
+        out[i] = { ok: false, error: err instanceof Error ? err.message : String(err) };
+      }
+    }
+  });
+  await Promise.all(workers);
+  return out;
+}
+
+// Read verbs accept a single value OR a batch array. These caps bound the
+// server-side fan-out; over the cap is a hard error (clear failure beats a
+// silent truncation the model can't see). Concurrency is deliberately small —
+// a batch is a convenience for the model, not a load-test of the graph.
+const GET_ENTITY_MAX_BATCH = 15;
+const FIND_ENTITY_MAX_BATCH = 10;
+const BATCH_CONCURRENCY = 5;
+
 // Proposed-but-unblessed procedures are invisible to normal retrieval — they
 // only enter circulation once a human approves them. Label-scoped to Procedure:
 // other node types may legitimately carry a status prop (cleanProps allows it)
@@ -123,44 +159,86 @@ async function findByVector(graph: string, q: string, type: string | undefined, 
 // ---------------------------------------------------------------------------
 
 const findEntityInput = {
-  q: z.string().min(1).describe("Name, id, or phrase to look up"),
+  // Single query OR a batch: pass `qs` to look up several phrases in one call.
+  // At least one form is required; `q` wins when both are given.
+  q: z.string().min(1).optional().describe("Name, id, or phrase to look up (single form)"),
+  qs: z.array(z.string().min(1)).min(1).max(FIND_ENTITY_MAX_BATCH).optional().describe(`Phrases to look up in one call (batch form, ≤${FIND_ENTITY_MAX_BATCH}) — prefer one batched call over sequential single searches`),
   type: z.string().optional().describe("Optional node type filter, e.g. 'Service'"),
   limit: z.number().int().min(1).max(50).default(10),
   graph: z.string().default(DEFAULT_GRAPH),
 };
 
-async function findEntity(input: z.infer<z.ZodObject<typeof findEntityInput>>) {
+// Single-query lookup — the one code path both the single and batch forms reuse.
+async function findEntityOne(graph: string, q: string, type: string | undefined, limit: number) {
   const exact = await run(
-    input.graph,
+    graph,
     `MATCH (n {id: $q}) RETURN labels(n)[0] AS type, n.id AS id, n.name AS name, n.description AS description, n.evidence AS anchor`,
-    { q: input.q },
+    { q },
   );
-  if (exact.length > 0) return { status: "exact", matches: exact };
+  if (exact.length > 0) return { status: "exact" as const, matches: exact as unknown as ScoredRow[] };
 
   // Lexical substring first — it's a high-precision signal when the caller
   // already knows a name/id fragment. Then augment with semantic matches the
   // substring scan can't reach. Lexical hits keep their rank; vector hits fill
   // the remaining slots, deduped by id.
-  const lexical: ScoredRow[] = (await findSimilar(input.graph, input.q, input.type, input.limit)).map(
+  const lexical: ScoredRow[] = (await findSimilar(graph, q, type, limit)).map(
     (r) => ({ ...r, via: "lexical" }),
   );
-  const { rows: vector, degraded } = await findByVector(input.graph, input.q, input.type, input.limit);
+  const { rows: vector, degraded } = await findByVector(graph, q, type, limit);
 
   const seen = new Set(lexical.map((r) => String(r.id)));
   const matches: ScoredRow[] = [...lexical];
   for (const v of vector) {
-    if (matches.length >= input.limit) break;
+    if (matches.length >= limit) break;
     if (seen.has(String(v.id))) continue;
     seen.add(String(v.id));
     matches.push(v);
   }
   return {
-    status: matches.length > 0 ? "similar" : "none",
+    status: (matches.length > 0 ? "similar" : "none") as "similar" | "none",
     matches,
     ...(degraded
       ? { warning: `Semantic search unavailable (${degraded}) — these results are substring-only and may miss related nodes. Do not conclude the graph lacks coverage from this response.` }
       : {}),
   };
+}
+
+async function findEntity(input: z.infer<z.ZodObject<typeof findEntityInput>>) {
+  if (input.q === undefined && input.qs === undefined) {
+    return { status: "error", error: "Pass `q` (single) or `qs` (batch, up to 10)." };
+  }
+  // Single form stays byte-for-byte compatible: {status, matches, warning?}.
+  if (input.q !== undefined) {
+    return findEntityOne(input.graph, input.q, input.type, input.limit);
+  }
+
+  // Batch: one group per query, in REQUEST ORDER. Cross-group duplicate node
+  // ids are noted tersely ("(also matched q1)") instead of repeating the full
+  // entry — the first group to surface an id owns the full match; later groups
+  // just point back. A per-query failure is isolated to that group.
+  const qs = input.qs as string[];
+  const settled = await mapWithConcurrency(qs, BATCH_CONCURRENCY, (q) =>
+    findEntityOne(input.graph, q, input.type, input.limit),
+  );
+
+  const firstSeenIn = new Map<string, number>(); // node id → group index that owns the full entry
+  const groups = settled.map((r, i) => {
+    if (!r.ok) return { query: qs[i], status: "error" as const, error: r.error };
+    const res = r.value;
+    const matches = res.matches.map((m) => {
+      const id = String(m.id);
+      const owner = firstSeenIn.get(id);
+      if (owner === undefined) {
+        firstSeenIn.set(id, i);
+        return m;
+      }
+      // Terse cross-group dedup note — full entry lives in the owning group.
+      return { id: m.id, note: `(also matched q${owner + 1})` };
+    });
+    return { query: qs[i], status: res.status, matches, ...("warning" in res ? { warning: res.warning } : {}) };
+  });
+
+  return { status: "batch", count: groups.length, groups };
 }
 
 // ---------------------------------------------------------------------------
@@ -317,7 +395,10 @@ async function upsertRelation(input: z.infer<z.ZodObject<typeof upsertRelationIn
 // ---------------------------------------------------------------------------
 
 const getEntityInput = {
-  id: z.string().min(1),
+  // Single id OR a batch: pass `ids` to fetch several nodes concurrently in one
+  // call. At least one form is required; `id` wins when both are given.
+  id: z.string().min(1).optional().describe("Node id to fetch (single form)"),
+  ids: z.array(z.string().min(1)).min(1).max(GET_ENTITY_MAX_BATCH).optional().describe(`Node ids to fetch in one call (batch form, ≤${GET_ENTITY_MAX_BATCH}) — prefer one batched call over sequential single lookups`),
   graph: z.string().default(DEFAULT_GRAPH),
 };
 
@@ -329,21 +410,50 @@ function stripEmbedding<T extends { props?: unknown }>(row: T): T {
   return row;
 }
 
-async function getEntity(input: z.infer<z.ZodObject<typeof getEntityInput>>) {
-  const node = await run(input.graph, `MATCH (n {id: $id}) RETURN labels(n)[0] AS type, properties(n) AS props`, { id: input.id });
-  if (node.length === 0) return { status: "not_found" };
+// Single-node fetch — the one code path both the single and batch forms reuse.
+async function getEntityOne(graph: string, id: string) {
+  const node = await run(graph, `MATCH (n {id: $id}) RETURN labels(n)[0] AS type, properties(n) AS props`, { id });
+  if (node.length === 0) return { status: "not_found" as const, id };
   stripEmbedding(node[0] as { props?: unknown });
   const out = await run(
-    input.graph,
+    graph,
     `MATCH ({id: $id})-[r]->(m) RETURN type(r) AS rel, labels(m)[0] AS type, m.id AS id, m.name AS name, properties(r) AS props`,
-    { id: input.id },
+    { id },
   );
   const inc = await run(
-    input.graph,
+    graph,
     `MATCH ({id: $id})<-[r]-(m) RETURN type(r) AS rel, labels(m)[0] AS type, m.id AS id, m.name AS name, properties(r) AS props`,
-    { id: input.id },
+    { id },
   );
-  return { status: "found", node: node[0], outgoing: out, incoming: inc };
+  return { status: "found" as const, id, node: node[0], outgoing: out, incoming: inc };
+}
+
+async function getEntity(input: z.infer<z.ZodObject<typeof getEntityInput>>) {
+  if (input.id === undefined && input.ids === undefined) {
+    return { status: "error", error: "Pass `id` (single) or `ids` (batch, up to 15)." };
+  }
+  // Single form stays byte-for-byte compatible: {status, node, outgoing, incoming}.
+  if (input.id !== undefined) {
+    const { id: _id, ...rest } = await getEntityOne(input.graph, input.id);
+    return rest;
+  }
+
+  // Batch: results in REQUEST ORDER, one section per id. A missing id is an
+  // explicit "not_found" entry (never silently dropped); a per-id failure is
+  // isolated to that section. Duplicate ids in the request are honored as-is —
+  // the model asked for them, and dropping would break positional pairing.
+  const ids = input.ids as string[];
+  const settled = await mapWithConcurrency(ids, BATCH_CONCURRENCY, (id) => getEntityOne(input.graph, id));
+  const results = settled.map((r, i) =>
+    r.ok ? r.value : { status: "error" as const, id: ids[i], error: r.error },
+  );
+  return {
+    status: "batch",
+    count: results.length,
+    found: results.filter((r) => r.status === "found").length,
+    not_found: results.filter((r) => r.status === "not_found").map((r) => r.id),
+    results,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -774,24 +884,38 @@ async function correctGraph(input: z.infer<z.ZodObject<typeof correctGraphInput>
 // silence gate, FTS exact-match bypass). Search it like you grep: symptoms,
 // identifiers, and file paths are the reliable path.
 
+const SEARCH_MEMORY_MAX_BATCH = 10;
+
 const searchMemoryInput = {
-  query: z.string().min(1).describe("What to look up. Works best with symptoms (verbatim error snippets), identifiers, command names, or file paths — like grep."),
+  // Single query OR a batch: pass `queries` to look up several things in one
+  // call. At least one form is required; `query` wins when both are given.
+  query: z.string().min(1).optional().describe("What to look up (single form). Works best with symptoms (verbatim error snippets), identifiers, command names, or file paths — like grep."),
+  queries: z.array(z.string().min(1)).min(1).max(SEARCH_MEMORY_MAX_BATCH).optional().describe(`Several things to look up in one call (batch form, ≤${SEARCH_MEMORY_MAX_BATCH}) — prefer one batched call over sequential single searches. Results come back grouped per query.`),
   repo: z.string().optional().describe("Repository name to scope to (defaults from the session's env). Cross-repo memories in the same product family are still eligible; unrelated repos are hard-filtered out."),
-  limit: z.number().int().min(1).max(50).optional().describe("Max memories to return (default 8)."),
+  limit: z.number().int().min(1).max(50).optional().describe("Max memories to return per query (default 8)."),
 };
 
 async function searchMemory(input: z.infer<z.ZodObject<typeof searchMemoryInput>>) {
+  if (input.query === undefined && input.queries === undefined) {
+    return { status: "error", error: "Pass `query` (single) or `queries` (batch, up to 10)." };
+  }
   const repo = input.repo || process.env.FLOW_REPO || "";
   const url =
     process.env.FLOW_MEMORY_URL ||
     (process.env.ORCHESTRATOR_URL ? `${process.env.ORCHESTRATOR_URL.replace(/\/$/, "")}/v1/memory/search` : "");
   const token = process.env.FLOW_ACTIVITY_TOKEN || process.env.FLOW_ADMIN_TOKEN || "";
   if (!url) return { status: "error", error: "No orchestrator configured for memory search (FLOW_MEMORY_URL unset)." };
+  // Proxy whichever form the caller sent — the orchestrator owns the batch
+  // fan-out, grouping, and ranking. `query` wins if both are present.
+  const payload =
+    input.query !== undefined
+      ? { query: input.query, repo: repo || null, limit: input.limit }
+      : { queries: input.queries, repo: repo || null, limit: input.limit };
   try {
     const res = await fetch(url, {
       method: "POST",
       headers: { "content-type": "application/json", ...(token ? { authorization: `Bearer ${token}` } : {}) },
-      body: JSON.stringify({ query: input.query, repo: repo || null, limit: input.limit }),
+      body: JSON.stringify(payload),
       signal: AbortSignal.timeout(6000),
     });
     const body = (await res.json().catch(() => ({}))) as { lines?: string; error?: string };
@@ -1058,7 +1182,7 @@ export const verbs = {
   },
   find_entity: {
     description:
-      "Look up graph entities by id, name, alias — or by INTENT: describe what the code does ('list git branches of a repo') and semantic search returns the matching nodes with their file:line anchors. Use this to find where behavior lives before grepping. Always check here before creating.",
+      "Look up graph entities by id, name, alias — or by INTENT: describe what the code does ('list git branches of a repo') and semantic search returns the matching nodes with their file:line anchors. Use this to find where behavior lives before grepping. Always check here before creating. BATCH: pass qs:[…] (up to 10) to look up several phrases at once — results come back grouped per query, in order; prefer one batched call over sequential single searches.",
     shape: findEntityInput,
     handler: findEntity,
   },
@@ -1073,7 +1197,8 @@ export const verbs = {
     handler: upsertRelation,
   },
   get_entity: {
-    description: "Fetch one node with all its incoming and outgoing relationships.",
+    description:
+      "Fetch a node with all its incoming and outgoing relationships. BATCH: pass ids:[…] (up to 15) to fetch several nodes in one call — sections come back in request order, one per id, with an explicit not-found entry for any missing id; prefer one batched call over sequential single lookups.",
     shape: getEntityInput,
     handler: getEntity,
   },
@@ -1124,7 +1249,7 @@ export const verbs = {
   },
   search_memory: {
     description:
-      "Search Flow's cross-session memory (distilled decisions, constraints, gotchas, how-tos, preferences) plus the slack/linear corpus. Retrieve-only. Search it like you grep — verbatim error snippets, identifiers, command names, and file paths work best. Call it when a failure surprises you or before making a decision that a past session may have already settled.",
+      "Search Flow's cross-session memory (distilled decisions, constraints, gotchas, how-tos, preferences) plus the slack/linear corpus. Retrieve-only. Search it like you grep — verbatim error snippets, identifiers, command names, and file paths work best. Call it when a failure surprises you or before making a decision that a past session may have already settled. BATCH: pass queries:[…] (up to 10) to search several things at once — results come back grouped per query, in order; prefer one batched call over sequential single searches.",
     shape: searchMemoryInput,
     handler: searchMemory,
   },

--- a/graph-gateway/src/verbs.ts
+++ b/graph-gateway/src/verbs.ts
@@ -767,6 +767,43 @@ async function correctGraph(input: z.infer<z.ZodObject<typeof correctGraphInput>
 // Flow may run remotely (EC2) and never assumes the agent's filesystem;
 // for Flow-run sessions the runtime injects defaults via env.
 
+// ---------------------------------------------------------------------------
+// search_memory — retrieve-only access to Flow's memory (distilled session
+// memories + slack/linear corpus). Thin proxy to the orchestrator, which owns
+// the store, the embeddings, and the eval-calibrated ranking (family hard gate,
+// silence gate, FTS exact-match bypass). Search it like you grep: symptoms,
+// identifiers, and file paths are the reliable path.
+
+const searchMemoryInput = {
+  query: z.string().min(1).describe("What to look up. Works best with symptoms (verbatim error snippets), identifiers, command names, or file paths — like grep."),
+  repo: z.string().optional().describe("Repository name to scope to (defaults from the session's env). Cross-repo memories in the same product family are still eligible; unrelated repos are hard-filtered out."),
+  limit: z.number().int().min(1).max(50).optional().describe("Max memories to return (default 8)."),
+};
+
+async function searchMemory(input: z.infer<z.ZodObject<typeof searchMemoryInput>>) {
+  const repo = input.repo || process.env.FLOW_REPO || "";
+  const url =
+    process.env.FLOW_MEMORY_URL ||
+    (process.env.ORCHESTRATOR_URL ? `${process.env.ORCHESTRATOR_URL.replace(/\/$/, "")}/v1/memory/search` : "");
+  const token = process.env.FLOW_ACTIVITY_TOKEN || process.env.FLOW_ADMIN_TOKEN || "";
+  if (!url) return { status: "error", error: "No orchestrator configured for memory search (FLOW_MEMORY_URL unset)." };
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json", ...(token ? { authorization: `Bearer ${token}` } : {}) },
+      body: JSON.stringify({ query: input.query, repo: repo || null, limit: input.limit }),
+      signal: AbortSignal.timeout(6000),
+    });
+    const body = (await res.json().catch(() => ({}))) as { lines?: string; error?: string };
+    if (!res.ok) return { status: "error", error: `Memory search failed (${res.status}): ${body.error ?? ""}` };
+    return { status: "ok", results: body.lines ?? "(no memories match)" };
+  } catch (err) {
+    return { status: "error", error: `Memory search failed: ${err instanceof Error ? err.message : String(err)}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+
 const noteInput = {
   text: z.string().min(1).describe("The note — a discovery, dead end, constraint, decision, or worry, written for whoever works on this branch next"),
   kind: z.enum(["wip", "note", "caution", "decision"]).default("note").describe("'wip' = rolling state of current work (replaces your previous wip note); others accumulate and get promoted to the graph on merge"),
@@ -860,6 +897,27 @@ async function fetchBranchNotes(repo: string, branch: string): Promise<OrientNot
   }
 }
 
+interface MemoryStats {
+  memories: number;
+  observations: number;
+  bySource: Record<string, number>;
+}
+
+async function fetchMemoryStats(): Promise<MemoryStats | null> {
+  const url =
+    process.env.FLOW_MEMORY_URL?.replace(/\/search$/, "/stats") ||
+    (process.env.ORCHESTRATOR_URL ? `${process.env.ORCHESTRATOR_URL.replace(/\/$/, "")}/v1/memory/stats` : "");
+  if (!url) return null;
+  const token = process.env.FLOW_ACTIVITY_TOKEN || process.env.FLOW_ADMIN_TOKEN || "";
+  try {
+    const res = await fetch(url, { headers: token ? { authorization: `Bearer ${token}` } : {}, signal: AbortSignal.timeout(4000) });
+    if (!res.ok) return null;
+    return (await res.json()) as MemoryStats;
+  } catch {
+    return null;
+  }
+}
+
 interface OrientProc {
   id: string;
   name: string;
@@ -873,7 +931,7 @@ async function orient(input: z.infer<z.ZodObject<typeof orientInput>>) {
   const repo = input.repo || process.env.FLOW_REPO || "";
   const branch = input.branch || process.env.FLOW_BRANCH || "";
 
-  const [repoRows, counts, procRows, notes] = await Promise.all([
+  const [repoRows, counts, procRows, notes, memStats] = await Promise.all([
     run(input.graph, `MATCH (r:Repository) RETURN r.id AS id, r.name AS name, r.description AS description`),
     run(input.graph, `MATCH (n) RETURN labels(n)[0] AS type, count(*) AS count ORDER BY count DESC`),
     run(
@@ -884,6 +942,7 @@ async function orient(input: z.infer<z.ZodObject<typeof orientInput>>) {
        ORDER BY p.created_at DESC`,
     ) as Promise<unknown> as Promise<OrientProc[]>,
     fetchBranchNotes(repo, branch),
+    fetchMemoryStats(),
   ]);
 
   // Repo identity: match by name when the caller told us which repo; otherwise
@@ -952,6 +1011,23 @@ async function orient(input: z.infer<z.ZodObject<typeof orientInput>>) {
     out.push("(no notes yet)");
   } else {
     out.push(...section(notes, (n) => `- [${n.kind}] ${oneLine(n.text, 260)}`, "they continue in this branch's note store"));
+  }
+  out.push("");
+  // MEMORY — cross-session distilled knowledge + corpus, reached via
+  // search_memory (retrieve-only). Counts orient the agent to whether it's
+  // worth a look; the one-liner tells it how to query.
+  if (memStats && (memStats.memories > 0 || memStats.observations > 0)) {
+    const srcBits = Object.entries(memStats.bySource)
+      .sort((a, b) => b[1] - a[1])
+      .map(([s, n]) => `${n} ${s}`)
+      .join(", ");
+    out.push(
+      `MEMORY: ${memStats.memories} distilled ${memStats.memories === 1 ? "memory" : "memories"}` +
+        (srcBits ? ` from ${srcBits} observations` : "") +
+        `. Search it like you grep — symptoms, identifiers, file paths work best (search_memory).`,
+    );
+  } else {
+    out.push("MEMORY: none yet — it fills as sessions end. Query with search_memory (symptoms, identifiers, file paths work best).");
   }
   out.push("");
   out.push(
@@ -1045,6 +1121,12 @@ export const verbs = {
       "Save a branch-scoped working note — discoveries, dead ends ('tried X, deadlocked'), constraints, decisions, or current WIP state (kind 'wip' replaces your previous wip note). Free to use, no approval needed; it surfaces automatically for future sessions on this branch. Note things the next session would otherwise re-learn the hard way.",
     shape: noteInput,
     handler: noteVerb,
+  },
+  search_memory: {
+    description:
+      "Search Flow's cross-session memory (distilled decisions, constraints, gotchas, how-tos, preferences) plus the slack/linear corpus. Retrieve-only. Search it like you grep — verbatim error snippets, identifiers, command names, and file paths work best. Call it when a failure surprises you or before making a decision that a past session may have already settled.",
+    shape: searchMemoryInput,
+    handler: searchMemory,
   },
 } as const;
 

--- a/graph-gateway/test/verbs-batch.test.ts
+++ b/graph-gateway/test/verbs-batch.test.ts
@@ -1,0 +1,186 @@
+// verbs-batch.test.ts — batched read verbs (get_entity ids[], find_entity qs[])
+// exercised WITHOUT a live FalkorDB. `./graph.js` (the only DB touch), the
+// journal, and the embed model are module-mocked, so the test isolates the
+// batch orchestration itself: order preservation, explicit not-found for
+// missing ids, per-item error isolation, cross-group dedup notes, cap
+// enforcement, and single-value backward compat.
+//
+// Run with: node --experimental-test-module-mocks --import tsx/esm --test test/verbs-batch.test.ts
+// (wired into `npm test` in package.json).
+
+import { test, describe, before, mock } from "node:test";
+import assert from "node:assert/strict";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+let callVerb: (name: string, input: unknown) => Promise<any>;
+
+// Canned graph state the mocked `run()` answers from. The mock parses just
+// enough of each Cypher string to serve the batch verbs' fixed query shapes.
+const NODES = new Map<string, { type: string; name: string }>([
+  ["svc:a", { type: "Service", name: "Alpha service" }],
+  ["svc:b", { type: "Service", name: "Beta service" }],
+  ["svc:c", { type: "Service", name: "Gamma service" }],
+]);
+// ids that should throw when fetched, to prove per-item error isolation.
+const THROW_IDS = new Set<string>(["svc:boom"]);
+
+function mockRun(_graph: string, cypher: string, params: Record<string, any> = {}): any[] {
+  const id = params.id ?? params.q;
+  if (typeof id === "string" && THROW_IDS.has(id)) throw new Error(`boom for ${id}`);
+
+  // get_entity: node lookup by id
+  if (/MATCH \(n \{id: \$id\}\) RETURN labels\(n\)\[0\] AS type, properties\(n\)/.test(cypher)) {
+    const n = NODES.get(String(id));
+    return n ? [{ type: n.type, props: { id, name: n.name } }] : [];
+  }
+  // get_entity: outgoing / incoming rels (none in this fixture)
+  if (/-\[r\]->\(m\)/.test(cypher) || /<-\[r\]-\(m\)/.test(cypher)) return [];
+
+  // find_entity: exact id match
+  if (/MATCH \(n \{id: \$q\}\)/.test(cypher)) {
+    const n = NODES.get(String(id));
+    return n ? [{ type: n.type, id, name: n.name, description: null, anchor: null }] : [];
+  }
+  // find_entity: lexical findSimilar — match any node whose name/id contains a token
+  if (/n\.embedding IS NOT NULL/.test(cypher)) return []; // vector pass: no embeddings
+  if (/CONTAINS/.test(cypher)) {
+    const tokens = Object.entries(params)
+      .filter(([k]) => /^t\d+$/.test(k) || k === "ql")
+      .map(([, v]) => String(v));
+    const out: any[] = [];
+    for (const [nid, n] of NODES) {
+      const hay = `${nid} ${n.name}`.toLowerCase();
+      if (tokens.length && tokens.every((t) => hay.includes(t))) {
+        out.push({ type: n.type, id: nid, name: n.name, description: null, anchor: null });
+      }
+    }
+    return out;
+  }
+  return [];
+}
+
+before(async () => {
+  mock.module("../src/graph.js", {
+    namedExports: {
+      DEFAULT_GRAPH: "memory",
+      run: async (g: string, c: string, p: Record<string, any> = {}) => mockRun(g, c, p),
+      raw: async () => ({}),
+      close: async () => {},
+    },
+  });
+  mock.module("../src/journal.js", {
+    namedExports: { record: async () => {}, tail: async () => [] },
+  });
+  mock.module("../src/embed.js", {
+    namedExports: {
+      EMBED_DIM: 768,
+      embeddingsEnabled: () => false, // vector pass self-noops → lexical only
+      entityText: () => "",
+      embedText: async () => null,
+      embedQuery: async () => ({ vec: null, error: "disabled in test" }),
+      embedBatch: async () => [],
+    },
+  });
+  ({ callVerb } = await import("../src/verbs.js"));
+});
+
+// ---------------------------------------------------------------------------
+describe("get_entity — batch", () => {
+  test("single id form stays backward compatible (flat {status,node,...})", async () => {
+    const res = await callVerb("get_entity", { id: "svc:a" });
+    assert.equal(res.status, "found");
+    assert.ok(res.node, "single form returns node directly");
+    assert.ok(!("results" in res), "single form has no batch envelope");
+  });
+
+  test("ids[] returns sections in REQUEST ORDER, one per id", async () => {
+    const res = await callVerb("get_entity", { ids: ["svc:c", "svc:a", "svc:b"] });
+    assert.equal(res.status, "batch");
+    assert.deepEqual(res.results.map((r: any) => r.id), ["svc:c", "svc:a", "svc:b"]);
+    assert.ok(res.results.every((r: any) => r.status === "found"));
+  });
+
+  test("a missing id is an explicit not_found entry, never dropped", async () => {
+    const res = await callVerb("get_entity", { ids: ["svc:a", "svc:missing", "svc:b"] });
+    assert.equal(res.results.length, 3, "missing id keeps its slot");
+    assert.equal(res.results[1].status, "not_found");
+    assert.equal(res.results[1].id, "svc:missing");
+    assert.deepEqual(res.not_found, ["svc:missing"]);
+    assert.equal(res.found, 2);
+  });
+
+  test("a per-item error is isolated — the rest of the batch still returns", async () => {
+    const res = await callVerb("get_entity", { ids: ["svc:a", "svc:boom", "svc:b"] });
+    assert.equal(res.results.length, 3);
+    assert.equal(res.results[0].status, "found");
+    assert.equal(res.results[1].status, "error");
+    assert.match(res.results[1].error, /boom/);
+    assert.equal(res.results[2].status, "found", "error in one item must not sink the others");
+  });
+
+  test("over the cap (16 ids) is a clear error, not silent truncation", async () => {
+    const ids = Array.from({ length: 16 }, (_, i) => `svc:${i}`);
+    const res = await callVerb("get_entity", { ids });
+    assert.equal(res.status, "error");
+    assert.match(res.error, /Invalid input/);
+  });
+
+  test("neither id nor ids → explicit error", async () => {
+    const res = await callVerb("get_entity", {});
+    assert.equal(res.status, "error");
+    assert.match(res.error, /id.*ids|ids.*id/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("find_entity — batch", () => {
+  test("single q form stays backward compatible (flat {status,matches})", async () => {
+    const res = await callVerb("find_entity", { q: "svc:a" });
+    assert.equal(res.status, "exact");
+    assert.ok(Array.isArray(res.matches));
+    assert.ok(!("groups" in res), "single form has no batch envelope");
+  });
+
+  test("qs[] groups results per query, in REQUEST ORDER", async () => {
+    const res = await callVerb("find_entity", { qs: ["svc:b", "svc:a"] });
+    assert.equal(res.status, "batch");
+    assert.deepEqual(res.groups.map((g: any) => g.query), ["svc:b", "svc:a"]);
+    assert.equal(res.groups[0].matches[0].id, "svc:b");
+    assert.equal(res.groups[1].matches[0].id, "svc:a");
+  });
+
+  test("cross-group duplicate ids get a terse note, not a repeated full entry", async () => {
+    // Both queries match every service by the shared token "service". The first
+    // group owns the full entries; the second group's overlaps are noted.
+    const res = await callVerb("find_entity", { qs: ["service", "service"] });
+    const g1 = res.groups[0].matches;
+    const g2 = res.groups[1].matches;
+    assert.ok(g1.length >= 1 && g1[0].name, "first group carries full entries");
+    // every g2 match that also appeared in g1 is a terse note back to q1
+    for (const m of g2) {
+      assert.match(m.note, /also matched q1/);
+      assert.ok(!("name" in m), "deduped entry omits the full fields");
+    }
+  });
+
+  test("a per-query error is isolated to its group", async () => {
+    const res = await callVerb("find_entity", { qs: ["svc:a", "svc:boom"] });
+    assert.equal(res.groups.length, 2);
+    assert.equal(res.groups[0].status, "exact");
+    assert.equal(res.groups[1].status, "error");
+    assert.match(res.groups[1].error, /boom/);
+  });
+
+  test("over the cap (11 qs) is a clear error", async () => {
+    const qs = Array.from({ length: 11 }, (_, i) => `q${i}`);
+    const res = await callVerb("find_entity", { qs });
+    assert.equal(res.status, "error");
+    assert.match(res.error, /Invalid input/);
+  });
+
+  test("neither q nor qs → explicit error", async () => {
+    const res = await callVerb("find_entity", {});
+    assert.equal(res.status, "error");
+    assert.match(res.error, /q.*qs|qs.*q/);
+  });
+});

--- a/graph-gateway/test/verbs-memory.test.ts
+++ b/graph-gateway/test/verbs-memory.test.ts
@@ -1,0 +1,220 @@
+// verbs-memory.test.ts — the gateway's memory-aware read verbs, exercised
+// WITHOUT a live FalkorDB or a live orchestrator. `./graph.js`, `./journal.js`,
+// `./embed.js`, and `./memory-client.js` are module-mocked, so the test isolates
+// the gateway-side orchestration:
+//   - get_entity appends the node HEADLINE INDEX (Section B); graceful when the
+//     memory source is unreachable ("attachments unavailable").
+//   - get_entity resolves mem:/obs:/lin:/slackthread: id NAMESPACES to drill-down
+//     cards (Section C), single AND in a mixed batch incl. not_found.
+//   - find_entity blends `memory_hits` (Section D) with the type quota already
+//     applied by the (mocked) orchestrator; single + batch.
+//
+// Run with: node --experimental-test-module-mocks --import tsx/esm --test test/verbs-memory.test.ts
+// (wired into `npm test` in package.json).
+
+import { test, describe, before, mock } from "node:test";
+import assert from "node:assert/strict";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+let callVerb: (name: string, input: unknown) => Promise<any>;
+
+const NODES = new Map<string, { type: string; name: string }>([
+  ["svc:payments", { type: "Service", name: "Payments service" }],
+  ["svc:cache", { type: "Service", name: "Cache service" }],
+]);
+
+function mockRun(_graph: string, cypher: string, params: Record<string, any> = {}): any[] {
+  const id = params.id ?? params.q;
+  if (/MATCH \(n \{id: \$id\}\) RETURN labels\(n\)\[0\] AS type, properties\(n\)/.test(cypher)) {
+    const n = NODES.get(String(id));
+    return n ? [{ type: n.type, props: { id, name: n.name } }] : [];
+  }
+  if (/-\[r\]->\(m\)/.test(cypher) || /<-\[r\]-\(m\)/.test(cypher)) return [];
+  if (/MATCH \(n \{id: \$q\}\)/.test(cypher)) {
+    const n = NODES.get(String(id));
+    return n ? [{ type: n.type, id, name: n.name, description: null, anchor: null }] : [];
+  }
+  if (/n\.embedding IS NOT NULL/.test(cypher)) return [];
+  if (/CONTAINS/.test(cypher)) return []; // keep graph matches empty; memory is the focus
+  return [];
+}
+
+// ---- memory-client mock: controllable per-test via these mutable knobs ----
+const MEM = {
+  headline: null as any, // fetchHeadline return
+  cards: new Map<string, any>(), // "type:id" -> CardResult
+  hits: new Map<string, string[]>(), // query -> hit lines
+};
+
+before(async () => {
+  mock.module("../src/graph.js", {
+    namedExports: {
+      DEFAULT_GRAPH: "memory",
+      run: async (g: string, c: string, p: Record<string, any> = {}) => mockRun(g, c, p),
+      raw: async () => ({}),
+      close: async () => {},
+    },
+  });
+  mock.module("../src/journal.js", { namedExports: { record: async () => {}, tail: async () => [] } });
+  mock.module("../src/embed.js", {
+    namedExports: {
+      EMBED_DIM: 768,
+      embeddingsEnabled: () => false,
+      entityText: () => "",
+      embedText: async () => null,
+      embedQuery: async () => ({ vec: null, error: "disabled in test" }),
+      embedBatch: async () => [],
+    },
+  });
+  mock.module("../src/memory-client.js", {
+    namedExports: {
+      fetchHeadline: async (_nodeId: string) => MEM.headline,
+      fetchCard: async (type: string, id: string) =>
+        MEM.cards.get(`${type}:${id}`) ?? { status: "not_found", type, id },
+      fetchMemoryHits: async (queries: string[]) =>
+        queries.map((q) => ({
+          query: q,
+          hits: (MEM.hits.get(q) ?? []).map((line) => ({
+            type: "memory", kind: "gotcha", headline: line, tier: "strong", id: "mem:x", line,
+          })),
+        })),
+      // real impl re-used (pure string parse) — keep it identical here.
+      parseCardId: (raw: string) => {
+        const CARD = new Set(["mem", "obs", "lin", "slackthread"]);
+        const i = raw.indexOf(":");
+        if (i <= 0) return null;
+        const t = raw.slice(0, i);
+        if (!CARD.has(t)) return null;
+        const rest = raw.slice(i + 1);
+        return rest ? { type: t, id: rest } : null;
+      },
+    },
+  });
+  ({ callVerb } = await import("../src/verbs.js"));
+});
+
+function resetMem() {
+  MEM.headline = null;
+  MEM.cards.clear();
+  MEM.hits.clear();
+}
+
+// ---------------------------------------------------------------------------
+describe("get_entity — headline index (Section B)", () => {
+  test("appends the headline index when the node has attachments", async () => {
+    resetMem();
+    MEM.headline = {
+      node_id: "svc:payments",
+      rendered: "MEMORIES:\n  ● hmac verify [gotcha] [mem:abc]",
+      hasAttachments: true,
+      counts: { memories: 1, tickets: 0, threads: 0 },
+    };
+    const res = await callVerb("get_entity", { id: "svc:payments" });
+    assert.equal(res.status, "found");
+    assert.match(res.attachments, /MEMORIES:/);
+    assert.match(res.attachments, /\[mem:abc\]/);
+    assert.deepEqual(res.attachment_counts, { memories: 1, tickets: 0, threads: 0 });
+  });
+
+  test("a node with no attachments returns cleanly (no attachments field)", async () => {
+    resetMem();
+    MEM.headline = { node_id: "svc:payments", rendered: "", hasAttachments: false, counts: { memories: 0, tickets: 0, threads: 0 } };
+    const res = await callVerb("get_entity", { id: "svc:payments" });
+    assert.equal(res.status, "found");
+    assert.ok(!("attachments" in res), "no attachments field when nothing anchors");
+  });
+
+  test("GRACEFUL: unreachable memory source → node WITHOUT attachments, noted", async () => {
+    resetMem();
+    MEM.headline = null; // fetchHeadline returns null on failure
+    const res = await callVerb("get_entity", { id: "svc:payments" });
+    assert.equal(res.status, "found");
+    assert.ok(res.node, "the node itself is still returned");
+    assert.equal(res.attachments, "unavailable");
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("get_entity — drill-down card namespaces (Section C)", () => {
+  test("mem:<id> resolves to a memory card, not a graph lookup", async () => {
+    resetMem();
+    MEM.cards.set("mem:abc-1", { status: "found", type: "mem", id: "abc-1", card: { kind: "memory", claim: "auth uses jwt" } });
+    const res = await callVerb("get_entity", { id: "mem:abc-1" });
+    assert.equal(res.status, "found");
+    assert.equal(res.card_type, "mem");
+    assert.equal((res.card as any).claim, "auth uses jwt");
+    assert.ok(!("node" in res), "a card is not a graph node");
+  });
+
+  test("lin:<identifier> and slackthread:<ts> resolve to cards", async () => {
+    resetMem();
+    MEM.cards.set("lin:ACME-9", { status: "found", type: "lin", id: "ACME-9", card: { kind: "ticket", identifier: "ACME-9" } });
+    MEM.cards.set("slackthread:1700000000.001", { status: "found", type: "slackthread", id: "1700000000.001", card: { kind: "thread" } });
+    const lin = await callVerb("get_entity", { id: "lin:ACME-9" });
+    assert.equal((lin.card as any).identifier, "ACME-9");
+    const th = await callVerb("get_entity", { id: "slackthread:1700000000.001" });
+    assert.equal((th.card as any).kind, "thread");
+  });
+
+  test("a missing card id → not_found (never a graph lookup fallthrough)", async () => {
+    resetMem();
+    const res = await callVerb("get_entity", { id: "mem:does-not-exist" });
+    assert.equal(res.status, "not_found");
+  });
+
+  test("BATCH ids[] mixing node ids, card ids, and a not_found — request order kept", async () => {
+    resetMem();
+    MEM.headline = { node_id: "svc:cache", rendered: "MEMORIES:\n  ● x [gotcha] [mem:z]", hasAttachments: true, counts: { memories: 1, tickets: 0, threads: 0 } };
+    MEM.cards.set("mem:m1", { status: "found", type: "mem", id: "m1", card: { kind: "memory", claim: "c1" } });
+    const res = await callVerb("get_entity", { ids: ["svc:cache", "mem:m1", "mem:missing", "obs:o404"] });
+    assert.equal(res.status, "batch");
+    assert.equal(res.results.length, 4);
+    // order preserved
+    assert.equal(res.results[0].node && res.results[0].status, "found"); // graph node + headline
+    assert.match(res.results[0].attachments, /MEMORIES:/);
+    assert.equal(res.results[1].card_type, "mem"); // card
+    assert.equal(res.results[2].status, "not_found"); // missing card
+    assert.equal(res.results[3].status, "not_found");
+    assert.deepEqual(res.not_found.sort(), ["mem:missing", "obs:o404"]);
+    assert.equal(res.found, 2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("find_entity — unified memory hits (Section D)", () => {
+  test("single: blends memory_hits alongside graph matches", async () => {
+    resetMem();
+    MEM.hits.set("hmac verify", ["[Memory:gotcha] payments verified with hmac (strong) [mem:a]"]);
+    const res = await callVerb("find_entity", { q: "hmac verify" });
+    assert.ok(Array.isArray(res.memory_hits));
+    assert.equal(res.memory_hits.length, 1);
+    assert.match(res.memory_hits[0], /\[Memory:gotcha\].*\[mem:a\]/);
+  });
+
+  test("single: no memory hits → no memory_hits field (byte-compatible)", async () => {
+    resetMem();
+    const res = await callVerb("find_entity", { q: "svc:payments" });
+    assert.ok(!("memory_hits" in res), "no field when there are no hits");
+  });
+
+  test("batch qs[]: each group carries its own memory_hits, in request order", async () => {
+    resetMem();
+    MEM.hits.set("hmac", ["[Memory:gotcha] hmac thing (strong) [mem:1]"]);
+    MEM.hits.set("cache", ["[Memory:gotcha] cache thing (medium) [mem:2]", "[Memory:decision] cache policy (strong) [mem:3]"]);
+    const res = await callVerb("find_entity", { qs: ["hmac", "cache"] });
+    assert.equal(res.status, "batch");
+    assert.equal(res.groups[0].query, "hmac");
+    assert.equal(res.groups[0].memory_hits.length, 1);
+    assert.equal(res.groups[1].query, "cache");
+    assert.equal(res.groups[1].memory_hits.length, 2);
+  });
+
+  test("the quota is the orchestrator's job — the gateway ships whatever it returns", async () => {
+    // The orchestrator caps at 3 (untyped) / lifts on type:. Here we prove the
+    // gateway is a faithful pass-through: 3 lines in → 3 lines out.
+    resetMem();
+    MEM.hits.set("q", ["[Memory:gotcha] a (strong) [mem:1]", "[Memory:gotcha] b (strong) [mem:2]", "[Memory:gotcha] c (strong) [mem:3]"]);
+    const res = await callVerb("find_entity", { q: "q" });
+    assert.equal(res.memory_hits.length, 3);
+  });
+});

--- a/orchestrator/package.json
+++ b/orchestrator/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts",
-    "test": "node --import tsx/esm --test test/fake-opencode.ts test/orchestrator.test.ts test/adapters.test.ts test/outbox-approve.test.ts test/llmlog.test.ts test/smoke.ts test/notify.test.ts test/pollers.test.ts test/poller.test.ts test/settings.test.ts test/sources.test.ts test/agent-diff.test.ts test/worktrees.test.ts",
+    "test": "node --import tsx/esm --test test/fake-opencode.ts test/orchestrator.test.ts test/adapters.test.ts test/outbox-approve.test.ts test/llmlog.test.ts test/smoke.ts test/notify.test.ts test/pollers.test.ts test/poller.test.ts test/settings.test.ts test/sources.test.ts test/agent-diff.test.ts test/worktrees.test.ts test/memory.test.ts",
     "verify": "npm test",
     "verify:real": "tsx test/real-integrations.ts",
     "verify:session": "tsx test/real-session.ts"

--- a/orchestrator/src/actions/index.ts
+++ b/orchestrator/src/actions/index.ts
@@ -13,6 +13,7 @@ import { addLinearComment, updateLinearTicketContext, createLinearTicket } from 
 import { proposeAction } from "./dm.js";
 import { upsertContextBlock, renderContextBlock } from "./contextblock.js";
 import { enqueueJob } from "../opencode.js";
+import { observeCorpus, repoForChannel } from "../memory/corpus-observe.js";
 
 const insertAudit = db.prepare(`
   INSERT INTO audit_log (event_id, classification, confidence, action, target, status, detail)
@@ -145,6 +146,9 @@ async function handleSlackAuto(event: NormalizedEvent, cls: ClassificationResult
       thread_ts: p.thread_ts ?? null,
       permalink: p.permalink ?? null,
     });
+    // Memory enrichment: mirror the message into the observations corpus so
+    // search_memory can surface it (embedded + FTS). Non-blocking, best-effort.
+    void observeCorpus({ source: "slack", text: p.text ?? "", repo: repoForChannel(p.channel) });
   }
 
   if (c === "knowledge_claim" || c === "correction") {

--- a/orchestrator/src/adapters/linear.ts
+++ b/orchestrator/src/adapters/linear.ts
@@ -18,6 +18,7 @@ import { createHmac } from "node:crypto";
 import { randomUUID } from "node:crypto";
 import { processEvent } from "../events.js";
 import type { NormalizedEvent } from "../events.js";
+import { observeCorpus, repoForTicket } from "../memory/corpus-observe.js";
 import db from "../db.js";
 import { registerPoller, pollNow } from "../pollers/engine.js";
 import { getSetting } from "../settings.js";
@@ -282,6 +283,10 @@ function mirrorTicket(issue: LinearIssueForPoller): void {
     url: issue.url ?? null,
     updated_at: issue.updatedAt ? Math.floor(new Date(issue.updatedAt).getTime() / 1000) : null,
   });
+  // Memory enrichment: mirror the ticket into the observations corpus so
+  // search_memory can surface it. repo_family inferred from the team prefix.
+  const text = [issue.title, issue.description].filter(Boolean).join(" — ");
+  void observeCorpus({ source: "linear", text, repo: repoForTicket(issue.identifier ?? null) });
 }
 
 // ------------------------------------------------------------------

--- a/orchestrator/src/agents/runtime.ts
+++ b/orchestrator/src/agents/runtime.ts
@@ -21,6 +21,7 @@ import db from "../db.js";
 import { llmApiKey, llmBaseUrl } from "../settings.js";
 import { addNote, matchNotes } from "../notes.js";
 import { embedText } from "../embed.js";
+import { onSessionClosed, setTranscriptReader, startIdleSweep } from "../memory/trigger.js";
 import {
   createSessionWorktree,
   listWorktrees,
@@ -540,12 +541,17 @@ export function emit(s: LiveSession, kind: SessionEvent["kind"], data: unknown):
 }
 
 function setStatus(s: LiveSession, status: SessionStatus, extra?: { stopReason?: string; error?: string }): void {
+  const wasClosed = s.status === "closed";
   s.status = status;
   if (extra?.stopReason) s.stopReason = extra.stopReason;
   if (extra?.error) s.error = extra.error;
   s.updatedAt = Date.now();
   updateSessionRow.run(status, s.acpSessionId ?? null, s.stopReason ?? null, s.error ?? null, s.updatedAt, s.id);
   emit(s, "status", { status, stopReason: s.stopReason, error: s.error });
+  // Memory v1 write path: a session going closed is distilled (non-blocking,
+  // off the hot path). The idle sweep (trigger.ts) covers sessions that end by
+  // going quiet rather than by an explicit close.
+  if (status === "closed" && !wasClosed) onSessionClosed(s.id, s.branch ?? null);
 }
 
 const rehydrateRow = db.prepare(`SELECT * FROM agent_sessions WHERE id = ?`);
@@ -659,6 +665,12 @@ export function readTranscript(id: string, sinceSeq = 0): SessionEvent[] {
   }
   return out;
 }
+
+// Wire the memory distiller's triggers: give it the transcript reader (avoids an
+// import cycle) and start the idle sweep. Guarded so tests that never touch
+// sessions don't spin up a timer; FLOW_DISTILLER=0 disables both.
+setTranscriptReader((id) => readTranscript(id).map((e) => ({ seq: e.seq, kind: e.kind, data: e.data })));
+startIdleSweep();
 
 // ---------------------------------------------------------------------------
 // ACP connections — one adapter process per backend, shared across sessions

--- a/orchestrator/src/agents/runtime.ts
+++ b/orchestrator/src/agents/runtime.ts
@@ -406,6 +406,7 @@ db.exec(`
     start_sha TEXT,
     start_untracked TEXT,
     worktree_id TEXT,
+    last_distilled_seq INTEGER,
     created_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL
   )

--- a/orchestrator/src/db.ts
+++ b/orchestrator/src/db.ts
@@ -5,7 +5,7 @@ import Database from "better-sqlite3";
 import { mkdirSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { migrate, MEMORY_SCHEMA, MEMORY_TRIGGERS } from "./migrations.js";
+import { migrate, MEMORY_SCHEMA, MEMORY_TRIGGERS, ANCHORS_SCHEMA } from "./migrations.js";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
@@ -267,6 +267,10 @@ db.exec(`
 // create byte-identical tables. See migrations.ts for the column semantics.
 db.exec(MEMORY_SCHEMA);
 db.exec(MEMORY_TRIGGERS);
+// anchors: item ↔ graph-node join (migration 9). flow.db is PRIMARY; graph is
+// a rebuildable projection. Kept byte-identical to the migration via the shared
+// ANCHORS_SCHEMA string.
+db.exec(ANCHORS_SCHEMA);
 
 // FTS triggers to keep virtual tables in sync with base tables
 db.exec(`

--- a/orchestrator/src/db.ts
+++ b/orchestrator/src/db.ts
@@ -5,7 +5,7 @@ import Database from "better-sqlite3";
 import { mkdirSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { migrate } from "./migrations.js";
+import { migrate, MEMORY_SCHEMA, MEMORY_TRIGGERS } from "./migrations.js";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
@@ -261,6 +261,12 @@ db.exec(`
   );
   CREATE INDEX IF NOT EXISTS idx_llm_log_ref ON llm_log(ref);
 `);
+
+// Memory v1 storage (observations + memories + FTS). Kept in migrations.ts as
+// MEMORY_SCHEMA so a fresh DB (this block) and an upgrading DB (migration 8)
+// create byte-identical tables. See migrations.ts for the column semantics.
+db.exec(MEMORY_SCHEMA);
+db.exec(MEMORY_TRIGGERS);
 
 // FTS triggers to keep virtual tables in sync with base tables
 db.exec(`

--- a/orchestrator/src/index.ts
+++ b/orchestrator/src/index.ts
@@ -22,6 +22,8 @@ import { registerAgentRoutes } from "./agents/routes.js";
 import { registerCorrectionRoutes } from "./corrections.js";
 import { registerNoteRoutes } from "./notes.js";
 import { registerMemoryRoutes } from "./memory/routes.js";
+import { setNodeAnchorProvider } from "./memory/anchors.js";
+import { makeGatewayAnchorProvider } from "./memory/anchor-provider.js";
 import { registerSourceRoutes } from "./sources.js";
 import { startAllPollers, stopAllPollers, getAllPollStatus } from "./pollers/engine.js";
 import { registerSettingsRoutes } from "./settings.js";
@@ -77,6 +79,10 @@ registerAgentRoutes(app);
 registerCorrectionRoutes(app);
 registerNoteRoutes(app);
 registerMemoryRoutes(app);
+// Memory anchors resolve graph node paths through the gateway; a null gateway
+// (no FLOW_GATEWAY_URL) leaves the default no-op provider and items stay
+// repo-level. flow.db is primary — this is a read-only projection lookup.
+setNodeAnchorProvider(makeGatewayAnchorProvider());
 registerSourceRoutes(app);
 
 // ------------------------------------------------------------------

--- a/orchestrator/src/index.ts
+++ b/orchestrator/src/index.ts
@@ -21,6 +21,7 @@ import { registerLlmLogRoute } from "./llmlog.js";
 import { registerAgentRoutes } from "./agents/routes.js";
 import { registerCorrectionRoutes } from "./corrections.js";
 import { registerNoteRoutes } from "./notes.js";
+import { registerMemoryRoutes } from "./memory/routes.js";
 import { registerSourceRoutes } from "./sources.js";
 import { startAllPollers, stopAllPollers, getAllPollStatus } from "./pollers/engine.js";
 import { registerSettingsRoutes } from "./settings.js";
@@ -75,6 +76,7 @@ registerLlmLogRoute(app);
 registerAgentRoutes(app);
 registerCorrectionRoutes(app);
 registerNoteRoutes(app);
+registerMemoryRoutes(app);
 registerSourceRoutes(app);
 
 // ------------------------------------------------------------------

--- a/orchestrator/src/memory/anchor-provider.ts
+++ b/orchestrator/src/memory/anchor-provider.ts
@@ -1,0 +1,71 @@
+// anchor-provider.ts — the PRODUCTION NodeAnchorProvider. Anchor resolution
+// needs graph node anchor PATHS (a node's `evidence` = 'file:line' prop), which
+// live in FalkorDB behind the gateway. The orchestrator reaches them over HTTP
+// via the gateway's read_query verb (POST /v1/verbs/read_query) — the same
+// service boundary the gateway uses to reach us for search/notes/corrections.
+//
+// flow.db stays PRIMARY: this provider only READS the projection to infer edges;
+// the edges themselves are stored in flow.db's anchors table. When the gateway
+// is unreachable, nodesForFiles returns [] and items fall back to repo-level —
+// anchoring is enrichment, never a hard dependency. Tests never use this file;
+// they inject a stub provider (see anchors.setNodeAnchorProvider).
+//
+// NOTE: read_query takes only {cypher} (no bound params) and rejects write
+// keywords. So we inline SANITIZED basenames (path chars only: [A-Za-z0-9._/-])
+// — never raw model text — into a CONTAINS filter. Correctness lives in
+// rankAnchors (which re-checks the full path); this query only needs to be a
+// safe superset.
+
+import type { NodeAnchor, NodeAnchorProvider } from "./anchors.js";
+
+function gatewayUrl(): string | null {
+  const base = process.env.FLOW_GATEWAY_URL || process.env.GRAPH_GATEWAY_URL || "";
+  if (!base) return null;
+  return `${base.replace(/\/$/, "")}/v1/verbs/read_query`;
+}
+
+// Keep only path-safe chars, then lower-case for the CONTAINS compare. Anything
+// else (quotes, spaces, cypher syntax) is stripped — no injection surface.
+function sanitizeBasename(f: string): string {
+  const base = f.replace(/\\/g, "/").split("/").pop() ?? f;
+  return base.replace(/[^A-Za-z0-9._-]/g, "").toLowerCase();
+}
+
+// Query the graph for nodes whose `evidence` path matches any candidate file.
+// Returns node ids with their evidence path; the ranker re-checks the full path
+// and derives specificity (deeper id = more specific; endpoints beat services).
+export function makeGatewayAnchorProvider(): NodeAnchorProvider {
+  return {
+    async nodesForFiles(_repo, files) {
+      const url = gatewayUrl();
+      if (!url || files.length === 0) return [];
+      const token = process.env.FLOW_ADMIN_TOKEN || process.env.FLOW_ACTIVITY_TOKEN || "";
+      const basenames = [...new Set(files.map(sanitizeBasename))].filter((b) => b.length >= 2);
+      if (basenames.length === 0) return [];
+      const orClause = basenames.map((b) => `toLower(n.evidence) CONTAINS '${b}'`).join(" OR ");
+      const cypher = `MATCH (n) WHERE n.evidence IS NOT NULL AND (${orClause})
+        RETURN n.id AS id, n.evidence AS evidence LIMIT 200`;
+      try {
+        const res = await fetch(url, {
+          method: "POST",
+          headers: { "content-type": "application/json", ...(token ? { authorization: `Bearer ${token}` } : {}) },
+          body: JSON.stringify({ cypher }),
+          signal: AbortSignal.timeout(4000),
+        });
+        if (!res.ok) return [];
+        const body = (await res.json().catch(() => ({}))) as { rows?: Array<{ id?: string; evidence?: string }> };
+        const rows = body.rows ?? [];
+        const out: NodeAnchor[] = [];
+        for (const r of rows) {
+          if (!r.id || !r.evidence) continue;
+          // evidence 'file:line' → path.
+          const path = String(r.evidence).replace(/:\d+(-\d+)?$/, "");
+          out.push({ node_id: String(r.id), paths: [path] });
+        }
+        return out;
+      } catch {
+        return [];
+      }
+    },
+  };
+}

--- a/orchestrator/src/memory/anchors.ts
+++ b/orchestrator/src/memory/anchors.ts
@@ -1,0 +1,277 @@
+// anchors.ts — resolve the join between a memory/observation and graph nodes.
+//
+// DESIGN (final, user-approved):
+//   flow.db is PRIMARY. The `anchors` table owns the item↔node edge; any graph
+//   representation is a rebuildable projection. Resolution runs at consolidation
+//   time and is DETERMINISTIC FIRST: match a memory's context_files (+ file-ish
+//   retrieval_keys) against the anchor PATHS of graph nodes. Cap 3 anchors per
+//   item; prefer the MOST SPECIFIC node (an endpoint under a service beats the
+//   service). Generalizes to corpus observations (linear/slack) when files or
+//   entities are inferable from their text.
+//
+//   Node anchor paths come from FalkorDB via the gateway. To keep this offline
+//   and testable, resolution is behind an injectable NodeAnchorProvider: tests
+//   stub it; the production impl queries the gateway/graph (nodes carry an
+//   `evidence` = 'file:line' prop; its path is the anchor path). A null provider
+//   (no graph reachable) → no anchors resolved, item falls back to repo-level.
+//
+//   RE-RESOLUTION is idempotent (callable on reindex): re-run matching from the
+//   item's STORED context_files/keys, replace the edge set. A node that has
+//   disappeared drops its edge; the item falls back to repo-level — never lost.
+
+import { randomUUID } from "node:crypto";
+import db from "../db.js";
+
+export const MAX_ANCHORS_PER_ITEM = 3;
+
+export type ItemType = "memory" | "observation";
+export type AnchorSource = "files" | "semantic";
+
+export interface AnchorRow {
+  id: string;
+  item_type: ItemType;
+  item_id: string;
+  node_id: string;
+  source: AnchorSource;
+  resolved_at: number;
+}
+
+// A graph node as seen for anchoring: its id and the set of file paths it is
+// anchored to in the repo (derived from the node's `evidence` = 'file:line').
+export interface NodeAnchor {
+  node_id: string;
+  // Repo-relative file paths this node covers (usually one; endpoints/services
+  // may span a few). Lower-cased comparison happens in the matcher.
+  paths: string[];
+  // Larger = more specific. An endpoint (deeper id / path) outranks the service
+  // that contains it when both match the same file. Provider supplies it; when
+  // absent we derive a fallback from the id/path shape.
+  specificity?: number;
+}
+
+// The seam to the graph. Production queries the gateway; tests stub it. Given a
+// repo and a set of candidate file paths, return the graph nodes anchored to any
+// of them. Returning [] (or a provider that throws → caught) means "graph
+// unreachable / no match" and the item simply stays repo-level.
+export interface NodeAnchorProvider {
+  nodesForFiles(repo: string | null, files: string[]): Promise<NodeAnchor[]>;
+}
+
+// Default provider resolves nothing — production wires a gateway-backed one at
+// boot (see anchor-provider.ts); tests inject their own stub.
+let _provider: NodeAnchorProvider = { nodesForFiles: async () => [] };
+export function setNodeAnchorProvider(p: NodeAnchorProvider): void {
+  _provider = p;
+}
+export function getNodeAnchorProvider(): NodeAnchorProvider {
+  return _provider;
+}
+
+// A token/path is "file-ish" if it looks like a path or a filename: contains a
+// slash, or a dot with a short-ish extension. Bare words are NOT file-ish (they
+// belong to the semantic path, not the deterministic file match).
+export function isFileIsh(s: string): boolean {
+  if (s.includes("/")) return true;
+  return /\.[a-z0-9]{1,6}$/i.test(s);
+}
+
+// Basename of a path, lower-cased (for endpoint-vs-service tie handling and for
+// matching a node whose path is stored as just a filename).
+function basename(p: string): string {
+  const clean = p.replace(/\\/g, "/");
+  const i = clean.lastIndexOf("/");
+  return (i >= 0 ? clean.slice(i + 1) : clean).toLowerCase();
+}
+
+// Derive a fallback specificity from a node id/path when the provider omits it:
+// deeper ids (more ':' or '/' segments) are more specific. Endpoints look like
+// 'api:svc:GET /x' (3 segments) and beat services 'svc:x' (1 segment).
+function derivedSpecificity(node: NodeAnchor): number {
+  if (typeof node.specificity === "number") return node.specificity;
+  const idSegs = node.node_id.split(/[:/]/).filter(Boolean).length;
+  const pathDepth = Math.max(0, ...node.paths.map((p) => p.split("/").length));
+  return idSegs * 10 + pathDepth;
+}
+
+// The file set an item exposes for deterministic matching: context_files plus
+// any file-ish retrieval_keys, deduped, normalized (basename kept as-is; full
+// path kept too so both a stored full path and a stored basename can match).
+export function candidateFiles(contextFiles: string[], retrievalKeys: string[]): string[] {
+  const out = new Set<string>();
+  for (const f of contextFiles) if (f && f.trim()) out.add(f.trim());
+  for (const k of retrievalKeys) if (k && isFileIsh(k)) out.add(k.trim());
+  return [...out];
+}
+
+// Do two path strings refer to the same file? Exact (lower-cased) OR one is the
+// basename of the other OR they share a basename — the deterministic matcher
+// wants "store.ts" to match "orchestrator/src/store.ts".
+function pathsMatch(a: string, b: string): boolean {
+  const la = a.toLowerCase();
+  const lb = b.toLowerCase();
+  if (la === lb) return true;
+  if (la.endsWith("/" + lb) || lb.endsWith("/" + la)) return true;
+  return basename(a) === basename(b) && basename(a).includes(".");
+}
+
+// Pure ranking core: given the item's candidate files and the graph nodes those
+// files hit, pick up to MAX_ANCHORS_PER_ITEM node ids, most-specific first.
+// Exposed for unit tests (no DB, no provider).
+export function rankAnchors(candidateFilesList: string[], nodes: NodeAnchor[]): string[] {
+  const scored: Array<{ id: string; spec: number; matches: number }> = [];
+  for (const node of nodes) {
+    let matches = 0;
+    for (const nf of node.paths) {
+      if (candidateFilesList.some((cf) => pathsMatch(cf, nf))) matches++;
+    }
+    if (matches > 0) scored.push({ id: node.node_id, spec: derivedSpecificity(node), matches });
+  }
+  // Most specific first; break ties by match count, then by id for determinism.
+  scored.sort((a, b) => b.spec - a.spec || b.matches - a.matches || (a.id < b.id ? -1 : 1));
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const s of scored) {
+    if (seen.has(s.id)) continue;
+    seen.add(s.id);
+    out.push(s.id);
+    if (out.length >= MAX_ANCHORS_PER_ITEM) break;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Persistence
+
+export function anchorsForItem(itemType: ItemType, itemId: string): AnchorRow[] {
+  return db
+    .prepare(`SELECT * FROM anchors WHERE item_type = ? AND item_id = ? ORDER BY resolved_at DESC, node_id`)
+    .all(itemType, itemId) as AnchorRow[];
+}
+
+export function nodeIdsForItem(itemType: ItemType, itemId: string): string[] {
+  return anchorsForItem(itemType, itemId).map((a) => a.node_id);
+}
+
+export function itemsAnchoredToNode(nodeId: string): AnchorRow[] {
+  return db.prepare(`SELECT * FROM anchors WHERE node_id = ? ORDER BY resolved_at DESC`).all(nodeId) as AnchorRow[];
+}
+
+// Replace the anchor edge set for one item with `nodeIds` (idempotent). Runs in
+// a transaction: delete the old edges, insert the new ones. Called by resolve
+// AND re-resolve — re-resolution is just "resolve again from stored files".
+export function setAnchors(itemType: ItemType, itemId: string, nodeIds: string[], source: AnchorSource): void {
+  const capped = nodeIds.slice(0, MAX_ANCHORS_PER_ITEM);
+  const now = Math.floor(Date.now() / 1000);
+  const tx = db.transaction(() => {
+    db.prepare(`DELETE FROM anchors WHERE item_type = ? AND item_id = ?`).run(itemType, itemId);
+    const ins = db.prepare(
+      `INSERT OR IGNORE INTO anchors (id, item_type, item_id, node_id, source, resolved_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    );
+    for (const nodeId of capped) ins.run(randomUUID(), itemType, itemId, nodeId, source, now);
+  });
+  tx();
+}
+
+// ---------------------------------------------------------------------------
+// Resolution (deterministic file match → anchor edges)
+
+export interface ResolvableItem {
+  item_type: ItemType;
+  item_id: string;
+  repo: string | null;
+  context_files: string[];
+  retrieval_keys: string[];
+}
+
+// Resolve (or re-resolve) one item's anchors from its files. Deterministic
+// first: match candidate files against graph node anchor paths via the
+// provider, rank most-specific, cap 3. Returns the node ids anchored (possibly
+// []). Never throws — a provider error → [] and the item falls back to
+// repo-level. Idempotent: re-running replaces the edge set, so a node that has
+// since disappeared (provider no longer returns it) drops its edge.
+export async function resolveItemAnchors(item: ResolvableItem): Promise<string[]> {
+  const files = candidateFiles(item.context_files, item.retrieval_keys);
+  if (files.length === 0) {
+    // Nothing file-ish to anchor on — clear any stale edges, fall back to repo.
+    setAnchors(item.item_type, item.item_id, [], "files");
+    return [];
+  }
+  let nodes: NodeAnchor[] = [];
+  try {
+    nodes = await _provider.nodesForFiles(item.repo, files);
+  } catch {
+    // Graph unreachable → leave existing edges untouched on a live resolve is
+    // tempting, but re-resolve semantics require we not lose the item; simplest
+    // safe behavior is "no new edges this pass". Keep prior edges intact.
+    return nodeIdsForItem(item.item_type, item.item_id);
+  }
+  const nodeIds = rankAnchors(files, nodes);
+  setAnchors(item.item_type, item.item_id, nodeIds, "files");
+  return nodeIds;
+}
+
+function parseJsonArray(s: string | null | undefined): string[] {
+  if (!s) return [];
+  try {
+    const v = JSON.parse(s);
+    return Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+// Resolve anchors for a memory by id, reading its stored context from attached
+// observations (union of context_files) + the memory's own retrieval_keys.
+// Called at consolidation time and on re-resolve.
+export async function resolveMemoryAnchors(memoryId: string): Promise<string[]> {
+  const mem = db.prepare(`SELECT id, repo, retrieval_keys FROM memories WHERE id = ?`).get(memoryId) as
+    | { id: string; repo: string | null; retrieval_keys: string | null }
+    | undefined;
+  if (!mem) return [];
+  // context_files come from the attached observations (the memory row doesn't
+  // store them; observations do).
+  const obsRows = db
+    .prepare(`SELECT context_files FROM observations WHERE memory_id = ?`)
+    .all(memoryId) as Array<{ context_files: string | null }>;
+  const ctxFiles = new Set<string>();
+  for (const r of obsRows) for (const f of parseJsonArray(r.context_files)) ctxFiles.add(f);
+  return resolveItemAnchors({
+    item_type: "memory",
+    item_id: mem.id,
+    repo: mem.repo,
+    context_files: [...ctxFiles],
+    retrieval_keys: parseJsonArray(mem.retrieval_keys),
+  });
+}
+
+// Resolve anchors for a corpus observation (linear/slack) by id. Files/entities
+// are inferred from its context_files + file-ish retrieval_keys, same path.
+export async function resolveObservationAnchors(observationId: string): Promise<string[]> {
+  const obs = db
+    .prepare(`SELECT id, repo, context_files, retrieval_keys FROM observations WHERE id = ?`)
+    .get(observationId) as
+    | { id: string; repo: string | null; context_files: string | null; retrieval_keys: string | null }
+    | undefined;
+  if (!obs) return [];
+  return resolveItemAnchors({
+    item_type: "observation",
+    item_id: obs.id,
+    repo: obs.repo,
+    context_files: parseJsonArray(obs.context_files),
+    retrieval_keys: parseJsonArray(obs.retrieval_keys),
+  });
+}
+
+// Re-resolve every active memory's anchors (callable on reindex). Idempotent;
+// nodes that disappeared drop their edges, items fall back to repo-level. Runs
+// serially — reindex is not latency-critical. Returns a summary.
+export async function reresolveAllMemoryAnchors(): Promise<{ items: number; anchored: number }> {
+  const rows = db.prepare(`SELECT id FROM memories WHERE status = 'active'`).all() as Array<{ id: string }>;
+  let anchored = 0;
+  for (const r of rows) {
+    const ids = await resolveMemoryAnchors(r.id);
+    if (ids.length) anchored++;
+  }
+  return { items: rows.length, anchored };
+}

--- a/orchestrator/src/memory/cards.ts
+++ b/orchestrator/src/memory/cards.ts
@@ -1,0 +1,298 @@
+// cards.ts — drill-down cards (Section C). Each new id namespace resolves to a
+// structured card the gateway serves via get_entity (single or batch ids[]):
+//
+//   mem:<uuid>          → claim, kind, strength value+tier + breakdown
+//                         (people_count, evidence_count, max source_weight,
+//                          contradiction_count, last_reinforced), born
+//                         (repo/branch/date), context files, anchors as node
+//                         ids, evidence observations as one-liners [obs:<id>].
+//   obs:<uuid>          → full text, source, session/channel, date, parent
+//                         memory id.
+//   lin:<identifier>    → title/status/description(truncated)/latest stored
+//                         comments + permalink + anchored nodes.
+//   slackthread:<ts>    → root text, participants, stored messages one-liners,
+//                         permalink.
+//
+// IMPLEMENTATION CHOICE (documented): the gateway resolves these namespaces by
+// calling the orchestrator over HTTP (/v1/memory/card/:type/:id) — the same
+// proxy pattern as FLOW_NOTES_URL / search_memory. The orchestrator owns
+// flow.db (memories, observations, corpus, anchors), so reading here is a
+// single indexed lookup with no graph round-trip. Cards carry NODE IDS for
+// anchors (not node bodies) so the model can get_entity them next.
+
+import db from "../db.js";
+import { strengthTier } from "./strength.js";
+import { nodeIdsForItem } from "./anchors.js";
+
+const DESC_TRUNC = 400;
+const LINE_TRUNC = 140;
+
+export type CardType = "mem" | "obs" | "lin" | "slackthread";
+
+export interface CardResult {
+  status: "found" | "not_found";
+  type: CardType;
+  id: string;
+  card?: Record<string, unknown>;
+}
+
+function trunc(s: string | null | undefined, max: number): string {
+  const t = String(s ?? "").replace(/\s+/g, " ").trim();
+  return t.length > max ? t.slice(0, max - 1) + "…" : t;
+}
+
+function parseKeys(s: string | null): string[] {
+  if (!s) return [];
+  try {
+    const v = JSON.parse(s);
+    return Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+function isoDate(epochSec: number | null | undefined): string | null {
+  if (!epochSec) return null;
+  return new Date(epochSec * 1000).toISOString();
+}
+
+// ---- mem:<uuid> ----
+function memoryCard(id: string): CardResult {
+  const m = db.prepare(`SELECT * FROM memories WHERE id = ?`).get(id) as
+    | {
+        id: string;
+        claim: string;
+        kind: string;
+        repo: string | null;
+        repo_family: string | null;
+        strength: number;
+        evidence_count: number;
+        people_count: number;
+        contradiction_count: number;
+        last_reinforced_at: number | null;
+        max_source_weight: string;
+        retrieval_keys: string | null;
+        created_at: number;
+        status: string;
+      }
+    | undefined;
+  if (!m) return { status: "not_found", type: "mem", id };
+
+  // Evidence observations attached to this memory — one-liners with [obs:id].
+  const obsRows = db
+    .prepare(
+      `SELECT id, source, claim, branch, context_files FROM observations
+       WHERE memory_id = ? ORDER BY created_at DESC LIMIT 12`,
+    )
+    .all(id) as Array<{ id: string; source: string; claim: string; branch: string | null; context_files: string | null }>;
+  const evidence = obsRows.map((o) => ({
+    id: `obs:${o.id}`,
+    line: `[${o.source}] ${trunc(o.claim, LINE_TRUNC)}`,
+  }));
+
+  // Context files = union across attached observations.
+  const ctxFiles = new Set<string>();
+  for (const o of obsRows) for (const f of parseKeys(o.context_files)) ctxFiles.add(f);
+
+  // "Born" = the earliest observation's repo/branch/date.
+  const born = db
+    .prepare(`SELECT repo, branch, created_at FROM observations WHERE memory_id = ? ORDER BY created_at ASC LIMIT 1`)
+    .get(id) as { repo: string | null; branch: string | null; created_at: number } | undefined;
+
+  return {
+    status: "found",
+    type: "mem",
+    id,
+    card: {
+      kind: "memory",
+      claim: m.claim,
+      memory_kind: m.kind,
+      strength: { value: Math.round(m.strength * 1000) / 1000, tier: strengthTier(m.strength) },
+      breakdown: {
+        people_count: m.people_count,
+        evidence_count: m.evidence_count,
+        max_source_weight: m.max_source_weight,
+        contradiction_count: m.contradiction_count,
+        last_reinforced: isoDate(m.last_reinforced_at),
+      },
+      born: born ? { repo: born.repo, branch: born.branch, date: isoDate(born.created_at) } : null,
+      context_files: [...ctxFiles],
+      anchors: nodeIdsForItem("memory", id), // node ids the model can get_entity
+      evidence,
+    },
+  };
+}
+
+// ---- obs:<uuid> ----
+function observationCard(id: string): CardResult {
+  const o = db.prepare(`SELECT * FROM observations WHERE id = ?`).get(id) as
+    | {
+        id: string;
+        source: string;
+        repo: string | null;
+        branch: string | null;
+        session_id: string | null;
+        claim: string;
+        kind: string;
+        source_weight: string;
+        context_files: string | null;
+        retrieval_keys: string | null;
+        memory_id: string | null;
+        created_at: number;
+      }
+    | undefined;
+  if (!o) return { status: "not_found", type: "obs", id };
+  return {
+    status: "found",
+    type: "obs",
+    id,
+    card: {
+      kind: "observation",
+      text: o.claim,
+      source: o.source,
+      observation_kind: o.kind,
+      source_weight: o.source_weight,
+      session: o.session_id,
+      channel: null, // corpus channel is carried on the corpus row; obs is repo-scoped
+      repo: o.repo,
+      branch: o.branch,
+      date: isoDate(o.created_at),
+      context_files: parseKeys(o.context_files),
+      parent_memory: o.memory_id ? `mem:${o.memory_id}` : null,
+      anchors: nodeIdsForItem("observation", id),
+    },
+  };
+}
+
+// ---- lin:<identifier> ----
+function linearCard(identifier: string): CardResult {
+  const t = db.prepare(`SELECT * FROM linear_tickets WHERE identifier = ? LIMIT 1`).get(identifier) as
+    | {
+        id: string;
+        identifier: string;
+        title: string;
+        description: string | null;
+        state: string | null;
+        assignee: string | null;
+        url: string | null;
+        updated_at: number | null;
+      }
+    | undefined;
+  if (!t) return { status: "not_found", type: "lin", id: identifier };
+
+  // Anchored nodes: any observation derived from this ticket that got anchored.
+  const anchoredNodes = anchoredNodesForCorpus("linear", identifier);
+
+  return {
+    status: "found",
+    type: "lin",
+    id: identifier,
+    card: {
+      kind: "ticket",
+      identifier: t.identifier,
+      title: t.title,
+      status: t.state,
+      description: trunc(t.description, DESC_TRUNC),
+      assignee: t.assignee,
+      permalink: t.url,
+      updated_at: isoDate(t.updated_at),
+      anchored_nodes: anchoredNodes,
+    },
+  };
+}
+
+// ---- slackthread:<ts> ----
+function slackThreadCard(ts: string): CardResult {
+  // Root message is the one whose ts equals the thread ts (or a message with
+  // that thread_ts if the root wasn't captured). Reply messages share thread_ts.
+  const root =
+    (db.prepare(`SELECT * FROM slack_messages WHERE ts = ? LIMIT 1`).get(ts) as SlackRow | undefined) ??
+    (db.prepare(`SELECT * FROM slack_messages WHERE thread_ts = ? ORDER BY ts ASC LIMIT 1`).get(ts) as SlackRow | undefined);
+  if (!root) return { status: "not_found", type: "slackthread", id: ts };
+
+  const rootTs = root.thread_ts || root.ts;
+  const messages = db
+    .prepare(
+      `SELECT id, user_id, text, ts, permalink FROM slack_messages
+       WHERE ts = ? OR thread_ts = ? ORDER BY ts ASC LIMIT 30`,
+    )
+    .all(rootTs, rootTs) as Array<{ id: string; user_id: string | null; text: string; ts: string; permalink: string | null }>;
+  const participants = [...new Set(messages.map((m) => m.user_id).filter((u): u is string => !!u))];
+
+  return {
+    status: "found",
+    type: "slackthread",
+    id: ts,
+    card: {
+      kind: "thread",
+      root_text: root.text,
+      channel: root.channel,
+      participants,
+      permalink: root.permalink,
+      messages: messages.map((m) => ({
+        user: m.user_id,
+        line: trunc(m.text, LINE_TRUNC),
+        ts: m.ts,
+      })),
+      anchored_nodes: anchoredNodesForCorpus("slack", rootTs),
+    },
+  };
+}
+
+interface SlackRow {
+  id: string;
+  channel: string | null;
+  user_id: string | null;
+  text: string;
+  ts: string;
+  thread_ts: string | null;
+  permalink: string | null;
+}
+
+// Nodes anchored via a corpus observation matching this source + key. Corpus
+// observations don't carry an FK to the corpus row, so we match on the
+// identifier/ts appearing in the observation's retrieval_keys. Best-effort.
+function anchoredNodesForCorpus(source: string, key: string): string[] {
+  const rows = db
+    .prepare(`SELECT id, retrieval_keys, claim FROM observations WHERE source = ?`)
+    .all(source) as Array<{ id: string; retrieval_keys: string | null; claim: string }>;
+  const nodeIds = new Set<string>();
+  for (const r of rows) {
+    const keys = parseKeys(r.retrieval_keys);
+    const hit = keys.some((k) => k === key || k === `ts:${key}`) || r.claim.includes(key);
+    if (!hit) continue;
+    for (const n of nodeIdsForItem("observation", r.id)) nodeIds.add(n);
+  }
+  return [...nodeIds];
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch — the gateway calls getCard(type, id). Unknown type → not_found.
+
+export function getCard(type: string, id: string): CardResult {
+  switch (type) {
+    case "mem":
+      return memoryCard(id);
+    case "obs":
+      return observationCard(id);
+    case "lin":
+      return linearCard(id);
+    case "slackthread":
+      return slackThreadCard(id);
+    default:
+      return { status: "not_found", type: type as CardType, id };
+  }
+}
+
+// Parse a namespaced id token ("mem:<uuid>") into {type, id}, or null if it's
+// not a card namespace. Shared with the gateway's get_entity dispatch shape.
+const CARD_TYPES = new Set(["mem", "obs", "lin", "slackthread"]);
+export function parseCardId(raw: string): { type: CardType; id: string } | null {
+  const i = raw.indexOf(":");
+  if (i <= 0) return null;
+  const type = raw.slice(0, i);
+  if (!CARD_TYPES.has(type)) return null;
+  const id = raw.slice(i + 1);
+  if (!id) return null;
+  return { type: type as CardType, id };
+}

--- a/orchestrator/src/memory/consolidate.ts
+++ b/orchestrator/src/memory/consolidate.ts
@@ -1,0 +1,127 @@
+// consolidate.ts — fold a new observation into the memories store.
+//
+// Eval-calibrated banding (do not re-litigate):
+//   cosine(obs, memory) < T_LO (0.50)  → CREATE a new memory. No auto-merge.
+//   cosine >= T_LO                      → ask an LLM judge (claude-haiku-4-5)
+//        which returns exactly one of: same | new | refines | contradicts.
+//   There is NO "auto-same" high band: contradictions embed MORE similarly than
+//   rewordings, so a naive 0.85 auto-merge band merged 87% of contradictions in
+//   the eval. Every above-threshold decision goes through the judge (98.6%
+//   action accuracy).
+//
+// Actions:
+//   same        → attach, evidence++, people recompute, last_reinforced=now
+//   refines     → attach + replace canonical claim with the refined text
+//   contradicts → attach as counter-evidence, contradiction_count++ (strength
+//                 penalty applied by recomputeStrength)
+//   new         → create a new memory
+//
+// The judge is INJECTED so tests use a deterministic fake and never call an LLM.
+
+import { cosine, blobToVec } from "../embed.js";
+import {
+  type ObservationRow,
+  type MemoryRow,
+  createMemory,
+  memoriesInFamily,
+  updateMemory,
+  attachObservation,
+  recomputePeopleCount,
+  evidenceCount,
+  unionRetrievalKeys,
+  getMemory,
+} from "./store.js";
+import { computeStrength, strongerWeight } from "./strength.js";
+
+export const T_LO = 0.5;
+
+export type JudgeVerdict = "same" | "new" | "refines" | "contradicts";
+
+// A judge compares two claims and returns exactly one verdict. The default
+// (haiku-backed) lives in judge.ts; tests pass a fake.
+export type Judge = (a: MemoryRow, b: ObservationRow) => Promise<{ verdict: JudgeVerdict; refinedClaim?: string }>;
+
+export interface ConsolidateResult {
+  action: JudgeVerdict;
+  memoryId: string;
+  created: boolean;
+}
+
+// Best cosine match among candidate memories for this observation's embedding.
+function bestMatch(obs: ObservationRow, candidates: MemoryRow[]): { mem: MemoryRow; sim: number } | null {
+  if (!obs.embedding) return null;
+  const q = blobToVec(obs.embedding);
+  let best: { mem: MemoryRow; sim: number } | null = null;
+  for (const m of candidates) {
+    if (!m.embedding) continue;
+    const sim = cosine(q, blobToVec(m.embedding));
+    if (!best || sim > best.sim) best = { mem: m, sim };
+  }
+  return best;
+}
+
+// Recompute + persist a memory's derived fields (people, evidence, keys,
+// strength) after an observation attaches.
+export function recomputeStrength(memoryId: string): MemoryRow {
+  const mem = getMemory(memoryId)!;
+  const people = recomputePeopleCount(memoryId);
+  const evidence = evidenceCount(memoryId);
+  const strength = computeStrength({
+    people_count: people,
+    evidence_count: evidence,
+    max_source_weight: mem.max_source_weight,
+    contradiction_count: mem.contradiction_count,
+    last_reinforced_at: mem.last_reinforced_at ?? mem.created_at,
+  });
+  updateMemory(memoryId, {
+    people_count: people,
+    evidence_count: evidence,
+    strength,
+    retrieval_keys: JSON.stringify(unionRetrievalKeys(memoryId)),
+  });
+  return getMemory(memoryId)!;
+}
+
+export async function consolidateObservation(obs: ObservationRow, judge: Judge): Promise<ConsolidateResult> {
+  const candidates = memoriesInFamily(obs.repo_family);
+  const match = bestMatch(obs, candidates);
+
+  // No candidate at all, or below T_LO → brand-new memory.
+  if (!match || match.sim < T_LO) {
+    const mem = createMemory(obs);
+    recomputeStrength(mem.id);
+    return { action: "new", memoryId: mem.id, created: true };
+  }
+
+  // At/above T_LO → the judge decides.
+  const { verdict, refinedClaim } = await judge(match.mem, obs);
+
+  if (verdict === "new") {
+    const mem = createMemory(obs);
+    recomputeStrength(mem.id);
+    return { action: "new", memoryId: mem.id, created: true };
+  }
+
+  // same | refines | contradicts all ATTACH the observation to the matched memory.
+  attachObservation(match.mem.id, obs.id);
+  const now = Math.floor(Date.now() / 1000);
+  const nextWeight = strongerWeight(match.mem.max_source_weight, obs.source_weight);
+
+  if (verdict === "contradicts") {
+    updateMemory(match.mem.id, {
+      contradiction_count: match.mem.contradiction_count + 1,
+      max_source_weight: nextWeight,
+      last_reinforced_at: now,
+    });
+  } else {
+    // same or refines: reinforce.
+    const fields: Partial<MemoryRow> = { max_source_weight: nextWeight, last_reinforced_at: now };
+    if (verdict === "refines" && refinedClaim && refinedClaim.trim()) {
+      fields.claim = refinedClaim.trim();
+    }
+    updateMemory(match.mem.id, fields);
+  }
+
+  recomputeStrength(match.mem.id);
+  return { action: verdict, memoryId: match.mem.id, created: false };
+}

--- a/orchestrator/src/memory/consolidate.ts
+++ b/orchestrator/src/memory/consolidate.ts
@@ -32,6 +32,8 @@ import {
   getMemory,
 } from "./store.js";
 import { computeStrength, strongerWeight } from "./strength.js";
+import { resolveMemoryAnchors } from "./anchors.js";
+import { invalidateHeadlineCache } from "./headline.js";
 
 export const T_LO = 0.5;
 
@@ -90,6 +92,7 @@ export async function consolidateObservation(obs: ObservationRow, judge: Judge):
   if (!match || match.sim < T_LO) {
     const mem = createMemory(obs);
     recomputeStrength(mem.id);
+    await anchorAfterConsolidate(mem.id);
     return { action: "new", memoryId: mem.id, created: true };
   }
 
@@ -99,6 +102,7 @@ export async function consolidateObservation(obs: ObservationRow, judge: Judge):
   if (verdict === "new") {
     const mem = createMemory(obs);
     recomputeStrength(mem.id);
+    await anchorAfterConsolidate(mem.id);
     return { action: "new", memoryId: mem.id, created: true };
   }
 
@@ -123,5 +127,20 @@ export async function consolidateObservation(obs: ObservationRow, judge: Judge):
   }
 
   recomputeStrength(match.mem.id);
+  await anchorAfterConsolidate(match.mem.id);
   return { action: verdict, memoryId: match.mem.id, created: false };
+}
+
+// Resolve a memory's anchors and invalidate the headline cache for any node it
+// now touches. Non-throwing: anchoring is best-effort enrichment — a graph
+// hiccup must never sink consolidation (the memory is already stored). The
+// resolve itself is idempotent, so a missed pass is recovered on the next
+// reinforcement or a reindex re-resolve.
+async function anchorAfterConsolidate(memoryId: string): Promise<void> {
+  try {
+    const nodeIds = await resolveMemoryAnchors(memoryId);
+    for (const id of nodeIds) invalidateHeadlineCache(id);
+  } catch {
+    /* best-effort; item falls back to repo-level */
+  }
 }

--- a/orchestrator/src/memory/corpus-observe.ts
+++ b/orchestrator/src/memory/corpus-observe.ts
@@ -1,0 +1,62 @@
+// corpus-observe.ts — enrich the corpus_insert path so slack/linear rows also
+// become observations (embedded, searchable via search_memory alongside session
+// memories). repo_family is inferred from a channel/ticket→repo mapping when one
+// exists; otherwise null, which the cross-family gate treats as match-all.
+//
+// Corpus observations are NOT consolidated into memories (they're evidence, not
+// distilled claims) — they live in the observations table with memory_id NULL
+// and surface through FTS + vector search directly.
+
+import { insertObservation } from "./store.js";
+import { getSetting } from "../settings.js";
+
+// Optional mapping: JSON in setting CORPUS_REPO_MAP, e.g.
+//   { "channels": {"C123":"acme-backend"}, "tickets": {"ACME":"acme-web"} }
+interface RepoMap {
+  channels?: Record<string, string>;
+  tickets?: Record<string, string>;
+}
+
+function repoMap(): RepoMap {
+  const raw = getSetting("CORPUS_REPO_MAP");
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw) as RepoMap;
+  } catch {
+    return {};
+  }
+}
+
+export function repoForChannel(channel: string | null | undefined): string | null {
+  if (!channel) return null;
+  return repoMap().channels?.[channel] ?? null;
+}
+
+// Linear identifiers are "ACME-123" — the team prefix is the mapping key.
+export function repoForTicket(identifier: string | null | undefined): string | null {
+  if (!identifier) return null;
+  const prefix = identifier.split("-")[0];
+  return repoMap().tickets?.[prefix] ?? null;
+}
+
+// Best-effort: never throws, never blocks the corpus insert (callers `void` it).
+export async function observeCorpus(o: {
+  source: "slack" | "linear" | "meeting";
+  text: string;
+  repo?: string | null;
+}): Promise<void> {
+  const text = o.text.trim();
+  if (!text) return;
+  try {
+    await insertObservation({
+      source: o.source,
+      repo: o.repo ?? null,
+      claim: text.slice(0, 1000),
+      kind: "gotcha", // corpus rows carry no distilled kind; a neutral bucket
+      source_weight: "user_stated", // a human said it in slack/linear
+      retrieval_keys: [],
+    });
+  } catch (err) {
+    console.warn(`[memory] corpus observe failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}

--- a/orchestrator/src/memory/distiller.ts
+++ b/orchestrator/src/memory/distiller.ts
@@ -1,0 +1,69 @@
+// distiller.ts — the session-end write path. NON-BLOCKING: the runtime queues a
+// distill job; it never delays session ops. One LLM call slims + extracts
+// durable observations, each is consolidated into the memories store, then a
+// cheap decay sweep runs.
+//
+// Pipeline: transcript events → slim → prompt → claude CLI → parse array →
+//   insert observations (embed at write) → consolidate (band + judge) → sweep.
+//
+// FLOW_DISTILLER=0 disables the whole path. The judge is the default haiku judge
+// but is injectable for tests via distillSession({ judge }).
+
+import { slimTranscript, type SlimEvent } from "./slim.js";
+import { buildDistillerPrompt } from "./prompt.js";
+import { parseObservations } from "./parse.js";
+import { callLlm, distillerModel, distillerEnabled } from "./llm.js";
+import { insertObservation, rawToNewObservation } from "./store.js";
+import { consolidateObservation, type Judge } from "./consolidate.js";
+import { haikuJudge } from "./judge.js";
+import { sweepMemories } from "./maintenance.js";
+
+export interface DistillContext {
+  sessionId: string;
+  repo: string | null;
+  branch: string | null;
+  events: SlimEvent[];
+  judge?: Judge; // injectable; defaults to haikuJudge
+}
+
+export interface DistillOutcome {
+  ran: boolean;
+  observations: number;
+  actions: Record<string, number>; // same|new|refines|contradicts counts
+  reason?: string;
+}
+
+export async function distillSession(ctx: DistillContext): Promise<DistillOutcome> {
+  if (!distillerEnabled()) return { ran: false, observations: 0, actions: {}, reason: "disabled" };
+
+  const slimmed = slimTranscript(ctx.events);
+  if (slimmed.trim().length < 40) {
+    // Nothing worth a model call — an empty/trivial session.
+    return { ran: false, observations: 0, actions: {}, reason: "empty-transcript" };
+  }
+
+  const prompt = buildDistillerPrompt(slimmed);
+  let reply: string;
+  try {
+    reply = await callLlm(prompt, distillerModel());
+  } catch (err) {
+    return { ran: false, observations: 0, actions: {}, reason: `llm-error: ${err instanceof Error ? err.message : String(err)}` };
+  }
+
+  const raws = parseObservations(reply);
+  const judge = ctx.judge ?? haikuJudge;
+  const actions: Record<string, number> = {};
+
+  for (const raw of raws) {
+    const obs = await insertObservation(
+      rawToNewObservation(raw, { repo: ctx.repo, branch: ctx.branch, session_id: ctx.sessionId }),
+    );
+    const res = await consolidateObservation(obs, judge);
+    actions[res.action] = (actions[res.action] ?? 0) + 1;
+  }
+
+  // Cheap maintenance sweep on completion (recency decay → sink under floor).
+  sweepMemories();
+
+  return { ran: true, observations: raws.length, actions };
+}

--- a/orchestrator/src/memory/find-hits.ts
+++ b/orchestrator/src/memory/find-hits.ts
@@ -1,0 +1,86 @@
+// find-hits.ts — the orchestrator half of unified find_entity (Section D).
+//
+// find_entity is a graph verb; memory lives in flow.db. Rather than project
+// memories into the graph index (which would require writing to FalkorDB — the
+// graph is a rebuildable PROJECTION, and we keep flow.db primary), the gateway
+// MERGES memory hits into find_entity results by asking the orchestrator here.
+//
+// This REUSES search.ts's ranking/gating verbatim (meaningful-token FTS + the
+// 0.55 silence gate + family gate) — no forked logic. On top of it we apply the
+// TYPE QUOTA: at most MEMORY_HIT_QUOTA memory hits per query UNLESS the caller
+// passed a type filter (a typed query is deliberately memory-first, so the quota
+// lifts). Batching (qs[]) works because it's just several single calls.
+//
+// Output is terse typed lines the gateway splices into find_entity's match list:
+//   [Memory:gotcha] <headline> (strong) [mem:<id>]
+
+import { searchMemory, type SearchTypeFilter } from "./search.js";
+
+// Max memory hits blended into a single find_entity query's results, unless the
+// query carries a type filter. Small on purpose: find_entity is graph-first; a
+// few memory hits enrich it without drowning the code nodes.
+export const MEMORY_HIT_QUOTA = 3;
+
+const HEADLINE_TRUNC = 100;
+
+export interface MemoryHitLine {
+  type: "memory";
+  kind: string;
+  headline: string;
+  tier: string;
+  id: string; // mem:<uuid>
+  line: string; // the rendered terse line
+}
+
+function trunc(s: string, max: number): string {
+  const t = String(s ?? "").replace(/\s+/g, " ").trim();
+  return t.length > max ? t.slice(0, max - 1) + "…" : t;
+}
+
+// Detect whether a query carries a type: filter — used to decide if the quota
+// applies. (search.ts parses and applies it; we only need to know it's present.)
+function hasTypeFilter(query: string, explicitType?: SearchTypeFilter | null): boolean {
+  if (explicitType) return true;
+  return /(^|\s)type:(memory|ticket|thread)(\s|$)/i.test(query);
+}
+
+// One query → up to quota terse memory-hit lines (quota lifts when typed).
+export async function memoryHitsForQuery(
+  query: string,
+  repo: string | null,
+  opts: { type?: SearchTypeFilter | null; limit?: number } = {},
+): Promise<MemoryHitLine[]> {
+  const typed = hasTypeFilter(query, opts.type);
+  const cap = typed ? (opts.limit ?? 8) : MEMORY_HIT_QUOTA;
+  // Ask search for a few extra so the quota slices from a ranked set.
+  const res = await searchMemory({ query, repo, type: opts.type ?? null, limit: Math.max(cap, MEMORY_HIT_QUOTA) });
+  return res.memories.slice(0, cap).map((m) => {
+    const headline = trunc(m.claim, HEADLINE_TRUNC);
+    return {
+      type: "memory" as const,
+      kind: m.kind,
+      headline,
+      tier: m.strengthTier,
+      id: `mem:${m.id}`,
+      line: `[Memory:${m.kind}] ${headline} (${m.strengthTier}) [mem:${m.id}]`,
+    };
+  });
+}
+
+export interface QueryHits {
+  query: string;
+  hits: MemoryHitLine[];
+}
+
+// Batch form: several queries, grouped in request order (mirrors search batch).
+export async function memoryHitsForQueries(
+  queries: string[],
+  repo: string | null,
+  opts: { type?: SearchTypeFilter | null; limit?: number } = {},
+): Promise<QueryHits[]> {
+  const out: QueryHits[] = [];
+  for (const q of queries) {
+    out.push({ query: q, hits: await memoryHitsForQuery(q, repo, opts) });
+  }
+  return out;
+}

--- a/orchestrator/src/memory/headline.ts
+++ b/orchestrator/src/memory/headline.ts
@@ -163,62 +163,55 @@ export function renderNodeHeadline(h: NodeHeadline): string {
   const lines: string[] = [];
   let budget = HEADLINE_CHAR_CAP;
 
-  // Each section renders as many lines as the SHARED budget allows, then an
-  // overflow "+N more" line if truncated. The overflow line is a working query.
-  const emit = (line: string): boolean => {
-    if (line.length + 1 > budget) return false;
-    lines.push(line);
-    budget -= line.length + 1;
-    return true;
-  };
   const moreLine = (remaining: number, type: string): string =>
     `  +${remaining} more: search_memory node:${h.node_id} type:${type}`;
 
-  // MEMORIES (strength-ranked)
-  if (h.memories.length) {
-    lines.push("MEMORIES:");
-    budget -= "MEMORIES:".length + 1;
-    let shown = 0;
-    for (const m of h.memories) {
-      const glyph = TIER_GLYPH[m.tier] ?? "○";
-      const line = `  ${glyph} ${trunc(m.claim, CLAIM_TRUNC)} [${m.kind}] [mem:${m.id}]`;
-      if (!emit(line)) break;
-      shown++;
-    }
-    if (shown < h.memories.length) emit(moreLine(h.memories.length - shown, "memory"));
-  }
+  // Render one typed section. RESERVES room for a "+N more" line before the last
+  // item that would fit, so the overflow line ALWAYS fits within the cap (a
+  // silently-dropped +N more would be a dead end). Header + blank separator are
+  // charged to the shared budget. Returns nothing; mutates `lines`/`budget`.
+  const renderSection = <T>(header: string, items: T[], type: string, line: (item: T) => string): void => {
+    if (items.length === 0) return;
+    const sep = lines.length ? 1 : 0; // blank line before a non-first section
+    const headerCost = sep + header.length + 1;
+    if (headerCost > budget) return;
+    if (sep) lines.push("");
+    lines.push(header);
+    budget -= headerCost;
 
-  // TICKETS (recency + status)
-  if (h.tickets.length) {
-    if (lines.length) lines.push("");
-    if (lines.length) budget -= 1;
-    lines.push("TICKETS:");
-    budget -= "TICKETS:".length + 1;
     let shown = 0;
-    for (const t of h.tickets) {
-      const status = t.state ? ` (${t.state})` : "";
-      const line = `  ${trunc(t.title, CLAIM_TRUNC)}${status} [lin:${t.identifier}]`;
-      if (!emit(line)) break;
+    for (let i = 0; i < items.length; i++) {
+      const text = line(items[i]);
+      const cost = text.length + 1;
+      const remainingAfter = items.length - (i + 1);
+      // If more items remain, reserve room for the overflow line we'd need next.
+      const reserve = remainingAfter > 0 ? moreLine(remainingAfter, type).length + 1 : 0;
+      if (cost + reserve > budget) break;
+      lines.push(text);
+      budget -= cost;
       shown++;
     }
-    if (shown < h.tickets.length) emit(moreLine(h.tickets.length - shown, "ticket"));
-  }
+    if (shown < items.length) {
+      const ml = moreLine(items.length - shown, type);
+      if (ml.length + 1 <= budget) {
+        lines.push(ml);
+        budget -= ml.length + 1;
+      }
+    }
+  };
 
-  // THREADS (recency)
-  if (h.threads.length) {
-    if (lines.length) lines.push("");
-    if (lines.length) budget -= 1;
-    lines.push("THREADS:");
-    budget -= "THREADS:".length + 1;
-    let shown = 0;
-    for (const th of h.threads) {
-      const link = th.permalink ? ` ${th.permalink}` : "";
-      const line = `  ${trunc(th.text, CLAIM_TRUNC)}${link} [slackthread:${th.ts}]`;
-      if (!emit(line)) break;
-      shown++;
-    }
-    if (shown < h.threads.length) emit(moreLine(h.threads.length - shown, "thread"));
-  }
+  renderSection("MEMORIES:", h.memories, "memory", (m) => {
+    const glyph = TIER_GLYPH[m.tier] ?? "○";
+    return `  ${glyph} ${trunc(m.claim, CLAIM_TRUNC)} [${m.kind}] [mem:${m.id}]`;
+  });
+  renderSection("TICKETS:", h.tickets, "ticket", (t) => {
+    const status = t.state ? ` (${t.state})` : "";
+    return `  ${trunc(t.title, CLAIM_TRUNC)}${status} [lin:${t.identifier}]`;
+  });
+  renderSection("THREADS:", h.threads, "thread", (th) => {
+    const link = th.permalink ? ` ${th.permalink}` : "";
+    return `  ${trunc(th.text, CLAIM_TRUNC)}${link} [slackthread:${th.ts}]`;
+  });
 
   return lines.join("\n");
 }

--- a/orchestrator/src/memory/headline.ts
+++ b/orchestrator/src/memory/headline.ts
@@ -1,0 +1,261 @@
+// headline.ts — the node headline index (Section B). Given a graph node id,
+// return the memories / tickets / threads anchored to it as TYPED, terse
+// headline sections. NO bodies — headlines only. HARD token cap (~300 tokens ≈
+// 1200 chars) across all sections combined; overflow becomes a "+N more" line
+// that is itself a working node-scoped search query.
+//
+// Rendering rules (final):
+//   - Three typed sections, NEVER blended: MEMORIES, TICKETS, THREADS.
+//   - MEMORIES: strength-ranked; tier glyph; one line; claim truncated ~110ch;
+//               id token [mem:<id>].
+//   - TICKETS: recency + status; [lin:<identifier>].
+//   - THREADS: recency; permalink; [slackthread:<ts>].
+//   - Total capped ~1200 chars; when a section overflows, append
+//     "+N more: search_memory node:<node_id> type:<t>".
+//
+// Served FAST: an in-process cache keyed by node id, invalidated on
+// consolidation (see consolidate.ts). Must add <20ms to get_entity — the query
+// is index-backed and the render is pure string work.
+
+import db from "../db.js";
+import { strengthTier } from "./strength.js";
+import { itemsAnchoredToNode } from "./anchors.js";
+
+// ~300 tokens ≈ 1200 chars. Kept as a single budget across sections so the node
+// can gain memories/tickets/threads without the headline growing unbounded.
+export const HEADLINE_CHAR_CAP = 1200;
+const CLAIM_TRUNC = 110;
+// Per-section fetch ceiling — we never need more rows than could fit the budget.
+const SECTION_FETCH = 25;
+
+const TIER_GLYPH: Record<string, string> = { strong: "●", medium: "◐", weak: "○" };
+
+export interface HeadlineMemory {
+  id: string;
+  claim: string;
+  kind: string;
+  strength: number;
+  tier: string;
+}
+export interface HeadlineTicket {
+  identifier: string;
+  title: string;
+  state: string | null;
+  updated_at: number | null;
+}
+export interface HeadlineThread {
+  ts: string;
+  text: string;
+  permalink: string | null;
+  inserted_at: number;
+}
+
+export interface NodeHeadline {
+  node_id: string;
+  memories: HeadlineMemory[];
+  tickets: HeadlineTicket[];
+  threads: HeadlineThread[];
+}
+
+function trunc(s: string, max: number): string {
+  const t = String(s ?? "").replace(/\s+/g, " ").trim();
+  return t.length > max ? t.slice(0, max - 1) + "…" : t;
+}
+
+// Pull the raw attachments for a node from flow.db. Memories are strength-ranked;
+// tickets/threads by recency. Corpus rows are reached via observations anchored
+// to the node (item_type 'observation'), joined to their source table.
+export function nodeHeadline(nodeId: string): NodeHeadline {
+  const anchors = itemsAnchoredToNode(nodeId);
+  const memoryIds = anchors.filter((a) => a.item_type === "memory").map((a) => a.item_id);
+  const observationIds = anchors.filter((a) => a.item_type === "observation").map((a) => a.item_id);
+
+  const memories: HeadlineMemory[] = [];
+  if (memoryIds.length) {
+    const ph = memoryIds.map(() => "?").join(",");
+    const rows = db
+      .prepare(
+        `SELECT id, claim, kind, strength FROM memories
+         WHERE status = 'active' AND id IN (${ph})
+         ORDER BY strength DESC LIMIT ${SECTION_FETCH}`,
+      )
+      .all(...memoryIds) as Array<{ id: string; claim: string; kind: string; strength: number }>;
+    for (const r of rows) {
+      memories.push({ id: r.id, claim: r.claim, kind: r.kind, strength: r.strength, tier: strengthTier(r.strength) });
+    }
+  }
+
+  // Corpus attachments: an anchored observation carries source + source id. We
+  // join back to linear_tickets / slack_messages by matching the observation's
+  // claim text is unreliable — instead corpus observations store no FK, so we
+  // surface tickets/threads whose text the observation was derived from via the
+  // corpus tables directly keyed by the observation's source + repo. To keep
+  // this deterministic and offline, we read the observation's source and, when
+  // it's linear/slack, look up the most recent matching corpus rows in the same
+  // repo family. (A future indexer can store an explicit FK; this is the
+  // pragmatic v1.)
+  const tickets: HeadlineTicket[] = [];
+  const threads: HeadlineThread[] = [];
+  if (observationIds.length) {
+    const ph = observationIds.map(() => "?").join(",");
+    const obs = db
+      .prepare(`SELECT id, source, claim, retrieval_keys FROM observations WHERE id IN (${ph})`)
+      .all(...observationIds) as Array<{ id: string; source: string; claim: string; retrieval_keys: string | null }>;
+    for (const o of obs) {
+      if (o.source === "linear") {
+        // Linear identifier is carried in retrieval_keys or is the leading token.
+        const ident = extractLinearIdentifier(o.retrieval_keys, o.claim);
+        if (ident) {
+          const t = db
+            .prepare(`SELECT identifier, title, state, updated_at FROM linear_tickets WHERE identifier = ? LIMIT 1`)
+            .get(ident) as HeadlineTicket | undefined;
+          if (t && t.identifier) tickets.push(t);
+        }
+      } else if (o.source === "slack") {
+        const ts = extractSlackTs(o.retrieval_keys);
+        if (ts) {
+          const m = db
+            .prepare(`SELECT ts, text, permalink, inserted_at FROM slack_messages WHERE ts = ? LIMIT 1`)
+            .get(ts) as HeadlineThread | undefined;
+          if (m && m.ts) threads.push(m);
+        }
+      }
+    }
+  }
+  tickets.sort((a, b) => (b.updated_at ?? 0) - (a.updated_at ?? 0));
+  threads.sort((a, b) => (b.inserted_at ?? 0) - (a.inserted_at ?? 0));
+  return { node_id: nodeId, memories, tickets, threads };
+}
+
+function parseKeys(s: string | null): string[] {
+  if (!s) return [];
+  try {
+    const v = JSON.parse(s);
+    return Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+// Linear identifiers look like ACME-123.
+export function extractLinearIdentifier(retrievalKeys: string | null, claim: string): string | null {
+  for (const k of parseKeys(retrievalKeys)) {
+    const m = k.match(/^[A-Z][A-Z0-9]+-\d+$/);
+    if (m) return m[0];
+  }
+  const m = claim.match(/\b[A-Z][A-Z0-9]+-\d+\b/);
+  return m ? m[0] : null;
+}
+
+// Slack ts keys are stored as "ts:1712345678.001" or a bare "1712.." float.
+export function extractSlackTs(retrievalKeys: string | null): string | null {
+  for (const k of parseKeys(retrievalKeys)) {
+    const m = k.match(/^(?:ts:)?(\d{6,}\.\d+)$/);
+    if (m) return m[1];
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Render — typed sections, hard char cap, "+N more" overflow lines.
+
+export function renderNodeHeadline(h: NodeHeadline): string {
+  const lines: string[] = [];
+  let budget = HEADLINE_CHAR_CAP;
+
+  // Each section renders as many lines as the SHARED budget allows, then an
+  // overflow "+N more" line if truncated. The overflow line is a working query.
+  const emit = (line: string): boolean => {
+    if (line.length + 1 > budget) return false;
+    lines.push(line);
+    budget -= line.length + 1;
+    return true;
+  };
+  const moreLine = (remaining: number, type: string): string =>
+    `  +${remaining} more: search_memory node:${h.node_id} type:${type}`;
+
+  // MEMORIES (strength-ranked)
+  if (h.memories.length) {
+    lines.push("MEMORIES:");
+    budget -= "MEMORIES:".length + 1;
+    let shown = 0;
+    for (const m of h.memories) {
+      const glyph = TIER_GLYPH[m.tier] ?? "○";
+      const line = `  ${glyph} ${trunc(m.claim, CLAIM_TRUNC)} [${m.kind}] [mem:${m.id}]`;
+      if (!emit(line)) break;
+      shown++;
+    }
+    if (shown < h.memories.length) emit(moreLine(h.memories.length - shown, "memory"));
+  }
+
+  // TICKETS (recency + status)
+  if (h.tickets.length) {
+    if (lines.length) lines.push("");
+    if (lines.length) budget -= 1;
+    lines.push("TICKETS:");
+    budget -= "TICKETS:".length + 1;
+    let shown = 0;
+    for (const t of h.tickets) {
+      const status = t.state ? ` (${t.state})` : "";
+      const line = `  ${trunc(t.title, CLAIM_TRUNC)}${status} [lin:${t.identifier}]`;
+      if (!emit(line)) break;
+      shown++;
+    }
+    if (shown < h.tickets.length) emit(moreLine(h.tickets.length - shown, "ticket"));
+  }
+
+  // THREADS (recency)
+  if (h.threads.length) {
+    if (lines.length) lines.push("");
+    if (lines.length) budget -= 1;
+    lines.push("THREADS:");
+    budget -= "THREADS:".length + 1;
+    let shown = 0;
+    for (const th of h.threads) {
+      const link = th.permalink ? ` ${th.permalink}` : "";
+      const line = `  ${trunc(th.text, CLAIM_TRUNC)}${link} [slackthread:${th.ts}]`;
+      if (!emit(line)) break;
+      shown++;
+    }
+    if (shown < h.threads.length) emit(moreLine(h.threads.length - shown, "thread"));
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// In-process cache — keyed by node id, invalidated on consolidation. The
+// rendered string is cached (that's what get_entity ships) so a repeat fetch is
+// a Map hit. Empty headline (no attachments) is cached too — an unanchored node
+// shouldn't re-query flow.db every get_entity.
+
+const _cache = new Map<string, { rendered: string; headline: NodeHeadline }>();
+
+export function invalidateHeadlineCache(nodeId?: string): void {
+  if (nodeId === undefined) _cache.clear();
+  else _cache.delete(nodeId);
+}
+
+export interface HeadlineResult {
+  node_id: string;
+  rendered: string;
+  hasAttachments: boolean;
+  counts: { memories: number; tickets: number; threads: number };
+}
+
+export function getNodeHeadline(nodeId: string): HeadlineResult {
+  let entry = _cache.get(nodeId);
+  if (!entry) {
+    const headline = nodeHeadline(nodeId);
+    entry = { rendered: renderNodeHeadline(headline), headline };
+    _cache.set(nodeId, entry);
+  }
+  const h = entry.headline;
+  const hasAttachments = h.memories.length + h.tickets.length + h.threads.length > 0;
+  return {
+    node_id: nodeId,
+    rendered: entry.rendered,
+    hasAttachments,
+    counts: { memories: h.memories.length, tickets: h.tickets.length, threads: h.threads.length },
+  };
+}

--- a/orchestrator/src/memory/judge.ts
+++ b/orchestrator/src/memory/judge.ts
@@ -1,0 +1,35 @@
+// judge.ts — the consolidation judge (claude-haiku-4-5). Given an existing
+// memory's canonical claim and a new observation's claim (both above the T_LO
+// cosine band), decide EXACTLY ONE of: same | new | refines | contradicts.
+//
+// This is the eval-calibrated action classifier (98.6% action accuracy). It is
+// wired as the default Judge for consolidateObservation; tests inject a fake
+// Judge instead and never reach this code.
+
+import type { Judge } from "./consolidate.js";
+import { callLlm, judgeModel } from "./llm.js";
+
+const JUDGE_PROMPT = `You compare two knowledge claims about a codebase and decide their relationship. Output EXACTLY ONE word, nothing else:
+
+- same        — B restates A (same fact, possibly reworded). No new information.
+- refines     — B is A made more precise, more correct, or more complete (a strict improvement of the SAME claim). If you pick this, you may also improve the wording.
+- contradicts — B asserts something that CANNOT both be true with A. Opposite decisions, negations, reversed conclusions. Be alert: a negation ("we do NOT use X") of A ("we use X") is CONTRADICTS, never same.
+- new         — B is about a genuinely different fact; it only happened to sound similar.
+
+Respond with only one of: same | refines | contradicts | new`;
+
+function parseVerdict(reply: string): "same" | "new" | "refines" | "contradicts" {
+  const t = reply.toLowerCase();
+  // Order matters: check contradicts before "new"/"same" substrings collide.
+  if (/\bcontradict/.test(t)) return "contradicts";
+  if (/\brefine/.test(t)) return "refines";
+  if (/\bsame\b/.test(t)) return "same";
+  return "new";
+}
+
+export const haikuJudge: Judge = async (a, b) => {
+  const prompt =
+    `${JUDGE_PROMPT}\n\nA (existing memory): ${a.claim}\n\nB (new observation): ${b.claim}\n\nRelationship:`;
+  const reply = await callLlm(prompt, judgeModel());
+  return { verdict: parseVerdict(reply) };
+};

--- a/orchestrator/src/memory/llm.ts
+++ b/orchestrator/src/memory/llm.ts
@@ -1,0 +1,60 @@
+// llm.ts — one narrow wrapper around a single-shot `claude -p` CLI call, used by
+// the distiller (one call per session) and the consolidation judge (one call
+// per above-threshold observation). No tools, JSON output, env-overridable model.
+//
+// The transport is INJECTABLE (setLlmTransport) so tests run entirely offline —
+// no CLI is spawned. Set FLOW_DISTILLER=0 to hard-disable the distiller path.
+//
+// Real transport: spawn the locally-installed `claude` executable with
+//   claude -p "<prompt>" --model <model> --output-format json
+// and return the `.result` string from the CLI's JSON envelope.
+
+import { execFile } from "node:child_process";
+import { resolveLocalExecutable } from "../agents/runtime.js";
+
+export const DISTILLER_MODEL_DEFAULT = "claude-sonnet-4-6";
+export const JUDGE_MODEL_DEFAULT = "claude-haiku-4-5";
+
+export function distillerModel(): string {
+  return process.env.DISTILLER_MODEL || DISTILLER_MODEL_DEFAULT;
+}
+export function judgeModel(): string {
+  return process.env.DISTILLER_JUDGE_MODEL || JUDGE_MODEL_DEFAULT;
+}
+
+export function distillerEnabled(): boolean {
+  return process.env.FLOW_DISTILLER !== "0";
+}
+
+// A transport takes a prompt + model and returns the model's raw text reply.
+export type LlmTransport = (prompt: string, model: string) => Promise<string>;
+
+// Real CLI transport. Returns the `.result` field of `--output-format json`.
+const cliTransport: LlmTransport = async (prompt, model) => {
+  const bin = (await resolveLocalExecutable("claude")) ?? "claude";
+  return await new Promise<string>((resolve, reject) => {
+    execFile(
+      bin,
+      ["-p", prompt, "--model", model, "--output-format", "json"],
+      { maxBuffer: 16 * 1024 * 1024, timeout: 120_000 },
+      (err, stdout) => {
+        if (err) return reject(err);
+        try {
+          const env = JSON.parse(stdout) as { result?: string };
+          resolve(typeof env.result === "string" ? env.result : stdout);
+        } catch {
+          // Not the JSON envelope — return raw stdout (parser is tolerant).
+          resolve(stdout);
+        }
+      },
+    );
+  });
+};
+
+let _transport: LlmTransport = cliTransport;
+export function setLlmTransport(fn: LlmTransport): void {
+  _transport = fn;
+}
+export function callLlm(prompt: string, model: string): Promise<string> {
+  return _transport(prompt, model);
+}

--- a/orchestrator/src/memory/maintenance.ts
+++ b/orchestrator/src/memory/maintenance.ts
@@ -6,6 +6,7 @@ import db from "../db.js";
 import { computeStrength, STRENGTH_FLOOR } from "./strength.js";
 import type { MemoryRow } from "./store.js";
 import { invalidateVectorCache } from "./store.js";
+import { invalidateHeadlineCache } from "./headline.js";
 
 export function sweepMemories(now = Math.floor(Date.now() / 1000)): { recomputed: number; sunk: number } {
   const rows = db.prepare(`SELECT * FROM memories WHERE status = 'active'`).all() as MemoryRow[];
@@ -28,5 +29,8 @@ export function sweepMemories(now = Math.floor(Date.now() / 1000)): { recomputed
   });
   tx();
   invalidateVectorCache();
+  // Strengths (and thus headline ranking + which memories are active) moved —
+  // drop the whole headline cache so get_entity re-renders fresh.
+  invalidateHeadlineCache();
   return { recomputed: rows.length, sunk };
 }

--- a/orchestrator/src/memory/maintenance.ts
+++ b/orchestrator/src/memory/maintenance.ts
@@ -1,0 +1,32 @@
+// maintenance.ts — cheap decay sweep, run on distill completion. Recomputes
+// each active memory's strength (recency decays it) and sinks any that fall
+// below STRENGTH_FLOOR to status 'sunk'. Pure code, no LLM, no embeddings.
+
+import db from "../db.js";
+import { computeStrength, STRENGTH_FLOOR } from "./strength.js";
+import type { MemoryRow } from "./store.js";
+import { invalidateVectorCache } from "./store.js";
+
+export function sweepMemories(now = Math.floor(Date.now() / 1000)): { recomputed: number; sunk: number } {
+  const rows = db.prepare(`SELECT * FROM memories WHERE status = 'active'`).all() as MemoryRow[];
+  const update = db.prepare(`UPDATE memories SET strength = ?, status = ?, updated_at = unixepoch() WHERE id = ?`);
+  let sunk = 0;
+  const tx = db.transaction(() => {
+    for (const m of rows) {
+      const strength = computeStrength({
+        people_count: m.people_count,
+        evidence_count: m.evidence_count,
+        max_source_weight: m.max_source_weight,
+        contradiction_count: m.contradiction_count,
+        last_reinforced_at: m.last_reinforced_at ?? m.created_at,
+        now,
+      });
+      const status = strength < STRENGTH_FLOOR ? "sunk" : "active";
+      if (status === "sunk") sunk++;
+      update.run(strength, status, m.id);
+    }
+  });
+  tx();
+  invalidateVectorCache();
+  return { recomputed: rows.length, sunk };
+}

--- a/orchestrator/src/memory/parse.ts
+++ b/orchestrator/src/memory/parse.ts
@@ -1,0 +1,104 @@
+// parse.ts — robustly pull the distiller's JSON array out of a model reply.
+// Adapted from flow-benchmarks/memory-evals/distiller/parse.mjs.
+//
+// Handles: markdown fences, leading prose, and the "[] then reconsider then the
+// real array" pattern — we scan for every TOP-LEVEL [...] block and take the
+// LAST one that parses as an array. Also validates each element into a typed
+// RawObservation, dropping malformed ones rather than throwing.
+
+export type ObservationKind = "decision" | "constraint" | "gotcha" | "how_to" | "preference" | "plan";
+export type ObservationSource = "user_stated" | "agent_inferred" | "error_proven";
+
+export interface RawObservation {
+  claim: string;
+  kind: ObservationKind;
+  context: { repo?: string; branch?: string; files?: string[] };
+  source: ObservationSource;
+  retrieval_keys: string[];
+}
+
+const KINDS: ReadonlySet<string> = new Set(["decision", "constraint", "gotcha", "how_to", "preference", "plan"]);
+const SOURCES: ReadonlySet<string> = new Set(["user_stated", "agent_inferred", "error_proven"]);
+
+// Return every top-level bracket block, then take the LAST that JSON-parses to
+// an array. Returns [] when nothing parses (an empty array is a valid answer).
+export function extractArray(result: string): unknown[] {
+  if (typeof result !== "string") return [];
+  const s = result.trim();
+  const candidates: string[] = [];
+  let depth = 0;
+  let start = -1;
+  let inStr = false;
+  let esc = false;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (c === "\\") esc = true;
+      else if (c === '"') inStr = false;
+      continue;
+    }
+    if (c === '"') {
+      inStr = true;
+      continue;
+    }
+    if (c === "[") {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (c === "]") {
+      depth--;
+      if (depth === 0 && start >= 0) {
+        candidates.push(s.slice(start, i + 1));
+        start = -1;
+      }
+    }
+  }
+  for (let i = candidates.length - 1; i >= 0; i--) {
+    try {
+      const parsed = JSON.parse(candidates[i]);
+      if (Array.isArray(parsed)) return parsed;
+    } catch {
+      /* try previous candidate */
+    }
+  }
+  return [];
+}
+
+function toStringArray(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  return v.filter((x): x is string => typeof x === "string" && x.trim().length > 0).map((x) => x.trim());
+}
+
+// Validate one raw element into a RawObservation, or null if unusable.
+export function validateObservation(raw: unknown): RawObservation | null {
+  if (!raw || typeof raw !== "object") return null;
+  const o = raw as Record<string, unknown>;
+  const claim = typeof o.claim === "string" ? o.claim.trim() : "";
+  if (!claim) return null;
+  const kind = KINDS.has(o.kind as string) ? (o.kind as ObservationKind) : null;
+  if (!kind) return null;
+  const source = SOURCES.has(o.source as string) ? (o.source as ObservationSource) : "agent_inferred";
+  const ctx = (o.context ?? {}) as Record<string, unknown>;
+  return {
+    claim,
+    kind,
+    source,
+    context: {
+      repo: typeof ctx.repo === "string" ? ctx.repo : undefined,
+      branch: typeof ctx.branch === "string" ? ctx.branch : undefined,
+      files: toStringArray(ctx.files),
+    },
+    retrieval_keys: toStringArray(o.retrieval_keys),
+  };
+}
+
+// Parse a full model reply into a validated observation list.
+export function parseObservations(modelReply: string): RawObservation[] {
+  const arr = extractArray(modelReply);
+  const out: RawObservation[] = [];
+  for (const el of arr) {
+    const v = validateObservation(el);
+    if (v) out.push(v);
+  }
+  return out;
+}

--- a/orchestrator/src/memory/prompt.ts
+++ b/orchestrator/src/memory/prompt.ts
@@ -1,0 +1,66 @@
+// prompt.ts — the distiller system+task prompt. Based on the eval-calibrated
+// prompt (95.7% precision) at flow-benchmarks/memory-evals/distiller/prompt.md,
+// with the three graded fixes applied inline (see FIX markers):
+//   (a) explicitly ban session-state / progress / todo claims
+//   (b) volatile model/vendor/version choices must be source=agent_inferred and
+//       phrased as point-in-time, never welded into durable how-tos
+//   (c) output contract = exactly one JSON array, nothing else
+// Plus: retrieval_keys must include symptom-shaped strings (verbatim error
+// snippets) when present.
+
+export const DISTILLER_PROMPT = `You are Flow's session distiller. Flow is a knowledge-graph + memory system for codebases. At the end of a coding session, you read a (slimmed) transcript and extract DURABLE MEMORIES: reusable knowledge that a future agent working on THIS repository would genuinely want surfaced before it starts work.
+
+You will be given a slimmed transcript. It contains the session's user prompts (verbatim), the concluding agent message of each turn, failed-tool titles with error heads, and error events. The middle of long agent turns is omitted — the conclusions are what matter.
+
+## What to extract
+
+Extract 0 to 5 observations. Fewer is better. MOST routine sessions yield 0-2. A session that just edited some files, answered a lookup question, or did mechanical work yields an empty array. Only extract something if you would bet it will still be true and useful weeks from now.
+
+Each observation is an object:
+{
+  "claim": "1-2 self-contained sentences. Must stand alone without the transcript. State the durable fact, decision, or rule.",
+  "kind": "decision | constraint | gotcha | how_to | preference | plan",
+  "context": { "repo": "<repo name>", "branch": "<branch if known, else omit>", "files": ["<paths central to the claim>"] },
+  "source": "user_stated | agent_inferred | error_proven",
+  "retrieval_keys": ["5-10 short strings: file paths, error symptoms (INCLUDE VERBATIM ERROR SNIPPETS when present), command names, and ALTERNATE PHRASINGS a future agent might search for"]
+}
+
+kind guide:
+- decision: a chosen approach / architecture / tradeoff that was settled ("we use X not Y because Z").
+- constraint: a hard limitation of the system/environment that bounds future work.
+- gotcha: a non-obvious trap, failure mode, or surprising behavior (including dead-ends that were tried and abandoned).
+- how_to: a reusable procedure/recipe for accomplishing something in this repo.
+- preference: a stated way the human wants things done (style, workflow, tooling).
+- plan: a committed future intention not yet executed ("next we will…").
+
+source guide:
+- user_stated: the human explicitly asserted it.
+- error_proven: an error/failed tool in the transcript demonstrated it.
+- agent_inferred: the agent concluded it from investigation (use sparingly; be more skeptical of these).
+
+## HARD RULES
+
+1. CONCLUSIONS OVER MID-SESSION BELIEFS. If the session started with a hypothesis and reversed it, record ONLY the final conclusion. You may record the abandoned path as a \`gotcha\` ("X was tried and does not work because…") but NEVER record the discarded belief as if still true.
+2. RETURN [] WHEN NOTHING IS DURABLE. An empty array is the correct and common answer. Do not invent memories to fill quota.
+3. NO SESSION TRIVIA. Never record "edited file X", "the agent read Y", "ran the tests", "created a PR", "user said thanks". Only reusable knowledge. Ask: "would this help a DIFFERENT future task on this repo?" If no, drop it.
+4. NO SESSION STATE OR PROGRESS. Never record the current status of THIS task, a todo list, "still need to…", "next step is to finish…", what is done vs remaining, or anything describing where this session left off. Those are session bookkeeping, not durable knowledge — they are stale the moment the session ends. (A committed future DECISION about the project is a \`plan\`; a leftover task checkbox is not.)
+5. VOLATILE CHOICES ARE POINT-IN-TIME, NOT DURABLE RECIPES. Any claim about a specific model, vendor, library version, pricing, or API-shape that changes over time MUST be source "agent_inferred" and phrased as a point-in-time observation ("as of this session, X was Y"). NEVER weld a volatile choice into a durable how_to (write the stable procedure; leave the swappable specific out or mark it as of-now).
+6. NO SECRETS. Never extract tokens, API keys, passwords, connection strings, or personal contact info. If a claim requires a secret to be useful, drop it.
+7. SELF-CONTAINED CLAIMS. A claim that only makes sense with the transcript open is useless. Resolve pronouns and "this/that". Name the actual thing.
+8. PREFER user_stated and error_proven over agent_inferred. Speculation is noise.
+9. DEDUPE. If two observations say the same thing, merge into one.
+10. Do NOT extract generic software knowledge true of all repos (e.g. "restart the server after config changes"). Only repo-specific durable facts.
+
+## OUTPUT CONTRACT
+
+Output EXACTLY ONE strict JSON array (possibly empty) and NOTHING ELSE. No prose, no markdown fences, no commentary, no second array, no reconsideration. Your entire response must be parseable as a single JSON array. Each element must have exactly the keys shown above (branch optional).
+
+---
+
+TRANSCRIPT:
+
+`;
+
+export function buildDistillerPrompt(slimmedTranscript: string): string {
+  return DISTILLER_PROMPT + slimmedTranscript + "\n";
+}

--- a/orchestrator/src/memory/repo-family.ts
+++ b/orchestrator/src/memory/repo-family.ts
@@ -1,0 +1,56 @@
+// repo-family.ts — normalize a repo name into its "family".
+//
+// Memory retrieval hard-gates on repo_family: a memory from `acme-backend` is
+// eligible for a query on `acme-frontend` (same product) but NOT for `other`.
+// We strip common component suffixes so the family is the product, not the tier.
+// Also strips owner prefix (owner/repo -> repo) and a trailing .git.
+//
+// A NULL/empty family means "match-all" (corpus rows we couldn't attribute to a
+// repo) — the gate treats null as matching every query's family.
+
+const SUFFIXES = [
+  "backend",
+  "frontend",
+  "api",
+  "server",
+  "client",
+  "web",
+  "app",
+  "service",
+  "svc",
+  "ui",
+  "worker",
+  "core",
+  "lib",
+  "sdk",
+  "infra",
+  "mobile",
+];
+
+export function repoFamily(repo: string | null | undefined): string | null {
+  if (!repo) return null;
+  let name = String(repo).trim().toLowerCase();
+  if (!name) return null;
+  // owner/repo -> repo
+  const slash = name.lastIndexOf("/");
+  if (slash >= 0) name = name.slice(slash + 1);
+  // trailing .git
+  name = name.replace(/\.git$/, "");
+  // strip ONE trailing component suffix separated by - or _
+  for (const s of SUFFIXES) {
+    const re = new RegExp(`[-_]${s}$`);
+    if (re.test(name)) {
+      name = name.replace(re, "");
+      break;
+    }
+  }
+  return name || null;
+}
+
+// Family gate: does a memory/observation with family `memFamily` match a query
+// scoped to `queryFamily`? Null on EITHER side means match-all (unattributed
+// corpus, or a query with no repo). Otherwise exact family equality.
+export function familyMatches(queryFamily: string | null, memFamily: string | null): boolean {
+  if (!queryFamily || !memFamily) return true;
+  return queryFamily === memFamily;
+}

--- a/orchestrator/src/memory/routes.ts
+++ b/orchestrator/src/memory/routes.ts
@@ -1,0 +1,51 @@
+// routes.ts — HTTP surface for memory v1. The gateway's search_memory verb
+// proxies here (the memories + embeddings + FTS all live in the orchestrator's
+// flow.db; the gateway is a thin proxy, matching the note/correct_graph shape).
+//
+//   POST /v1/memory/search  {query, repo?, limit?} → {lines, memories, corpus, durationMs}
+//   GET  /v1/memory/stats                          → counts per source (for orient)
+
+import type { FastifyInstance } from "fastify";
+import db from "../db.js";
+import { searchMemory, renderSearchResult } from "./search.js";
+
+export interface MemoryStats {
+  memories: number;
+  observations: number;
+  bySource: Record<string, number>;
+}
+
+export function memoryStats(): MemoryStats {
+  const mem = db.prepare(`SELECT COUNT(*) AS n FROM memories WHERE status = 'active'`).get() as { n: number };
+  const obs = db.prepare(`SELECT COUNT(*) AS n FROM observations`).get() as { n: number };
+  const rows = db
+    .prepare(`SELECT source, COUNT(*) AS n FROM observations GROUP BY source`)
+    .all() as Array<{ source: string; n: number }>;
+  const bySource: Record<string, number> = {};
+  for (const r of rows) bySource[r.source] = r.n;
+  return { memories: mem.n, observations: obs.n, bySource };
+}
+
+export function registerMemoryRoutes(app: FastifyInstance): void {
+  app.post<{ Body: { query?: string; repo?: string | null; limit?: number } }>(
+    "/v1/memory/search",
+    async (req, reply) => {
+      const b = req.body ?? {};
+      if (!b.query || !String(b.query).trim()) {
+        return reply.code(400).send({ error: "query is required" });
+      }
+      const res = await searchMemory({ query: String(b.query), repo: b.repo ?? null, limit: b.limit });
+      // Log latency to the activity stream (stdout) — the retrieval budget is
+      // <300ms; a slow call is a signal worth seeing.
+      console.log(`[memory] search "${String(b.query).slice(0, 60)}" → ${res.memories.length}m/${res.corpus.length}c in ${res.durationMs}ms`);
+      return reply.send({
+        lines: renderSearchResult(res),
+        memories: res.memories,
+        corpus: res.corpus,
+        durationMs: res.durationMs,
+      });
+    },
+  );
+
+  app.get("/v1/memory/stats", async () => memoryStats());
+}

--- a/orchestrator/src/memory/routes.ts
+++ b/orchestrator/src/memory/routes.ts
@@ -5,6 +5,11 @@
 //   POST /v1/memory/search  {query, repo?, limit?}   → {lines, memories, corpus, durationMs}
 //                           {queries:[…], repo?, limit?} → {lines, groups, durationMs} (batch)
 //   GET  /v1/memory/stats                            → counts per source (for orient)
+//   GET  /v1/memory/headline/:nodeId                 → node headline index (Section B)
+//   GET  /v1/memory/card/:type/:id                   → drill-down card (Section C)
+//   POST /v1/memory/hits    {query|queries, repo?, limit?} → find_entity memory
+//                                                     merge (Section D): typed
+//                                                     terse lines + quota.
 
 import type { FastifyInstance } from "fastify";
 import db from "../db.js";
@@ -15,6 +20,9 @@ import {
   renderBatchSearchResult,
   SEARCH_MEMORY_MAX_BATCH,
 } from "./search.js";
+import { getNodeHeadline } from "./headline.js";
+import { getCard } from "./cards.js";
+import { memoryHitsForQueries, MEMORY_HIT_QUOTA } from "./find-hits.js";
 
 export interface MemoryStats {
   memories: number;
@@ -76,4 +84,44 @@ export function registerMemoryRoutes(app: FastifyInstance): void {
   );
 
   app.get("/v1/memory/stats", async () => memoryStats());
+
+  // Node headline index (Section B). Served from the in-process cache; the
+  // gateway appends `rendered` to get_entity output. Fast (<20ms target): an
+  // index-backed read + a cached render.
+  app.get<{ Params: { nodeId: string } }>("/v1/memory/headline/:nodeId", async (req) => {
+    const nodeId = decodeURIComponent(req.params.nodeId);
+    return getNodeHeadline(nodeId);
+  });
+
+  // Drill-down cards (Section C). type ∈ {mem,obs,lin,slackthread}. The gateway
+  // resolves these id namespaces in get_entity (single + batch ids[]) by calling
+  // here — flow.db owns the store, so it's one indexed lookup, no graph hop.
+  app.get<{ Params: { type: string; id: string } }>("/v1/memory/card/:type/:id", async (req, reply) => {
+    const card = getCard(req.params.type, decodeURIComponent(req.params.id));
+    if (card.status === "not_found") return reply.code(404).send(card);
+    return card;
+  });
+
+  // find_entity memory merge (Section D). Returns typed terse lines the gateway
+  // splices into find_entity results, with the type quota already applied.
+  app.post<{ Body: { query?: string; queries?: string[]; repo?: string | null; limit?: number } }>(
+    "/v1/memory/hits",
+    async (req, reply) => {
+      const b = req.body ?? {};
+      const repo = b.repo ?? null;
+      if (b.queries !== undefined) {
+        if (!Array.isArray(b.queries)) return reply.code(400).send({ error: "queries must be an array of strings" });
+        const queries = b.queries.map((q) => String(q ?? "").trim()).filter(Boolean);
+        if (queries.length === 0) return reply.code(400).send({ error: "queries is empty" });
+        if (queries.length > SEARCH_MEMORY_MAX_BATCH) {
+          return reply.code(400).send({ error: `too many queries (${queries.length}); max ${SEARCH_MEMORY_MAX_BATCH}` });
+        }
+        const groups = await memoryHitsForQueries(queries, repo, { limit: b.limit });
+        return reply.send({ quota: MEMORY_HIT_QUOTA, groups });
+      }
+      if (!b.query || !String(b.query).trim()) return reply.code(400).send({ error: "query is required" });
+      const groups = await memoryHitsForQueries([String(b.query)], repo, { limit: b.limit });
+      return reply.send({ quota: MEMORY_HIT_QUOTA, hits: groups[0].hits });
+    },
+  );
 }

--- a/orchestrator/src/memory/routes.ts
+++ b/orchestrator/src/memory/routes.ts
@@ -2,12 +2,19 @@
 // proxies here (the memories + embeddings + FTS all live in the orchestrator's
 // flow.db; the gateway is a thin proxy, matching the note/correct_graph shape).
 //
-//   POST /v1/memory/search  {query, repo?, limit?} → {lines, memories, corpus, durationMs}
-//   GET  /v1/memory/stats                          → counts per source (for orient)
+//   POST /v1/memory/search  {query, repo?, limit?}   → {lines, memories, corpus, durationMs}
+//                           {queries:[…], repo?, limit?} → {lines, groups, durationMs} (batch)
+//   GET  /v1/memory/stats                            → counts per source (for orient)
 
 import type { FastifyInstance } from "fastify";
 import db from "../db.js";
-import { searchMemory, renderSearchResult } from "./search.js";
+import {
+  searchMemory,
+  searchMemoryBatch,
+  renderSearchResult,
+  renderBatchSearchResult,
+  SEARCH_MEMORY_MAX_BATCH,
+} from "./search.js";
 
 export interface MemoryStats {
   memories: number;
@@ -27,10 +34,31 @@ export function memoryStats(): MemoryStats {
 }
 
 export function registerMemoryRoutes(app: FastifyInstance): void {
-  app.post<{ Body: { query?: string; repo?: string | null; limit?: number } }>(
+  app.post<{ Body: { query?: string; queries?: string[]; repo?: string | null; limit?: number } }>(
     "/v1/memory/search",
     async (req, reply) => {
       const b = req.body ?? {};
+
+      // Batch form: {queries:[…]}. Grouped, order-preserved. Empty/blank query
+      // strings are dropped before dispatch; the cap is a hard 400 (a clear
+      // failure the caller can act on beats a silent truncation).
+      if (b.queries !== undefined) {
+        if (!Array.isArray(b.queries)) return reply.code(400).send({ error: "queries must be an array of strings" });
+        const queries = b.queries.map((q) => String(q ?? "").trim()).filter(Boolean);
+        if (queries.length === 0) return reply.code(400).send({ error: "queries is empty" });
+        if (queries.length > SEARCH_MEMORY_MAX_BATCH) {
+          return reply.code(400).send({ error: `too many queries (${queries.length}); max ${SEARCH_MEMORY_MAX_BATCH} per call` });
+        }
+        const res = await searchMemoryBatch({ queries, repo: b.repo ?? null, limit: b.limit });
+        const total = res.groups.reduce((n, g) => n + g.result.memories.length + g.result.corpus.length, 0);
+        console.log(`[memory] batch search ${queries.length}q → ${total} hits in ${res.durationMs}ms`);
+        return reply.send({
+          lines: renderBatchSearchResult(res),
+          groups: res.groups,
+          durationMs: res.durationMs,
+        });
+      }
+
       if (!b.query || !String(b.query).trim()) {
         return reply.code(400).send({ error: "query is required" });
       }

--- a/orchestrator/src/memory/search.ts
+++ b/orchestrator/src/memory/search.ts
@@ -46,11 +46,43 @@ export interface SearchResult {
   durationMs: number;
 }
 
-// Escape a free-text query for FTS5 MATCH: quote each token so punctuation-heavy
-// identifiers/error snippets don't blow up the FTS parser. Empty → no FTS.
+// Filler words a keyword search must ignore. The point (per the grep analogy):
+// a model searching memory keys on meaningful strings, not whole sentences — so
+// a natural-language query like "…images ON a landing page" must NOT match a
+// memory merely because both contain "on". Without this, common-token FTS hits
+// bypass the silence gate and every query returns noise. This is NOT about
+// negation — "not"/"no" are dropped here because FTS never carries meaning;
+// the agent reads the claim text to see whether a memory says always vs never.
+const STOPWORDS = new Set([
+  "a", "an", "and", "are", "as", "at", "be", "been", "but", "by", "can", "could",
+  "did", "do", "does", "for", "from", "get", "gets", "got", "had", "has", "have",
+  "how", "i", "if", "in", "into", "is", "it", "its", "me", "my", "no", "not", "of",
+  "on", "or", "our", "out", "over", "so", "than", "that", "the", "their", "them",
+  "then", "there", "they", "this", "to", "up", "us", "was", "we", "were", "what",
+  "when", "where", "which", "while", "will", "with", "would", "you", "your", "about",
+  "all", "any", "just", "like", "some", "such", "via", "using", "use", "should",
+]);
+
+// Meaningful search tokens, grep-style: keep identifiers/paths/error snippets
+// (anything with a code char) at any length; keep plain words that aren't filler;
+// drop everything else. Lowercased for matching.
+export function meaningfulTokens(query: string): string[] {
+  const raw = query.match(/[A-Za-z0-9_./:-]+/g) ?? [];
+  const out: string[] = [];
+  for (const t of raw) {
+    const lower = t.toLowerCase();
+    const hasCodeChar = /[_./:-]/.test(t) || /\d/.test(t);
+    if (hasCodeChar) { out.push(lower); continue; }
+    if (lower.length >= 2 && !STOPWORDS.has(lower)) out.push(lower);
+  }
+  return out;
+}
+
+// Escape meaningful tokens for FTS5 MATCH: quote each so punctuation-heavy
+// identifiers/error snippets don't blow up the parser. Empty → no FTS (and thus
+// no keyword bypass of the silence gate — a filler-only query stays silent).
 function ftsQuery(query: string): string {
-  const tokens = query.match(/[A-Za-z0-9_./:-]+/g) ?? [];
-  const quoted = tokens.filter((t) => t.length >= 2).map((t) => `"${t.replace(/"/g, '""')}"`);
+  const quoted = meaningfulTokens(query).map((t) => `"${t.replace(/"/g, '""')}"`);
   return quoted.join(" OR ");
 }
 
@@ -83,7 +115,7 @@ export async function searchMemory(input: SearchInput): Promise<SearchResult> {
   const t0 = Date.now();
   const limit = Math.max(1, Math.min(50, input.limit ?? 8));
   const queryFamily = repoFamily(input.repo);
-  const queryTokens = (input.query.match(/[A-Za-z0-9_./:-]+/g) ?? []).map((t) => t.toLowerCase());
+  const queryTokens = meaningfulTokens(input.query);
 
   // --- FTS candidate ids (always eligible past the silence gate) ---
   const ftsIds = new Set<string>();

--- a/orchestrator/src/memory/search.ts
+++ b/orchestrator/src/memory/search.ts
@@ -201,6 +201,46 @@ export async function searchMemory(input: SearchInput): Promise<SearchResult> {
   };
 }
 
+// Batch search: run several queries in one call, reusing the single-query core
+// per query so ranking/gating logic is never forked. Results are grouped and
+// kept in REQUEST ORDER. Concurrency is bounded — each query is a full FTS +
+// vector pass, so a small pool keeps a batch from monopolizing the event loop.
+export const SEARCH_MEMORY_MAX_BATCH = 10;
+const BATCH_CONCURRENCY = 4;
+
+export interface BatchSearchInput {
+  queries: string[];
+  repo?: string | null;
+  limit?: number;
+}
+
+export interface SearchGroup {
+  query: string;
+  result: SearchResult;
+}
+
+export interface BatchSearchResult {
+  groups: SearchGroup[];
+  durationMs: number;
+}
+
+export async function searchMemoryBatch(input: BatchSearchInput): Promise<BatchSearchResult> {
+  const t0 = Date.now();
+  const queries = input.queries;
+  const groups: SearchGroup[] = new Array(queries.length);
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(BATCH_CONCURRENCY, queries.length) }, async () => {
+    for (;;) {
+      const i = cursor++;
+      if (i >= queries.length) return;
+      const result = await searchMemory({ query: queries[i], repo: input.repo, limit: input.limit });
+      groups[i] = { query: queries[i], result };
+    }
+  });
+  await Promise.all(workers);
+  return { groups, durationMs: Date.now() - t0 };
+}
+
 function corpusHits(query: string, limit: number): CorpusHit[] {
   const match = ftsQuery(query);
   if (!match) return [];
@@ -232,4 +272,13 @@ export function renderSearchResult(res: SearchResult): string {
     }
   }
   return lines.join("\n");
+}
+
+// Batched search render — one labeled section per query, in request order. Each
+// section is exactly the single-query render (same format), so a batched call
+// reads as several single results stacked under their query headers.
+export function renderBatchSearchResult(res: BatchSearchResult): string {
+  return res.groups
+    .map((g, i) => `=== q${i + 1}: ${g.query} ===\n${renderSearchResult(g.result)}`)
+    .join("\n\n");
 }

--- a/orchestrator/src/memory/search.ts
+++ b/orchestrator/src/memory/search.ts
@@ -20,8 +20,48 @@ import { getEmbedder, memoryVectors, type MemoryRow } from "./store.js";
 import { repoFamily, familyMatches } from "./repo-family.js";
 import { strengthTier } from "./strength.js";
 import { searchCorpus } from "../corpus.js";
+import { itemsAnchoredToNode } from "./anchors.js";
 
 export const COSINE_FLOOR = 0.55;
+
+// Node-scoped + type filters parsed out of the query string (Section E). A
+// caller can write `node:svc:users type:memory hmac` and get memories anchored
+// to svc:users matching "hmac"; the tokens are stripped before FTS/embedding so
+// they don't pollute the meaningful-token match. `node` / `type` params take
+// precedence over the in-query tokens when both are given.
+export type SearchTypeFilter = "memory" | "ticket" | "thread";
+const TYPE_FILTERS = new Set<SearchTypeFilter>(["memory", "ticket", "thread"]);
+
+export interface ParsedQuery {
+  query: string; // query with node:/type: tokens removed
+  node: string | null;
+  type: SearchTypeFilter | null;
+}
+
+// `node:` values are graph node ids which themselves contain colons
+// (api:dashboard:GET /agents), so we capture the rest of that whitespace-
+// delimited token, not just up to the next colon.
+export function parseSearchTokens(raw: string): ParsedQuery {
+  let node: string | null = null;
+  let type: SearchTypeFilter | null = null;
+  const kept: string[] = [];
+  for (const tok of raw.split(/\s+/)) {
+    if (!tok) continue;
+    if (tok.startsWith("node:") && tok.length > 5) {
+      node = tok.slice(5);
+      continue;
+    }
+    if (tok.startsWith("type:") && tok.length > 5) {
+      const t = tok.slice(5).toLowerCase();
+      if (TYPE_FILTERS.has(t as SearchTypeFilter)) {
+        type = t as SearchTypeFilter;
+        continue;
+      }
+    }
+    kept.push(tok);
+  }
+  return { query: kept.join(" ").trim(), node, type };
+}
 
 export interface MemoryHit {
   id: string;
@@ -109,18 +149,42 @@ export interface SearchInput {
   query: string;
   repo?: string | null;
   limit?: number;
+  // Node-scoped filter (Section E). Also parseable from a `node:` token in the
+  // query; the explicit param wins. Restricts hits to items anchored to the node.
+  node?: string | null;
+  // Type filter: memory | ticket | thread. Also parseable from `type:`.
+  type?: SearchTypeFilter | null;
 }
 
 export async function searchMemory(input: SearchInput): Promise<SearchResult> {
   const t0 = Date.now();
   const limit = Math.max(1, Math.min(50, input.limit ?? 8));
+
+  // Pull node:/type: out of the query string; explicit params override.
+  const parsed = parseSearchTokens(input.query);
+  const effectiveQuery = parsed.query;
+  const node = input.node ?? parsed.node;
+  const type = input.type ?? parsed.type;
+
   const queryFamily = repoFamily(input.repo);
-  const queryTokens = meaningfulTokens(input.query);
+  const queryTokens = meaningfulTokens(effectiveQuery);
+
+  // Node scope: the ids anchored to the node, partitioned by item kind. Used to
+  // (a) restrict the memory candidate set and (b) scope corpus hits.
+  const nodeScope = node ? nodeScopeIds(node) : null;
+  // Empty query under a node scope is legitimate ("everything on this node") —
+  // the "+N more" line is exactly that. Fall through with empty tokens; the
+  // node filter carries the selection.
+
+  // Node scope excludes the memory pass entirely when the type filter asks for
+  // tickets/threads only.
+  const wantMemories = !type || type === "memory";
+  const wantCorpus = !type || type === "ticket" || type === "thread";
 
   // --- FTS candidate ids (always eligible past the silence gate) ---
   const ftsIds = new Set<string>();
-  const match = ftsQuery(input.query);
-  if (match) {
+  const match = ftsQuery(effectiveQuery);
+  if (wantMemories && match) {
     try {
       const rows = db
         .prepare(
@@ -144,18 +208,27 @@ export async function searchMemory(input: SearchInput): Promise<SearchResult> {
   }
 
   // --- Vector candidates from the in-process cache ---
-  const qvec = await getEmbedder()(input.query);
+  const qvec = effectiveQuery ? await getEmbedder()(effectiveQuery) : null;
   const cosById = new Map<string, number>();
-  if (qvec) {
+  if (wantMemories && qvec) {
     for (const { id, vec } of memoryVectors()) {
       cosById.set(id, cosine(qvec, vec));
     }
   }
 
-  // Merge candidate ids: everything with a cosine + every FTS hit.
+  // Node-scoped, no keyword: the anchored memory set IS the candidate set (the
+  // "+N more" line's query). Seed candidates from the node scope so an empty
+  // query still returns the node's memories, strength-ranked.
+  const nodeMemoryIds = nodeScope ? new Set(nodeScope.memoryIds) : null;
+
+  // Merge candidate ids: everything with a cosine + every FTS hit (+ node
+  // memories when node-scoped so an empty query still surfaces them).
   const candidateIds = new Set<string>([...cosById.keys(), ...ftsIds]);
-  if (candidateIds.size === 0) {
-    return { memories: [], corpus: corpusHits(input.query, limit), durationMs: Date.now() - t0 };
+  if (nodeMemoryIds && effectiveQuery === "") for (const id of nodeMemoryIds) candidateIds.add(id);
+
+  const corpus = wantCorpus ? corpusHits(effectiveQuery, limit, nodeScope, type) : [];
+  if (candidateIds.size === 0 || !wantMemories) {
+    return { memories: [], corpus, durationMs: Date.now() - t0 };
   }
 
   const placeholders = [...candidateIds].map(() => "?").join(",");
@@ -163,16 +236,25 @@ export async function searchMemory(input: SearchInput): Promise<SearchResult> {
     .prepare(`SELECT * FROM memories WHERE status = 'active' AND id IN (${placeholders})`)
     .all(...candidateIds) as MemoryRow[];
 
+  // Empty query = no meaningful tokens → nothing is an FTS "exact hit" and the
+  // cosine floor would silence everything. Under a node scope that's wrong: the
+  // anchored set is the intended answer. Track it so the gate lets it through.
+  const emptyNodeScope = nodeMemoryIds !== null && effectiveQuery === "";
+
   const hits: MemoryHit[] = [];
   for (const m of memRows) {
+    // Node scope: drop memories not anchored to the node.
+    if (nodeMemoryIds && !nodeMemoryIds.has(m.id)) continue;
+
     // HARD family gate — drop, don't downweight.
     if (!familyMatches(queryFamily, m.repo_family)) continue;
 
     const cos = cosById.get(m.id) ?? 0;
     const isFts = ftsIds.has(m.id);
     // Silence gate: vector-only candidates must clear the cosine floor; FTS
-    // exact hits bypass it.
-    if (!isFts && cos < COSINE_FLOOR) continue;
+    // exact hits bypass it. An empty node-scoped query bypasses (the anchor IS
+    // the selection).
+    if (!emptyNodeScope && !isFts && cos < COSINE_FLOOR) continue;
 
     const keys = parseJsonArray(m.retrieval_keys);
     const keyOverlap = overlap(queryTokens, keys);
@@ -196,8 +278,23 @@ export async function searchMemory(input: SearchInput): Promise<SearchResult> {
   hits.sort((a, b) => b.score - a.score);
   return {
     memories: hits.slice(0, limit),
-    corpus: corpusHits(input.query, limit),
+    corpus,
     durationMs: Date.now() - t0,
+  };
+}
+
+// Ids anchored to a node, split by item kind. memoryIds scope the memory pass;
+// observationIds scope corpus hits (a corpus observation anchored to the node
+// points back to its linear/slack row).
+interface NodeScope {
+  memoryIds: string[];
+  observationIds: string[];
+}
+function nodeScopeIds(nodeId: string): NodeScope {
+  const rows = itemsAnchoredToNode(nodeId);
+  return {
+    memoryIds: rows.filter((r) => r.item_type === "memory").map((r) => r.item_id),
+    observationIds: rows.filter((r) => r.item_type === "observation").map((r) => r.item_id),
   };
 }
 
@@ -241,11 +338,46 @@ export async function searchMemoryBatch(input: BatchSearchInput): Promise<BatchS
   return { groups, durationMs: Date.now() - t0 };
 }
 
-function corpusHits(query: string, limit: number): CorpusHit[] {
+// type filter → corpus source. ticket = linear, thread = slack. When node-scoped
+// the corpus is restricted to rows whose derived observation is anchored to the
+// node; an empty query under a node scope returns those rows directly.
+function corpusHits(
+  query: string,
+  limit: number,
+  nodeScope: NodeScope | null = null,
+  type: SearchTypeFilter | null = null,
+): CorpusHit[] {
+  const source = type === "ticket" ? "linear" : type === "thread" ? "slack" : undefined;
+
+  // Node-scoped: surface only corpus rows reachable from observations anchored
+  // to the node. We already have the anchored observation ids; read their source
+  // rows directly (keyword still narrows when present, but the anchor is the
+  // primary filter). Kept simple: return the anchored corpus observations' own
+  // claim text (the corpus row body) as hits.
+  if (nodeScope) {
+    if (nodeScope.observationIds.length === 0) return [];
+    const ph = nodeScope.observationIds.map(() => "?").join(",");
+    const rows = db
+      .prepare(
+        `SELECT id, source, claim FROM observations
+         WHERE id IN (${ph}) AND source IN ('slack','linear','meeting')
+         ${source ? "AND source = ?" : ""} LIMIT ?`,
+      )
+      .all(...nodeScope.observationIds, ...(source ? [source] : []), limit) as Array<{
+      id: string;
+      source: string;
+      claim: string;
+    }>;
+    const tokens = meaningfulTokens(query);
+    return rows
+      .filter((r) => tokens.length === 0 || tokens.some((t) => r.claim.toLowerCase().includes(t)))
+      .map((r) => ({ id: r.id, text: r.claim, source: r.source }));
+  }
+
   const match = ftsQuery(query);
   if (!match) return [];
   try {
-    const rows = searchCorpus(match, undefined, limit) as Array<{ id: string; text?: string; source: string }>;
+    const rows = searchCorpus(match, source, limit) as Array<{ id: string; text?: string; source: string }>;
     return rows.map((r) => ({ id: r.id, text: String(r.text ?? ""), source: r.source }));
   } catch {
     return [];

--- a/orchestrator/src/memory/search.ts
+++ b/orchestrator/src/memory/search.ts
@@ -1,0 +1,203 @@
+// search.ts — retrieval for search_memory. Eval-calibrated ranking:
+//
+//   HARD GATE on repo_family mismatch — drop, never downweight. (null family on
+//     either side = match-all.)
+//   score = cosine
+//         + 0.15 * retrieval_keys_overlap
+//         + 0.10 * file_mention_overlap
+//         + 0.08 * same_repo_exact
+//   SILENCE GATE: drop results under ~0.55 cosine UNLESS they are an FTS5 exact
+//     hit. FTS candidates are ALWAYS eligible (identifiers/error strings are the
+//     reliable path); vector-only candidates must clear the cosine floor.
+//   Merge FTS5 + vector candidates before ranking.
+//
+// Returns terse lines. Also searches the corpus (slack/linear/meeting FTS) and
+// labels each result's source. Vectors come from the in-process cache.
+
+import db from "../db.js";
+import { cosine, blobToVec } from "../embed.js";
+import { getEmbedder, memoryVectors, type MemoryRow } from "./store.js";
+import { repoFamily, familyMatches } from "./repo-family.js";
+import { strengthTier } from "./strength.js";
+import { searchCorpus } from "../corpus.js";
+
+export const COSINE_FLOOR = 0.55;
+
+export interface MemoryHit {
+  id: string;
+  claim: string;
+  kind: string;
+  strengthTier: string;
+  source: "memory";
+  score: number;
+  cosine: number;
+  ftsHit: boolean;
+}
+
+export interface CorpusHit {
+  id: string;
+  text: string;
+  source: string; // slack | linear | meeting
+}
+
+export interface SearchResult {
+  memories: MemoryHit[];
+  corpus: CorpusHit[];
+  durationMs: number;
+}
+
+// Escape a free-text query for FTS5 MATCH: quote each token so punctuation-heavy
+// identifiers/error snippets don't blow up the FTS parser. Empty → no FTS.
+function ftsQuery(query: string): string {
+  const tokens = query.match(/[A-Za-z0-9_./:-]+/g) ?? [];
+  const quoted = tokens.filter((t) => t.length >= 2).map((t) => `"${t.replace(/"/g, '""')}"`);
+  return quoted.join(" OR ");
+}
+
+function overlap(a: string[], b: string[]): number {
+  if (a.length === 0 || b.length === 0) return 0;
+  const bl = b.map((x) => x.toLowerCase());
+  const setB = new Set(bl);
+  let hit = 0;
+  for (const x of a) if (setB.has(x.toLowerCase())) hit++;
+  return hit / a.length;
+}
+
+function parseJsonArray(s: string | null): string[] {
+  if (!s) return [];
+  try {
+    const v = JSON.parse(s);
+    return Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+export interface SearchInput {
+  query: string;
+  repo?: string | null;
+  limit?: number;
+}
+
+export async function searchMemory(input: SearchInput): Promise<SearchResult> {
+  const t0 = Date.now();
+  const limit = Math.max(1, Math.min(50, input.limit ?? 8));
+  const queryFamily = repoFamily(input.repo);
+  const queryTokens = (input.query.match(/[A-Za-z0-9_./:-]+/g) ?? []).map((t) => t.toLowerCase());
+
+  // --- FTS candidate ids (always eligible past the silence gate) ---
+  const ftsIds = new Set<string>();
+  const match = ftsQuery(input.query);
+  if (match) {
+    try {
+      const rows = db
+        .prepare(
+          `SELECT o.id AS id FROM observations_fts fts
+           JOIN observations o ON o.rowid = fts.rowid
+           WHERE observations_fts MATCH ? ORDER BY rank LIMIT 100`,
+        )
+        .all(match) as Array<{ id: string }>;
+      // FTS is over observations; map to their memory_id.
+      const obsIds = rows.map((r) => r.id);
+      if (obsIds.length) {
+        const placeholders = obsIds.map(() => "?").join(",");
+        const memRows = db
+          .prepare(`SELECT DISTINCT memory_id FROM observations WHERE id IN (${placeholders}) AND memory_id IS NOT NULL`)
+          .all(...obsIds) as Array<{ memory_id: string }>;
+        for (const m of memRows) ftsIds.add(m.memory_id);
+      }
+    } catch {
+      /* FTS parse error → no FTS candidates, vectors still run */
+    }
+  }
+
+  // --- Vector candidates from the in-process cache ---
+  const qvec = await getEmbedder()(input.query);
+  const cosById = new Map<string, number>();
+  if (qvec) {
+    for (const { id, vec } of memoryVectors()) {
+      cosById.set(id, cosine(qvec, vec));
+    }
+  }
+
+  // Merge candidate ids: everything with a cosine + every FTS hit.
+  const candidateIds = new Set<string>([...cosById.keys(), ...ftsIds]);
+  if (candidateIds.size === 0) {
+    return { memories: [], corpus: corpusHits(input.query, limit), durationMs: Date.now() - t0 };
+  }
+
+  const placeholders = [...candidateIds].map(() => "?").join(",");
+  const memRows = db
+    .prepare(`SELECT * FROM memories WHERE status = 'active' AND id IN (${placeholders})`)
+    .all(...candidateIds) as MemoryRow[];
+
+  const hits: MemoryHit[] = [];
+  for (const m of memRows) {
+    // HARD family gate — drop, don't downweight.
+    if (!familyMatches(queryFamily, m.repo_family)) continue;
+
+    const cos = cosById.get(m.id) ?? 0;
+    const isFts = ftsIds.has(m.id);
+    // Silence gate: vector-only candidates must clear the cosine floor; FTS
+    // exact hits bypass it.
+    if (!isFts && cos < COSINE_FLOOR) continue;
+
+    const keys = parseJsonArray(m.retrieval_keys);
+    const keyOverlap = overlap(queryTokens, keys);
+    const files = keys.filter((k) => k.includes("/") || k.includes("."));
+    const fileOverlap = overlap(queryTokens, files);
+    const sameRepoExact = input.repo && m.repo && input.repo.toLowerCase() === m.repo.toLowerCase() ? 1 : 0;
+
+    const score = cos + 0.15 * keyOverlap + 0.1 * fileOverlap + 0.08 * sameRepoExact;
+    hits.push({
+      id: m.id,
+      claim: m.claim,
+      kind: m.kind,
+      strengthTier: strengthTier(m.strength),
+      source: "memory",
+      score,
+      cosine: cos,
+      ftsHit: isFts,
+    });
+  }
+
+  hits.sort((a, b) => b.score - a.score);
+  return {
+    memories: hits.slice(0, limit),
+    corpus: corpusHits(input.query, limit),
+    durationMs: Date.now() - t0,
+  };
+}
+
+function corpusHits(query: string, limit: number): CorpusHit[] {
+  const match = ftsQuery(query);
+  if (!match) return [];
+  try {
+    const rows = searchCorpus(match, undefined, limit) as Array<{ id: string; text?: string; source: string }>;
+    return rows.map((r) => ({ id: r.id, text: String(r.text ?? ""), source: r.source }));
+  } catch {
+    return [];
+  }
+}
+
+// Render terse lines for the model. One line per hit: claim, kind, tier, source, id.
+export function renderSearchResult(res: SearchResult): string {
+  const lines: string[] = [];
+  if (res.memories.length === 0 && res.corpus.length === 0) {
+    return "(no memories match — try symptoms, identifiers, or file paths)";
+  }
+  if (res.memories.length) {
+    lines.push("MEMORY:");
+    for (const m of res.memories) {
+      lines.push(`- ${m.claim} [${m.kind}/${m.strengthTier}] (memory ${m.id})`);
+    }
+  }
+  if (res.corpus.length) {
+    lines.push("CORPUS:");
+    for (const c of res.corpus) {
+      const t = c.text.replace(/\s+/g, " ").trim();
+      lines.push(`- ${t.length > 180 ? t.slice(0, 179) + "…" : t} [${c.source}] (${c.id})`);
+    }
+  }
+  return lines.join("\n");
+}

--- a/orchestrator/src/memory/search.ts
+++ b/orchestrator/src/memory/search.ts
@@ -38,25 +38,42 @@ export interface ParsedQuery {
   type: SearchTypeFilter | null;
 }
 
-// `node:` values are graph node ids which themselves contain colons
-// (api:dashboard:GET /agents), so we capture the rest of that whitespace-
-// delimited token, not just up to the next colon.
+// `node:` values are graph node ids which contain colons AND, for endpoints, a
+// single space between the HTTP method and the path ('api:dashboard:GET
+// /agents'). A naive whitespace split severs that id. So on hitting `node:` we
+// absorb ONE following token into the id when it's a path continuation — the
+// last part is an HTTP method OR the next token starts with '/'. Everything else
+// (real keywords like 'hmac') stays a keyword. `type:` is a plain leading token
+// that also ends node absorption. This matches the "+N more" line the headline
+// emits: `search_memory node:<id> type:<t>`.
+const HTTP_METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]);
 export function parseSearchTokens(raw: string): ParsedQuery {
   let node: string | null = null;
   let type: SearchTypeFilter | null = null;
   const kept: string[] = [];
-  for (const tok of raw.split(/\s+/)) {
-    if (!tok) continue;
-    if (tok.startsWith("node:") && tok.length > 5) {
-      node = tok.slice(5);
+  const toks = raw.split(/\s+/).filter(Boolean);
+  const isTypeTok = (t: string) =>
+    t.startsWith("type:") && TYPE_FILTERS.has(t.slice(5).toLowerCase() as SearchTypeFilter);
+
+  for (let i = 0; i < toks.length; i++) {
+    const tok = toks[i];
+    if (node === null && tok.startsWith("node:") && tok.length > 5) {
+      const parts = [tok.slice(5)];
+      // Absorb a path continuation for endpoint ids: '<...>:GET' + '/agents'.
+      while (i + 1 < toks.length && !isTypeTok(toks[i + 1])) {
+        const next = toks[i + 1];
+        const last = parts[parts.length - 1];
+        const lastSeg = last.slice(last.lastIndexOf(":") + 1);
+        const continues = next.startsWith("/") || HTTP_METHODS.has(lastSeg);
+        if (!continues) break;
+        parts.push(toks[++i]);
+      }
+      node = parts.join(" ");
       continue;
     }
-    if (tok.startsWith("type:") && tok.length > 5) {
-      const t = tok.slice(5).toLowerCase();
-      if (TYPE_FILTERS.has(t as SearchTypeFilter)) {
-        type = t as SearchTypeFilter;
-        continue;
-      }
+    if (isTypeTok(tok)) {
+      type = tok.slice(5).toLowerCase() as SearchTypeFilter;
+      continue;
     }
     kept.push(tok);
   }

--- a/orchestrator/src/memory/slim.ts
+++ b/orchestrator/src/memory/slim.ts
@@ -1,0 +1,125 @@
+// slim.ts — reduce a Flow agent-session transcript to the durable-signal parts
+// before the distiller LLM call. Adapted from
+// flow-benchmarks/memory-evals/distiller/slim.mjs.
+//
+// Keeps: full user_prompt texts (minus the MCP orientation preamble), error
+// events, FAILED tool_call titles + error heads, and the concluding agent
+// message of each turn-run. Caps CAP chars, preserving the END on truncation
+// (conclusions matter most).
+//
+// Operates on the SessionEvent[] the runtime already persists (kind/data shape),
+// not raw JSONL — so it needs no file access and is trivially unit-testable.
+
+export interface SlimEvent {
+  kind: string;
+  data: unknown;
+}
+
+const CAP = 20000;
+const AGENT_RUN_TAIL = 1400;
+
+function getUpdate(e: SlimEvent): Record<string, unknown> {
+  const d = (e.data ?? {}) as Record<string, unknown>;
+  const u = (d.update ?? d) as Record<string, unknown>;
+  return u ?? {};
+}
+
+// The MCP orientation preamble is prepended to the first real user prompt.
+// Strip it so we keep the user's actual ask.
+export function stripPreamble(text: string): string {
+  const marker = "Consult it FIRST to orient yourself";
+  if (text.includes("flow-graph") && text.includes(marker)) {
+    const idx = text.indexOf("\n\n");
+    const lower = text.toLowerCase();
+    const endMarkers = ["when you hit an unexpected failure", "before diving into files"];
+    let cut = 0;
+    for (const m of endMarkers) {
+      const p = lower.indexOf(m);
+      if (p >= 0) cut = Math.max(cut, p);
+    }
+    if (cut > 0) {
+      const after = text.indexOf("\n", cut);
+      if (after >= 0 && text.length - after > 30) {
+        return "[preamble stripped] " + text.slice(after).trim();
+      }
+    }
+    if (idx > 0 && text.length - idx > 40) {
+      return "[preamble stripped] " + text.slice(idx).trim();
+    }
+  }
+  return text;
+}
+
+type TimelineItem =
+  | { t: "meta"; repo?: string; backend?: string; title?: string; branch?: string }
+  | { t: "user"; text: string }
+  | { t: "agent_run"; text: string }
+  | { t: "tool_fail"; id?: string; err: string }
+  | { t: "error"; text: string };
+
+export function slimTranscript(events: SlimEvent[]): string {
+  const timeline: TimelineItem[] = [];
+  let agentBuf = "";
+  const titleById: Record<string, string> = {};
+
+  const flush = () => {
+    if (agentBuf.trim()) {
+      timeline.push({ t: "agent_run", text: agentBuf.trim() });
+      agentBuf = "";
+    }
+  };
+
+  for (const e of events) {
+    if (e.kind === "created") {
+      const d = (e.data ?? {}) as Record<string, string>;
+      timeline.push({ t: "meta", repo: d.repo, backend: d.backend, title: d.title, branch: d.branch });
+    } else if (e.kind === "user_prompt") {
+      flush();
+      const d = (e.data ?? {}) as Record<string, string>;
+      timeline.push({ t: "user", text: stripPreamble(d.text || "") });
+    } else if (e.kind === "error") {
+      flush();
+      timeline.push({ t: "error", text: JSON.stringify(e.data).slice(0, 600) });
+    } else if (e.kind === "update") {
+      const u = getUpdate(e);
+      const su = u.sessionUpdate;
+      if (su === "agent_message_chunk") {
+        const content = u.content as { text?: string } | undefined;
+        agentBuf += content?.text || "";
+      } else if (su === "tool_call" && typeof u.toolCallId === "string") {
+        const meta = (u._meta as { claudeCode?: { toolName?: string } } | undefined)?.claudeCode?.toolName;
+        titleById[u.toolCallId] = (u.title as string) || meta || "tool";
+      } else if (su === "tool_call_update" && u.status === "failed") {
+        const content = (u.content as Array<{ content?: { text?: string } }> | undefined)?.[0]?.content?.text || "";
+        timeline.push({ t: "tool_fail", id: u.toolCallId as string | undefined, err: content.slice(0, 400) });
+      }
+    }
+  }
+  flush();
+
+  const parts: string[] = [];
+  const meta = timeline.find((x): x is Extract<TimelineItem, { t: "meta" }> => x.t === "meta");
+  if (meta) {
+    parts.push(`### SESSION META\nrepo: ${meta.repo ?? ""}\nbackend: ${meta.backend ?? ""}\ntitle: ${meta.title ?? ""}\n`);
+  }
+
+  for (const ev of timeline) {
+    if (ev.t === "user") {
+      parts.push(`\n### USER PROMPT\n${ev.text}`);
+    } else if (ev.t === "agent_run") {
+      let txt = ev.text;
+      if (txt.length > AGENT_RUN_TAIL) txt = "…[mid omitted]…\n" + txt.slice(txt.length - AGENT_RUN_TAIL);
+      parts.push(`\n### AGENT (turn conclusion)\n${txt}`);
+    } else if (ev.t === "tool_fail") {
+      parts.push(`\n### TOOL FAILED: ${(ev.id && titleById[ev.id]) || "tool"}\n${ev.err}`);
+    } else if (ev.t === "error") {
+      parts.push(`\n### ERROR EVENT\n${ev.text}`);
+    }
+  }
+
+  let out = parts.join("\n");
+  if (out.length > CAP) {
+    out = "…[BEGINNING TRUNCATED]…\n" + out.slice(out.length - CAP);
+  }
+  return out;
+}

--- a/orchestrator/src/memory/store.ts
+++ b/orchestrator/src/memory/store.ts
@@ -1,0 +1,247 @@
+// store.ts — the single SQLite substrate for memory v1 (observations + memories)
+// plus the in-process vector cache used by search. Embeddings are computed at
+// WRITE time only; the embedder is INJECTED (default: the gateway-backed
+// embedText) so tests can pass a deterministic stub and never load the model.
+
+import { randomUUID } from "node:crypto";
+import db from "../db.js";
+import { blobToVec, vecToBlob, embedText as gatewayEmbed } from "../embed.js";
+import { repoFamily } from "./repo-family.js";
+import type { RawObservation } from "./parse.js";
+
+// An embedder returns a 768-dim vector or null (model not ready). Injectable.
+export type Embedder = (text: string) => Promise<Float32Array | null>;
+
+let _embedder: Embedder = gatewayEmbed;
+export function setEmbedder(fn: Embedder): void {
+  _embedder = fn;
+}
+export function getEmbedder(): Embedder {
+  return _embedder;
+}
+
+export interface ObservationRow {
+  id: string;
+  source: string;
+  repo: string | null;
+  repo_family: string | null;
+  branch: string | null;
+  session_id: string | null;
+  claim: string;
+  kind: string;
+  source_weight: string;
+  context_files: string | null;
+  retrieval_keys: string | null;
+  embedding: Buffer | null;
+  memory_id: string | null;
+  created_at: number;
+}
+
+export interface MemoryRow {
+  id: string;
+  claim: string;
+  kind: string;
+  repo: string | null;
+  repo_family: string | null;
+  strength: number;
+  evidence_count: number;
+  people_count: number;
+  contradiction_count: number;
+  last_reinforced_at: number | null;
+  status: string;
+  embedding: Buffer | null;
+  retrieval_keys: string | null;
+  max_source_weight: string;
+  created_at: number;
+  updated_at: number;
+}
+
+const insertObservationStmt = db.prepare(`
+  INSERT INTO observations
+    (id, source, repo, repo_family, branch, session_id, claim, kind, source_weight,
+     context_files, retrieval_keys, embedding, memory_id)
+  VALUES
+    (@id, @source, @repo, @repo_family, @branch, @session_id, @claim, @kind, @source_weight,
+     @context_files, @retrieval_keys, @embedding, @memory_id)
+`);
+
+export interface NewObservation {
+  source: "session" | "slack" | "linear" | "meeting";
+  repo?: string | null;
+  branch?: string | null;
+  session_id?: string | null;
+  claim: string;
+  kind: string;
+  source_weight?: string;
+  context_files?: string[];
+  retrieval_keys?: string[];
+  memory_id?: string | null;
+}
+
+// The text we embed for an observation: claim + retrieval keys (identifiers and
+// error snippets carry the retrieval signal).
+export function observationEmbedText(claim: string, keys: string[]): string {
+  return keys.length ? `${claim}\n${keys.join(" ")}` : claim;
+}
+
+// Insert an observation, embedding at write time (best-effort). Returns the row.
+export async function insertObservation(o: NewObservation): Promise<ObservationRow> {
+  const id = randomUUID();
+  const keys = o.retrieval_keys ?? [];
+  const vec = await _embedder(observationEmbedText(o.claim, keys).slice(0, 2000));
+  const row = {
+    id,
+    source: o.source,
+    repo: o.repo ?? null,
+    repo_family: repoFamily(o.repo),
+    branch: o.branch ?? null,
+    session_id: o.session_id ?? null,
+    claim: o.claim,
+    kind: o.kind,
+    source_weight: o.source_weight ?? "agent_inferred",
+    context_files: o.context_files && o.context_files.length ? JSON.stringify(o.context_files) : null,
+    retrieval_keys: keys.length ? JSON.stringify(keys) : null,
+    embedding: vec ? vecToBlob(vec) : null,
+    memory_id: o.memory_id ?? null,
+  };
+  insertObservationStmt.run(row);
+  invalidateVectorCache();
+  return { ...row, created_at: Math.floor(Date.now() / 1000) };
+}
+
+// Map a distiller RawObservation → NewObservation (source always 'session').
+export function rawToNewObservation(
+  raw: RawObservation,
+  ctx: { repo: string | null; branch: string | null; session_id: string | null },
+): NewObservation {
+  return {
+    source: "session",
+    repo: raw.context.repo ?? ctx.repo,
+    branch: raw.context.branch ?? ctx.branch,
+    session_id: ctx.session_id,
+    claim: raw.claim,
+    kind: raw.kind,
+    source_weight: raw.source,
+    context_files: raw.context.files ?? [],
+    retrieval_keys: raw.retrieval_keys ?? [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Memory rows
+
+export function getMemory(id: string): MemoryRow | undefined {
+  return db.prepare(`SELECT * FROM memories WHERE id = ?`).get(id) as MemoryRow | undefined;
+}
+
+export function memoriesInFamily(family: string | null): MemoryRow[] {
+  // family null (unattributed observation) → compare against all active memories.
+  if (family === null) {
+    return db.prepare(`SELECT * FROM memories WHERE status = 'active'`).all() as MemoryRow[];
+  }
+  return db
+    .prepare(`SELECT * FROM memories WHERE status = 'active' AND (repo_family = ? OR repo_family IS NULL)`)
+    .all(family) as MemoryRow[];
+}
+
+export function createMemory(o: ObservationRow): MemoryRow {
+  const id = randomUUID();
+  const now = Math.floor(Date.now() / 1000);
+  db.prepare(`
+    INSERT INTO memories
+      (id, claim, kind, repo, repo_family, strength, evidence_count, people_count,
+       contradiction_count, last_reinforced_at, status, embedding, retrieval_keys, max_source_weight)
+    VALUES
+      (@id, @claim, @kind, @repo, @repo_family, @strength, 1, 1, 0, @now, 'active', @embedding, @retrieval_keys, @max_source_weight)
+  `).run({
+    id,
+    claim: o.claim,
+    kind: o.kind,
+    repo: o.repo,
+    repo_family: o.repo_family,
+    strength: 0,
+    now,
+    embedding: o.embedding,
+    retrieval_keys: o.retrieval_keys,
+    max_source_weight: o.source_weight,
+  });
+  db.prepare(`UPDATE observations SET memory_id = ? WHERE id = ?`).run(id, o.id);
+  invalidateVectorCache();
+  return getMemory(id)!;
+}
+
+export function updateMemory(id: string, fields: Partial<MemoryRow>): void {
+  const keys = Object.keys(fields).filter((k) => k !== "id");
+  if (keys.length === 0) return;
+  const setClause = keys.map((k) => `${k} = @${k}`).join(", ");
+  db.prepare(`UPDATE memories SET ${setClause}, updated_at = unixepoch() WHERE id = @id`).run({
+    id,
+    ...fields,
+  });
+  invalidateVectorCache();
+}
+
+export function attachObservation(memoryId: string, observationId: string): void {
+  db.prepare(`UPDATE observations SET memory_id = ? WHERE id = ?`).run(memoryId, observationId);
+}
+
+// Distinct people who produced attached observations. People are approximated by
+// (source, session_id) for sessions and by source for corpus rows — the eval
+// only needs "independent origins", not real identities. Never below 1.
+export function recomputePeopleCount(memoryId: string): number {
+  const row = db
+    .prepare(
+      `SELECT COUNT(DISTINCT (source || ':' || COALESCE(session_id, id))) AS n
+       FROM observations WHERE memory_id = ?`,
+    )
+    .get(memoryId) as { n: number };
+  return Math.max(1, row.n || 1);
+}
+
+export function evidenceCount(memoryId: string): number {
+  const row = db.prepare(`SELECT COUNT(*) AS n FROM observations WHERE memory_id = ?`).get(memoryId) as { n: number };
+  return row.n || 0;
+}
+
+// Union of retrieval keys across attached observations (deduped, capped).
+export function unionRetrievalKeys(memoryId: string): string[] {
+  const rows = db
+    .prepare(`SELECT retrieval_keys FROM observations WHERE memory_id = ? AND retrieval_keys IS NOT NULL`)
+    .all(memoryId) as Array<{ retrieval_keys: string }>;
+  const set = new Set<string>();
+  for (const r of rows) {
+    try {
+      for (const k of JSON.parse(r.retrieval_keys) as string[]) set.add(k);
+    } catch {
+      /* skip */
+    }
+  }
+  return [...set].slice(0, 40);
+}
+
+// ---------------------------------------------------------------------------
+// In-process vector cache — search reads vectors from here, not SQLite BLOBs,
+// to hit the <300ms target. Invalidated on any write; rebuilt lazily.
+
+interface CachedVec {
+  id: string;
+  vec: Float32Array;
+}
+let _memVecCache: CachedVec[] | null = null;
+
+export function invalidateVectorCache(): void {
+  _memVecCache = null;
+}
+
+export function memoryVectors(): CachedVec[] {
+  if (_memVecCache) return _memVecCache;
+  const rows = db
+    .prepare(`SELECT id, embedding FROM memories WHERE status = 'active' AND embedding IS NOT NULL`)
+    .all() as Array<{ id: string; embedding: Buffer }>;
+  _memVecCache = rows.map((r) => ({ id: r.id, vec: blobToVec(r.embedding) }));
+  return _memVecCache;
+}
+
+export function activeMemoryRows(): MemoryRow[] {
+  return db.prepare(`SELECT * FROM memories WHERE status = 'active'`).all() as MemoryRow[];
+}

--- a/orchestrator/src/memory/strength.ts
+++ b/orchestrator/src/memory/strength.ts
@@ -1,0 +1,84 @@
+// strength.ts — the ONE place memory strength is computed. Pure, auditable,
+// no LLM. A memory's strength is a single REAL in [0, ~1.3] combining:
+//
+//   people_count   — how many DISTINCT people independently produced evidence.
+//                     This DOMINATES: three people saying it once beats one
+//                     person saying it three times (independent corroboration
+//                     is the strongest durability signal).
+//   evidence_count  — total attached observations (repetition; weaker than people).
+//   max_source_weight — the strongest provenance any attached observation carries:
+//                     error_proven > user_stated > agent_inferred. A single
+//                     error-proven fact outranks a pile of agent guesses.
+//   recency         — exponential decay on last_reinforced_at. Old, un-reinforced
+//                     memories fade; a memory under FLOOR is swept to 'sunk'.
+//   contradiction_count — counter-evidence penalty. Contradicted memories lose
+//                     strength fast (a contested claim is not durable knowledge).
+//
+// The bands (T_LO) and judge live in consolidate.ts; this file only scores.
+
+export type SourceWeight = "agent_inferred" | "user_stated" | "error_proven";
+
+const SOURCE_WEIGHT_VALUE: Record<SourceWeight, number> = {
+  agent_inferred: 0.15,
+  user_stated: 0.45,
+  error_proven: 0.6,
+};
+
+export function sourceWeightRank(w: string): number {
+  return SOURCE_WEIGHT_VALUE[(w as SourceWeight)] ?? 0;
+}
+
+// Pick the strongest of two source weights (used when attaching an observation).
+export function strongerWeight(a: string, b: string): SourceWeight {
+  return sourceWeightRank(a) >= sourceWeightRank(b) ? (a as SourceWeight) : (b as SourceWeight);
+}
+
+const HALF_LIFE_DAYS = 45; // reinforcement resets the clock; after ~45d idle, recency halves
+const DECAY_LAMBDA = Math.LN2 / (HALF_LIFE_DAYS * 24 * 3600);
+
+// Strength below this floor → the maintenance sweep marks the memory 'sunk'.
+export const STRENGTH_FLOOR = 0.2;
+
+export interface StrengthInput {
+  people_count: number;
+  evidence_count: number;
+  max_source_weight: string;
+  contradiction_count: number;
+  last_reinforced_at: number; // unix seconds
+  now?: number; // unix seconds; injectable for tests
+}
+
+// recencyFactor in (0, 1]: 1 when just reinforced, halving every HALF_LIFE_DAYS.
+export function recencyFactor(lastReinforcedAt: number, now: number): number {
+  const ageSec = Math.max(0, now - lastReinforcedAt);
+  return Math.exp(-DECAY_LAMBDA * ageSec);
+}
+
+export function computeStrength(input: StrengthInput): number {
+  const now = input.now ?? Math.floor(Date.now() / 1000);
+  const people = Math.max(1, input.people_count);
+  const evidence = Math.max(1, input.evidence_count);
+
+  // people dominates evidence: log-scaled, but people weighted ~2.2x.
+  // 3 people (once each) -> ~0.61 base; 1 person, 3 observations -> ~0.34 base.
+  const peopleTerm = 0.55 * Math.log2(1 + people);
+  const evidenceTerm = 0.18 * Math.log2(1 + evidence);
+  const provenanceTerm = sourceWeightRank(input.max_source_weight);
+
+  const raw = peopleTerm + evidenceTerm + provenanceTerm;
+
+  // Contradiction penalty is multiplicative and steep: each counter-observation
+  // roughly halves the surviving strength.
+  const contradictionFactor = Math.pow(0.5, Math.max(0, input.contradiction_count));
+
+  const recency = recencyFactor(input.last_reinforced_at, now);
+
+  return raw * contradictionFactor * recency;
+}
+
+// Human-facing tier for terse search output.
+export function strengthTier(strength: number): "strong" | "medium" | "weak" {
+  if (strength >= 0.6) return "strong";
+  if (strength >= 0.35) return "medium";
+  return "weak";
+}

--- a/orchestrator/src/memory/trigger.ts
+++ b/orchestrator/src/memory/trigger.ts
@@ -34,13 +34,19 @@ interface SessionMetaRow {
   last_distilled_seq: number | null;
 }
 
+// Statements are prepared LAZILY: agent_sessions is created by runtime.ts at
+// its module load, which imports this file at its TOP — so the table does not
+// exist yet when this module first evaluates. Preparing on first call defers
+// until the table is guaranteed present.
 function sessionMeta(id: string): SessionMetaRow | undefined {
   return db
     .prepare(`SELECT id, repo, status, updated_at, last_distilled_seq FROM agent_sessions WHERE id = ?`)
     .get(id) as SessionMetaRow | undefined;
 }
 
-const setDistilledSeq = db.prepare(`UPDATE agent_sessions SET last_distilled_seq = ? WHERE id = ?`);
+function setDistilledSeq(seq: number, id: string): void {
+  db.prepare(`UPDATE agent_sessions SET last_distilled_seq = ? WHERE id = ?`).run(seq, id);
+}
 
 // Run one distill for a session if it has new events. Non-throwing. Returns
 // whether it actually distilled (for tests).
@@ -64,7 +70,7 @@ export async function maybeDistill(id: string, branch: string | null = null): Pr
   }
   // Advance the high-water mark even on a zero-observation run — the content was
   // consumed; re-reading it yields nothing new.
-  setDistilledSeq.run(maxSeq, id);
+  setDistilledSeq(maxSeq, id);
   return true;
 }
 

--- a/orchestrator/src/memory/trigger.ts
+++ b/orchestrator/src/memory/trigger.ts
@@ -1,0 +1,115 @@
+// trigger.ts — decides WHEN to distill a session and runs it off the hot path.
+//
+// Two triggers (both funnel through queueDistill, which never blocks session ops):
+//   1. session → 'closed'    (setStatus in runtime.ts calls onSessionClosed)
+//   2. idle sweep            (a timer; a session idle > IDLE_MS with transcript
+//                             events past last_distilled_seq gets distilled)
+//
+// last_distilled_seq (agent_sessions column) is the high-water mark of transcript
+// seqs already consumed — so re-distilling only happens when there's NEW content,
+// and a crash mid-distill just re-runs next sweep (observations are idempotent
+// enough: at worst a duplicate observation the consolidator folds via 'same').
+
+import db from "../db.js";
+import { distillSession } from "./distiller.js";
+import { distillerEnabled } from "./llm.js";
+import type { SlimEvent } from "./slim.js";
+
+export const IDLE_MS = 45 * 60 * 1000;
+const SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+
+// Injectable transcript reader — avoids a hard import cycle with runtime.ts and
+// lets tests feed synthetic transcripts. Set by wireDistillTrigger().
+type TranscriptReader = (id: string) => Array<{ seq: number; kind: string; data: unknown }>;
+let _readTranscript: TranscriptReader = () => [];
+export function setTranscriptReader(fn: TranscriptReader): void {
+  _readTranscript = fn;
+}
+
+interface SessionMetaRow {
+  id: string;
+  repo: string | null;
+  status: string;
+  updated_at: number;
+  last_distilled_seq: number | null;
+}
+
+function sessionMeta(id: string): SessionMetaRow | undefined {
+  return db
+    .prepare(`SELECT id, repo, status, updated_at, last_distilled_seq FROM agent_sessions WHERE id = ?`)
+    .get(id) as SessionMetaRow | undefined;
+}
+
+const setDistilledSeq = db.prepare(`UPDATE agent_sessions SET last_distilled_seq = ? WHERE id = ?`);
+
+// Run one distill for a session if it has new events. Non-throwing. Returns
+// whether it actually distilled (for tests).
+export async function maybeDistill(id: string, branch: string | null = null): Promise<boolean> {
+  if (!distillerEnabled()) return false;
+  const meta = sessionMeta(id);
+  if (!meta) return false;
+
+  const events = _readTranscript(id);
+  if (events.length === 0) return false;
+  const maxSeq = events[events.length - 1].seq;
+  const since = meta.last_distilled_seq ?? 0;
+  if (maxSeq <= since) return false; // nothing new since last distill
+
+  const slimEvents: SlimEvent[] = events.map((e) => ({ kind: e.kind, data: e.data }));
+  try {
+    await distillSession({ sessionId: id, repo: meta.repo, branch, events: slimEvents });
+  } catch (err) {
+    console.warn(`[memory] distill failed for ${id}: ${err instanceof Error ? err.message : String(err)}`);
+    return false;
+  }
+  // Advance the high-water mark even on a zero-observation run — the content was
+  // consumed; re-reading it yields nothing new.
+  setDistilledSeq.run(maxSeq, id);
+  return true;
+}
+
+// Fire-and-forget: queue a distill without blocking the caller (setStatus).
+export function queueDistill(id: string, branch: string | null = null): void {
+  if (!distillerEnabled()) return;
+  setImmediate(() => {
+    void maybeDistill(id, branch);
+  });
+}
+
+// Trigger 1: called from setStatus when a session becomes 'closed'.
+export function onSessionClosed(id: string, branch: string | null = null): void {
+  queueDistill(id, branch);
+}
+
+// Trigger 2: idle sweep. A session that's been idle past IDLE_MS with new
+// transcript content gets distilled. Runs on an interval; also callable directly.
+export async function idleSweep(now = Date.now()): Promise<number> {
+  if (!distillerEnabled()) return 0;
+  const cutoff = Math.floor((now - IDLE_MS) / 1000);
+  const rows = db
+    .prepare(
+      `SELECT id FROM agent_sessions
+       WHERE status IN ('idle','error','closed') AND updated_at <= ?`,
+    )
+    .all(cutoff) as Array<{ id: string }>;
+  let ran = 0;
+  for (const r of rows) {
+    if (await maybeDistill(r.id)) ran++;
+  }
+  return ran;
+}
+
+let _timer: ReturnType<typeof setInterval> | null = null;
+export function startIdleSweep(): void {
+  if (_timer || process.env.FLOW_DISTILLER === "0") return;
+  _timer = setInterval(() => {
+    void idleSweep();
+  }, SWEEP_INTERVAL_MS);
+  _timer.unref?.();
+}
+export function stopIdleSweep(): void {
+  if (_timer) {
+    clearInterval(_timer);
+    _timer = null;
+  }
+}

--- a/orchestrator/src/migrations.ts
+++ b/orchestrator/src/migrations.ts
@@ -153,7 +153,38 @@ export const MIGRATIONS: Migration[] = [
       db.exec("ALTER TABLE agent_sessions ADD COLUMN last_distilled_seq INTEGER");
     },
   },
+  {
+    id: 9,
+    name: "memory v1: anchors join table (item ↔ graph node)",
+    up: (db) => {
+      // Keep byte-identical to ANCHORS_SCHEMA in db.ts (see migration 8 note).
+      db.exec(ANCHORS_SCHEMA);
+    },
+  },
 ];
+
+// Anchors: the join between a memory/observation (flow.db PRIMARY) and a graph
+// node (a rebuildable projection). flow.db owns the edge; any graph
+// representation is derivable. item_type distinguishes distilled memories from
+// raw corpus observations (linear/slack) so a node's headline index can pull
+// the right kind. node_id is the graph node id string (e.g. 'svc:users',
+// 'api:dashboard:GET /agents'); source records HOW the edge was inferred
+// (deterministic file match vs. semantic). resolved_at is the epoch the edge
+// was last (re)resolved — re-resolution deletes+reinserts. Cap of 3 anchors per
+// item is enforced in code, not schema. UNIQUE keeps re-resolution idempotent.
+export const ANCHORS_SCHEMA = `
+  CREATE TABLE IF NOT EXISTS anchors (
+    id          TEXT PRIMARY KEY,
+    item_type   TEXT NOT NULL,   -- 'memory' | 'observation'
+    item_id     TEXT NOT NULL,
+    node_id     TEXT NOT NULL,   -- graph node id string
+    source      TEXT NOT NULL,   -- 'files' | 'semantic'
+    resolved_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    UNIQUE(item_type, item_id, node_id)
+  );
+  CREATE INDEX IF NOT EXISTS idx_anchors_item ON anchors(item_type, item_id);
+  CREATE INDEX IF NOT EXISTS idx_anchors_node ON anchors(node_id);
+`;
 
 // Memory v1 storage. observations = raw per-session/corpus claims (the corpus,
 // FTS-mirrored); memories = consolidated canonical claims an observation attaches

--- a/orchestrator/src/migrations.ts
+++ b/orchestrator/src/migrations.ts
@@ -139,7 +139,92 @@ export const MIGRATIONS: Migration[] = [
       db.exec("ALTER TABLE agent_sessions ADD COLUMN worktree_id TEXT");
     },
   },
+  {
+    id: 8,
+    name: "memory v1: observations + memories + FTS5, distill bookkeeping",
+    up: (db) => {
+      // Keep this schema IDENTICAL to the baseline block in db.ts (MEMORY_SCHEMA
+      // there) — fresh DBs are born from the baseline and skip this migration,
+      // so drift between the two would go unnoticed until an existing DB upgrades.
+      db.exec(MEMORY_SCHEMA);
+      db.exec(MEMORY_TRIGGERS);
+      // Idle-sweep bookkeeping: the highest transcript seq the distiller has
+      // already consumed for a session. NULL = never distilled.
+      db.exec("ALTER TABLE agent_sessions ADD COLUMN last_distilled_seq INTEGER");
+    },
+  },
 ];
+
+// Memory v1 storage. observations = raw per-session/corpus claims (the corpus,
+// FTS-mirrored); memories = consolidated canonical claims an observation attaches
+// to. Both carry a 768-dim Gemma embedding BLOB (see embed.ts). repo_family is
+// the normalized repo name (suffixes like -backend stripped) — the retrieval
+// hard gate keys on it. Kept in one exported string so db.ts's baseline and
+// migration 8 stay byte-identical.
+export const MEMORY_SCHEMA = `
+  CREATE TABLE IF NOT EXISTS observations (
+    id             TEXT PRIMARY KEY,
+    source         TEXT NOT NULL,   -- session | slack | linear | meeting
+    repo           TEXT,
+    repo_family    TEXT,            -- normalized repo (e.g. foo-backend -> foo); NULL = match-all
+    branch         TEXT,
+    session_id     TEXT,
+    claim          TEXT NOT NULL,
+    kind           TEXT NOT NULL,   -- decision|constraint|gotcha|how_to|preference|plan
+    source_weight  TEXT NOT NULL DEFAULT 'agent_inferred', -- user_stated|agent_inferred|error_proven
+    context_files  TEXT,            -- JSON array
+    retrieval_keys TEXT,            -- JSON array
+    embedding      BLOB,
+    memory_id      TEXT,            -- FK -> memories.id, nullable until consolidated
+    created_at     INTEGER NOT NULL DEFAULT (unixepoch())
+  );
+  CREATE INDEX IF NOT EXISTS idx_observations_family ON observations(repo_family, memory_id);
+  CREATE INDEX IF NOT EXISTS idx_observations_memory ON observations(memory_id);
+
+  CREATE TABLE IF NOT EXISTS memories (
+    id                 TEXT PRIMARY KEY,
+    claim              TEXT NOT NULL,   -- canonical
+    kind               TEXT NOT NULL,
+    repo               TEXT,
+    repo_family        TEXT,
+    strength           REAL NOT NULL DEFAULT 0,
+    evidence_count     INTEGER NOT NULL DEFAULT 0,
+    people_count       INTEGER NOT NULL DEFAULT 0,
+    contradiction_count INTEGER NOT NULL DEFAULT 0,
+    last_reinforced_at INTEGER,
+    status             TEXT NOT NULL DEFAULT 'active', -- active | sunk
+    embedding          BLOB,
+    retrieval_keys     TEXT,            -- JSON array (union of attached observations)
+    max_source_weight  TEXT NOT NULL DEFAULT 'agent_inferred',
+    created_at         INTEGER NOT NULL DEFAULT (unixepoch()),
+    updated_at         INTEGER NOT NULL DEFAULT (unixepoch())
+  );
+  CREATE INDEX IF NOT EXISTS idx_memories_family ON memories(repo_family, status);
+
+  CREATE VIRTUAL TABLE IF NOT EXISTS observations_fts USING fts5(
+    id UNINDEXED, claim, retrieval_keys,
+    content='observations', content_rowid='rowid'
+  );
+`;
+
+// FTS triggers mirroring the corpus.ts pattern — kept out of MEMORY_SCHEMA so
+// they can be created once (baseline + migration both call ensureMemoryTriggers).
+export const MEMORY_TRIGGERS = `
+  CREATE TRIGGER IF NOT EXISTS observations_ai AFTER INSERT ON observations BEGIN
+    INSERT INTO observations_fts(rowid, id, claim, retrieval_keys)
+      VALUES (new.rowid, new.id, new.claim, new.retrieval_keys);
+  END;
+  CREATE TRIGGER IF NOT EXISTS observations_ad AFTER DELETE ON observations BEGIN
+    INSERT INTO observations_fts(observations_fts, rowid, id, claim, retrieval_keys)
+      VALUES ('delete', old.rowid, old.id, old.claim, old.retrieval_keys);
+  END;
+  CREATE TRIGGER IF NOT EXISTS observations_au AFTER UPDATE ON observations BEGIN
+    INSERT INTO observations_fts(observations_fts, rowid, id, claim, retrieval_keys)
+      VALUES ('delete', old.rowid, old.id, old.claim, old.retrieval_keys);
+    INSERT INTO observations_fts(rowid, id, claim, retrieval_keys)
+      VALUES (new.rowid, new.id, new.claim, new.retrieval_keys);
+  END;
+`;
 
 export const LATEST_VERSION = MIGRATIONS.reduce((max, m) => Math.max(max, m.id), 0);
 

--- a/orchestrator/test/memory.test.ts
+++ b/orchestrator/test/memory.test.ts
@@ -399,6 +399,123 @@ describe("keyword matching + multi-memory retrieval", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Batched memory search: one call, several queries. Reuses the single-query
+// core per query (no forked ranking), groups results, preserves request order.
+describe("batched memory search", () => {
+  before(() => store.setEmbedder(stubEmbedder));
+
+  async function seed(claim: string, repo: string, keys: string[] = []) {
+    const o = await store.insertObservation({ source: "session", repo, claim, kind: "gotcha", source_weight: "user_stated", retrieval_keys: keys, session_id: "s1" });
+    return consolidate.consolidateObservation(o, async () => ({ verdict: "new" as const }));
+  }
+
+  test("groups per query and preserves request order", async () => {
+    clearMemory();
+    await seed("route all sqlite writes through the shared db singleton", "acme", ["insertObservation", "db.ts", "sqlite"]);
+    await seed("payments verified with an hmac signature", "acme", ["hmac", "webhook"]);
+    const res = await search.searchMemoryBatch({ queries: ["insertObservation", "hmac"], repo: "acme", limit: 10 });
+    assert.equal(res.groups.length, 2);
+    // order preserved: q0 is the sqlite query, q1 the hmac query
+    assert.equal(res.groups[0].query, "insertObservation");
+    assert.equal(res.groups[1].query, "hmac");
+    assert.ok(res.groups[0].result.memories.some((m) => m.claim.includes("db singleton")));
+    assert.ok(res.groups[1].result.memories.some((m) => m.claim.includes("hmac")));
+  });
+
+  test("single-query result equals that query's group in a batch (no forked logic)", async () => {
+    clearMemory();
+    await seed("retries use exponential backoff with jitter", "acme", ["retry", "backoff"]);
+    const single = await search.searchMemory({ query: "backoff", repo: "acme", limit: 10 });
+    const batch = await search.searchMemoryBatch({ queries: ["backoff"], repo: "acme", limit: 10 });
+    assert.deepEqual(
+      batch.groups[0].result.memories.map((m) => m.id),
+      single.memories.map((m) => m.id),
+    );
+  });
+
+  test("a query with no hits still gets an (empty) group in order", async () => {
+    clearMemory();
+    await seed("dashboard uses tailwind for styling", "acme", ["tailwind", "css"]);
+    const res = await search.searchMemoryBatch({ queries: ["tailwind", "zzznonexistentzzz"], repo: "acme", limit: 10 });
+    assert.equal(res.groups.length, 2);
+    assert.ok(res.groups[0].result.memories.length >= 1);
+    assert.equal(res.groups[1].result.memories.length, 0, "empty group is kept, not dropped");
+  });
+
+  test("batch render labels each query section in order", async () => {
+    clearMemory();
+    await seed("ci runs on github-actions with caching", "acme", ["github-actions", "ci"]);
+    const res = await search.searchMemoryBatch({ queries: ["github-actions", "nomatchtoken"], repo: "acme", limit: 10 });
+    const text = search.renderBatchSearchResult(res);
+    assert.match(text, /=== q1: github-actions ===/);
+    assert.match(text, /=== q2: nomatchtoken ===/);
+    assert.ok(text.indexOf("q1:") < text.indexOf("q2:"), "sections in request order");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// HTTP surface for batched search: cap enforcement, single-value backward
+// compat, and blank/empty handling live at the route, so exercise them there.
+describe("memory search route: batch shape", () => {
+  let app: any;
+  let routes: typeof import("../src/memory/routes.js");
+  let fastify: any;
+
+  before(async () => {
+    store.setEmbedder(stubEmbedder);
+    fastify = (await import("fastify")).default;
+    routes = await import("../src/memory/routes.js");
+    app = fastify();
+    routes.registerMemoryRoutes(app);
+    await app.ready();
+  });
+
+  async function seed(claim: string, repo: string, keys: string[] = []) {
+    const o = await store.insertObservation({ source: "session", repo, claim, kind: "gotcha", source_weight: "user_stated", retrieval_keys: keys, session_id: "s1" });
+    return consolidate.consolidateObservation(o, async () => ({ verdict: "new" as const }));
+  }
+
+  test("single {query} form still works (backward compatible)", async () => {
+    clearMemory();
+    store.setEmbedder(stubEmbedder);
+    await seed("payments verified with an hmac signature", "acme", ["hmac"]);
+    const res = await app.inject({ method: "POST", url: "/v1/memory/search", payload: { query: "hmac", repo: "acme" } });
+    assert.equal(res.statusCode, 200);
+    const body = res.json();
+    assert.ok("memories" in body, "single form returns flat memories");
+    assert.ok(!("groups" in body), "single form has no groups");
+    assert.ok(typeof body.lines === "string");
+  });
+
+  test("{queries:[…]} form returns grouped results in order", async () => {
+    clearMemory();
+    store.setEmbedder(stubEmbedder);
+    await seed("route sqlite writes through the db singleton", "acme", ["insertObservation", "sqlite"]);
+    await seed("payments verified with an hmac signature", "acme", ["hmac"]);
+    const res = await app.inject({ method: "POST", url: "/v1/memory/search", payload: { queries: ["insertObservation", "hmac"], repo: "acme" } });
+    assert.equal(res.statusCode, 200);
+    const body = res.json();
+    assert.equal(body.groups.length, 2);
+    assert.equal(body.groups[0].query, "insertObservation");
+    assert.equal(body.groups[1].query, "hmac");
+    assert.match(body.lines, /=== q1: insertObservation ===/);
+  });
+
+  test("over the cap (11 queries) is a clear 400, not truncation", async () => {
+    const queries = Array.from({ length: search.SEARCH_MEMORY_MAX_BATCH + 1 }, (_, i) => `q${i}`);
+    const res = await app.inject({ method: "POST", url: "/v1/memory/search", payload: { queries, repo: "acme" } });
+    assert.equal(res.statusCode, 400);
+    assert.match(res.json().error, /too many queries/);
+  });
+
+  test("blank query strings are dropped; all-blank is 400", async () => {
+    const res = await app.inject({ method: "POST", url: "/v1/memory/search", payload: { queries: ["", "   "], repo: "acme" } });
+    assert.equal(res.statusCode, 400);
+    assert.match(res.json().error, /empty/);
+  });
+});
+
+// ---------------------------------------------------------------------------
 describe("migration idempotency", () => {
   test("running migrate twice on an existing pre-v8 DB is a no-op", async () => {
     const Database = (await import("better-sqlite3")).default;

--- a/orchestrator/test/memory.test.ts
+++ b/orchestrator/test/memory.test.ts
@@ -337,6 +337,68 @@ describe("search ranking", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Grep-style keyword matching: filler words are stripped so a natural-language
+// query can't false-match a memory on a shared stopword. This is the fix for
+// the live-proof failure where "…images ON a landing page" surfaced an
+// unrelated sqlite memory because both contained "on" and FTS hits bypass the
+// silence gate. Multi-memory store so ranking/discrimination is exercised too.
+describe("keyword matching + multi-memory retrieval", () => {
+  before(() => store.setEmbedder(stubEmbedder));
+
+  async function seed(claim: string, repo: string, keys: string[] = []) {
+    const o = await store.insertObservation({ source: "session", repo, claim, kind: "gotcha", source_weight: "user_stated", retrieval_keys: keys, session_id: "s1" });
+    return consolidate.consolidateObservation(o, async () => ({ verdict: "new" as const }));
+  }
+
+  test("meaningfulTokens strips filler, keeps identifiers/paths/errors", () => {
+    const t = search.meaningfulTokens("rotating avatar images for user profile cards on a marketing landing page");
+    for (const filler of ["for", "on", "a"]) assert.ok(!t.includes(filler), `"${filler}" must be stripped`);
+    assert.ok(t.includes("avatar") && t.includes("landing"));
+    // identifiers/paths/error snippets survive at any length
+    const c = search.meaningfulTokens("SqliteError: database is locked in store.ts insertObservation");
+    assert.ok(!c.includes("is"), '"is" must be stripped');
+    assert.ok(c.includes("database") && c.includes("locked"));
+    assert.ok(c.some((x) => x.includes("store.ts")) && c.includes("insertobservation"));
+    // an all-filler query yields nothing → no keyword bypass of silence
+    assert.deepEqual(search.meaningfulTokens("how is it that we do this with the"), []);
+  });
+
+  test("stopword-only overlap does NOT surface a memory (the live bug)", async () => {
+    clearMemory();
+    // The memory shares ONLY filler words with the query below ("on", "with").
+    await seed("the ci pipeline runs on github-actions with layer caching", "acme", ["ci", "github-actions", "caching"]);
+    const res = await search.searchMemory({ query: "avatar images on profile cards with rounded corners", repo: "acme", limit: 10 });
+    assert.equal(res.memories.length, 0, "shared stopwords must not surface an unrelated memory");
+    // positive control: a real content token from that memory DOES surface it
+    const hit = await search.searchMemory({ query: "github-actions caching", repo: "acme", limit: 10 });
+    assert.ok(hit.memories.length >= 1 && hit.memories[0].ftsHit, "real keyword must still hit");
+  });
+
+  test("grep-style identifier query pinpoints the right memory among many", async () => {
+    clearMemory();
+    await seed("route all sqlite writes through the shared db singleton in db.ts", "acme", ["insertObservation", "db.ts", "sqlite"]);
+    await seed("dashboard uses tailwind for styling", "acme", ["tailwind", "css"]);
+    await seed("payments verified with an hmac signature", "acme", ["hmac", "webhook"]);
+    await seed("retries use exponential backoff with jitter", "acme", ["retry", "backoff"]);
+    const res = await search.searchMemory({ query: "insertObservation", repo: "acme", limit: 10 });
+    assert.ok(res.memories.length >= 1);
+    assert.ok(res.memories[0].claim.includes("db singleton"), "the identifier must rank the sqlite memory first");
+  });
+
+  test("both polarities of a topic surface — retrieval doesn't need to resolve negation", async () => {
+    clearMemory();
+    // Two memories, opposite advice, same topic. Retrieval should surface BOTH
+    // (the agent reads the claim text to see always vs never); the consolidator,
+    // not search, is where contradiction is adjudicated.
+    await seed("always run bare `flow up` to refresh every project at once", "acme", ["flow-up", "restart"]);
+    await seed("never run bare `flow up` — restart one project and verify health", "acme", ["flow-up", "restart"]);
+    const res = await search.searchMemory({ query: "flow-up restart", repo: "acme", limit: 10 });
+    assert.equal(res.memories.length, 2, "both the always- and never- memories must surface");
+    assert.ok(res.memories.some((m) => m.claim.includes("always")) && res.memories.some((m) => m.claim.includes("never")));
+  });
+});
+
+// ---------------------------------------------------------------------------
 describe("migration idempotency", () => {
   test("running migrate twice on an existing pre-v8 DB is a no-op", async () => {
     const Database = (await import("better-sqlite3")).default;

--- a/orchestrator/test/memory.test.ts
+++ b/orchestrator/test/memory.test.ts
@@ -1,0 +1,396 @@
+// memory.test.ts — Flow memory v1. Fully offline: an in-memory DB, a stub
+// embedder (deterministic vectors, no model), a fake judge, and an injected LLM
+// transport — NO test calls a real LLM or loads the embedding model.
+
+import { test, describe, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+// Env BEFORE importing anything that touches the DB.
+process.env.DB_PATH = ":memory:";
+process.env.FLOW_ADMIN_TOKEN = "test-admin-token-memory";
+process.env.FLOW_FAKE_OPENCODE = "1";
+process.env.FLOW_DRAIN_DISABLE = "1";
+process.env.FLOW_POLL_DISABLE = "1";
+process.env.FLOW_DISTILLER = "1";
+
+// ---- module handles, loaded in before() so DB_PATH is set first ----
+/* eslint-disable @typescript-eslint/no-explicit-any */
+let db: any;
+let slim: typeof import("../src/memory/slim.js");
+let parse: typeof import("../src/memory/parse.js");
+let repoFamily: typeof import("../src/memory/repo-family.js");
+let strength: typeof import("../src/memory/strength.js");
+let store: typeof import("../src/memory/store.js");
+let consolidate: typeof import("../src/memory/consolidate.js");
+let maintenance: typeof import("../src/memory/maintenance.js");
+let search: typeof import("../src/memory/search.js");
+let distiller: typeof import("../src/memory/distiller.js");
+let llm: typeof import("../src/memory/llm.js");
+let migrations: typeof import("../src/migrations.js");
+let cosine: (a: Float32Array, b: Float32Array) => number;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+// A deterministic stub embedder: hashes tokens into a fixed-dim vector so that
+// texts sharing tokens are close in cosine space, and negations still land
+// close to their positive (they share almost all tokens) — exactly the eval
+// hazard the banding must handle via the judge, not the cosine.
+const DIM = 64;
+function stubVec(text: string): Float32Array {
+  const v = new Float32Array(DIM);
+  const tokens = text.toLowerCase().match(/[a-z0-9]+/g) ?? [];
+  for (const tok of tokens) {
+    let h = 0;
+    for (let i = 0; i < tok.length; i++) h = (h * 31 + tok.charCodeAt(i)) >>> 0;
+    v[h % DIM] += 1;
+  }
+  // normalize
+  let n = 0;
+  for (const x of v) n += x * x;
+  n = Math.sqrt(n) || 1;
+  for (let i = 0; i < DIM; i++) v[i] /= n;
+  return v;
+}
+const stubEmbedder = async (t: string) => stubVec(t);
+
+function clearMemory(): void {
+  db.exec("DELETE FROM observations; DELETE FROM memories;");
+  store.invalidateVectorCache();
+}
+
+before(async () => {
+  db = (await import("../src/db.js")).default;
+  slim = await import("../src/memory/slim.js");
+  parse = await import("../src/memory/parse.js");
+  repoFamily = await import("../src/memory/repo-family.js");
+  strength = await import("../src/memory/strength.js");
+  store = await import("../src/memory/store.js");
+  consolidate = await import("../src/memory/consolidate.js");
+  maintenance = await import("../src/memory/maintenance.js");
+  search = await import("../src/memory/search.js");
+  distiller = await import("../src/memory/distiller.js");
+  llm = await import("../src/memory/llm.js");
+  migrations = await import("../src/migrations.js");
+  cosine = (await import("../src/embed.js")).cosine;
+  store.setEmbedder(stubEmbedder);
+});
+
+beforeEach(() => clearMemory());
+
+// ---------------------------------------------------------------------------
+describe("slimming", () => {
+  test("keeps user prompts, agent conclusions, and failed tools; drops chatter", () => {
+    const events = [
+      { kind: "created", data: { repo: "acme", backend: "claude", title: "fix bug", branch: "main" } },
+      { kind: "user_prompt", data: { text: "Make the login flow use JWT not sessions" } },
+      { kind: "update", data: { sessionUpdate: "agent_message_chunk", content: { text: "Looking into it. " } } },
+      { kind: "update", data: { sessionUpdate: "tool_call", toolCallId: "t1", title: "run tests" } },
+      { kind: "update", data: { sessionUpdate: "tool_call_update", toolCallId: "t1", status: "failed", content: [{ content: { text: "Error: ECONNREFUSED 127.0.0.1:5432" } }] } },
+      { kind: "update", data: { sessionUpdate: "agent_message_chunk", content: { text: "Done — switched to JWT." } } },
+    ];
+    const out = slim.slimTranscript(events);
+    assert.match(out, /login flow use JWT/);
+    assert.match(out, /switched to JWT/);
+    assert.match(out, /ECONNREFUSED/);
+    assert.match(out, /TOOL FAILED: run tests/);
+  });
+
+  test("caps at ~20k keeping the END", () => {
+    // Many prompt/agent turns so the assembled output (each agent run tail-capped
+    // to 1400) still overflows CAP and forces beginning-truncation.
+    const events: Array<{ kind: string; data: unknown }> = [];
+    for (let i = 0; i < 40; i++) {
+      events.push({ kind: "user_prompt", data: { text: `prompt ${i} ` + "p".repeat(600) } });
+      events.push({ kind: "update", data: { sessionUpdate: "agent_message_chunk", content: { text: `turn ${i} conclusion ` + "c".repeat(600) } } });
+    }
+    events.push({ kind: "user_prompt", data: { text: "THE_END prompt" } });
+    const out = slim.slimTranscript(events);
+    assert.ok(out.length <= 20050, `length ${out.length}`);
+    assert.match(out, /THE_END/);
+    assert.match(out, /BEGINNING TRUNCATED/);
+  });
+
+  test("strips the MCP orientation preamble", () => {
+    const preamble =
+      "You have a flow-graph tool. Consult it FIRST to orient yourself before diving into files.\n\nActually fix the JSON parser in the config loader, it drops trailing commas.";
+    const out = slim.stripPreamble(preamble);
+    assert.match(out, /preamble stripped/);
+    assert.match(out, /fix the JSON parser/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("distiller JSON parse", () => {
+  test("plain array parses", () => {
+    const reply = JSON.stringify([
+      { claim: "We use JWT for auth", kind: "decision", context: { repo: "acme" }, source: "user_stated", retrieval_keys: ["jwt", "auth"] },
+    ]);
+    const obs = parse.parseObservations(reply);
+    assert.equal(obs.length, 1);
+    assert.equal(obs[0].kind, "decision");
+  });
+
+  test("the []-then-array wrapper bug: takes the LAST valid array", () => {
+    // Model emits an empty array, reconsiders, then the real one.
+    const reply =
+      "[]\nWait, on reflection there is something durable:\n" +
+      JSON.stringify([{ claim: "Postgres must be on 5432", kind: "constraint", context: {}, source: "error_proven", retrieval_keys: ["5432", "ECONNREFUSED"] }]);
+    const obs = parse.parseObservations(reply);
+    assert.equal(obs.length, 1);
+    assert.match(obs[0].claim, /5432/);
+  });
+
+  test("markdown fences + leading prose tolerated", () => {
+    const reply = "Here are the memories:\n```json\n" + JSON.stringify([{ claim: "c", kind: "gotcha", context: {}, source: "agent_inferred", retrieval_keys: [] }]) + "\n```";
+    const obs = parse.parseObservations(reply);
+    assert.equal(obs.length, 1);
+  });
+
+  test("empty array is valid (common answer)", () => {
+    assert.deepEqual(parse.parseObservations("[]"), []);
+  });
+
+  test("malformed elements are dropped, valid ones kept", () => {
+    const reply = JSON.stringify([
+      { claim: "", kind: "decision", context: {}, source: "user_stated", retrieval_keys: [] }, // no claim
+      { claim: "good one", kind: "bogus_kind", context: {}, source: "user_stated", retrieval_keys: [] }, // bad kind
+      { claim: "keeper", kind: "how_to", context: {}, source: "user_stated", retrieval_keys: [] },
+    ]);
+    const obs = parse.parseObservations(reply);
+    assert.equal(obs.length, 1);
+    assert.equal(obs[0].claim, "keeper");
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("repo family", () => {
+  test("strips component suffixes and owner prefix", () => {
+    assert.equal(repoFamily.repoFamily("acme-backend"), "acme");
+    assert.equal(repoFamily.repoFamily("acme-frontend"), "acme");
+    assert.equal(repoFamily.repoFamily("org/acme-api.git"), "acme");
+    assert.equal(repoFamily.repoFamily("acme"), "acme");
+    assert.equal(repoFamily.repoFamily(null), null);
+  });
+
+  test("family gate: null matches all; mismatch drops", () => {
+    assert.equal(repoFamily.familyMatches("acme", "acme"), true);
+    assert.equal(repoFamily.familyMatches("acme", "other"), false);
+    assert.equal(repoFamily.familyMatches(null, "acme"), true);
+    assert.equal(repoFamily.familyMatches("acme", null), true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("strength formula properties", () => {
+  const base = { people_count: 1, evidence_count: 1, max_source_weight: "agent_inferred", contradiction_count: 0, last_reinforced_at: 1_000_000, now: 1_000_000 };
+
+  test("reinforcement (more evidence) raises strength", () => {
+    const a = strength.computeStrength(base);
+    const b = strength.computeStrength({ ...base, evidence_count: 4 });
+    assert.ok(b > a, `${b} > ${a}`);
+  });
+
+  test("contradiction lowers strength", () => {
+    const a = strength.computeStrength({ ...base, evidence_count: 3 });
+    const b = strength.computeStrength({ ...base, evidence_count: 3, contradiction_count: 2 });
+    assert.ok(b < a, `${b} < ${a}`);
+  });
+
+  test("recency decay sinks an old memory below floor", () => {
+    const fresh = strength.computeStrength({ ...base, people_count: 2, evidence_count: 2 });
+    const old = strength.computeStrength({ ...base, people_count: 2, evidence_count: 2, now: 1_000_000 + 400 * 24 * 3600 });
+    assert.ok(old < fresh);
+    assert.ok(old < strength.STRENGTH_FLOOR, `decayed ${old} should be under floor ${strength.STRENGTH_FLOOR}`);
+  });
+
+  test("people_count dominates evidence_count", () => {
+    // 3 distinct people, once each vs 1 person, 3 observations.
+    const threePeople = strength.computeStrength({ ...base, people_count: 3, evidence_count: 3 });
+    const onePersonThrice = strength.computeStrength({ ...base, people_count: 1, evidence_count: 3 });
+    assert.ok(threePeople > onePersonThrice, `${threePeople} > ${onePersonThrice}`);
+  });
+
+  test("error_proven outranks agent_inferred provenance", () => {
+    const inferred = strength.computeStrength(base);
+    const proven = strength.computeStrength({ ...base, max_source_weight: "error_proven" });
+    assert.ok(proven > inferred);
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("consolidation banding", () => {
+  before(() => store.setEmbedder(stubEmbedder));
+
+  async function obs(claim: string, repo = "acme", keys: string[] = []) {
+    return store.insertObservation({ source: "session", repo, claim, kind: "decision", source_weight: "user_stated", retrieval_keys: keys, session_id: "s1" });
+  }
+
+  test("below T_LO → new memory, judge never consulted", async () => {
+    let judgeCalls = 0;
+    const judge = async () => { judgeCalls++; return { verdict: "same" as const }; };
+    const o1 = await obs("we deploy with kubernetes helm charts");
+    const o2 = await obs("the color theme uses a warm orange palette"); // unrelated tokens → low cosine
+    await consolidate.consolidateObservation(o1, judge);
+    const r2 = await consolidate.consolidateObservation(o2, judge);
+    assert.equal(r2.action, "new");
+    assert.equal(judgeCalls, 0, "judge must not run below T_LO");
+    const count = (db.prepare("SELECT COUNT(*) AS n FROM memories").get() as { n: number }).n;
+    assert.equal(count, 2);
+  });
+
+  test("negation is CONTRADICTS, never auto-merged (embeds similarly)", async () => {
+    // "we use redis for caching" vs "we do not use redis for caching" share
+    // almost all tokens → high cosine. A naive band would merge them; the judge
+    // must be reached and its 'contradicts' honored.
+    const judge = async (_a: any, b: any) => ({ verdict: /\bnot\b/.test(b.claim) ? ("contradicts" as const) : ("same" as const) });
+    const o1 = await obs("we use redis for caching sessions");
+    const r1 = await consolidate.consolidateObservation(o1, judge);
+    const o2 = await obs("we do not use redis for caching sessions");
+    // sanity: they must actually be in the same band (>= T_LO) for this to test anything
+    const sim = cosine(stubVec(o1.claim), stubVec(o2.claim));
+    assert.ok(sim >= consolidate.T_LO, `negation cosine ${sim} must be >= T_LO ${consolidate.T_LO} to exercise the judge`);
+    const r2 = await consolidate.consolidateObservation(o2, judge);
+    assert.equal(r2.action, "contradicts");
+    assert.equal(r2.memoryId, r1.memoryId, "attached as counter-evidence to the same memory, not a new one");
+    const mem = store.getMemory(r1.memoryId);
+    assert.equal(mem.contradiction_count, 1);
+  });
+
+  test("same → reinforces (evidence++, people recompute)", async () => {
+    const judge = async () => ({ verdict: "same" as const });
+    const o1 = await store.insertObservation({ source: "session", repo: "acme", claim: "ci runs on github actions", kind: "decision", source_weight: "user_stated", session_id: "s1" });
+    const r1 = await consolidate.consolidateObservation(o1, judge);
+    const o2 = await store.insertObservation({ source: "session", repo: "acme", claim: "ci runs on github actions workflows", kind: "decision", source_weight: "user_stated", session_id: "s2" });
+    const r2 = await consolidate.consolidateObservation(o2, judge);
+    assert.equal(r2.action, "same");
+    assert.equal(r2.memoryId, r1.memoryId);
+    const mem = store.getMemory(r1.memoryId);
+    assert.equal(mem.evidence_count, 2);
+    assert.equal(mem.people_count, 2, "two distinct sessions → 2 people");
+  });
+
+  test("refines → replaces canonical claim", async () => {
+    const judge = async () => ({ verdict: "refines" as const, refinedClaim: "CI runs on GitHub Actions, self-hosted runners" });
+    const o1 = await obs("ci runs on github actions");
+    const r1 = await consolidate.consolidateObservation(o1, judge);
+    const o2 = await obs("ci runs on github actions self hosted");
+    await consolidate.consolidateObservation(o2, judge);
+    const mem = store.getMemory(r1.memoryId);
+    assert.match(mem.claim, /self-hosted runners/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("maintenance sweep", () => {
+  test("recomputes decay and sinks memories under the floor", async () => {
+    store.setEmbedder(stubEmbedder);
+    const o = await store.insertObservation({ source: "session", repo: "acme", claim: "ephemeral fact about something", kind: "gotcha", source_weight: "agent_inferred", session_id: "s1" });
+    const judge = async () => ({ verdict: "new" as const });
+    const r = await consolidate.consolidateObservation(o, judge);
+    // Backdate last_reinforced_at far into the past so decay sinks it.
+    db.prepare("UPDATE memories SET last_reinforced_at = ? WHERE id = ?").run(1000, r.memoryId);
+    const res = maintenance.sweepMemories();
+    assert.ok(res.sunk >= 1);
+    const mem = store.getMemory(r.memoryId);
+    assert.equal(mem.status, "sunk");
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("search ranking", () => {
+  before(() => store.setEmbedder(stubEmbedder));
+
+  async function seed(claim: string, repo: string | null, keys: string[] = []) {
+    const o = await store.insertObservation({ source: "session", repo, claim, kind: "decision", source_weight: "user_stated", retrieval_keys: keys, session_id: "s1" });
+    const judge = async () => ({ verdict: "new" as const });
+    return consolidate.consolidateObservation(o, judge);
+  }
+
+  test("family hard gate drops cross-family memories", async () => {
+    await seed("payment webhooks are verified with an hmac signature", "acme-backend", ["hmac", "webhook"]);
+    await seed("payment webhooks are verified with an hmac signature", "other-repo", ["hmac", "webhook"]);
+    store.setEmbedder(stubEmbedder);
+    const res = await search.searchMemory({ query: "payment webhooks hmac signature verified", repo: "acme-frontend", limit: 10 });
+    // acme-frontend shares family "acme" with acme-backend, NOT with other-repo.
+    assert.ok(res.memories.length >= 1);
+    assert.ok(res.memories.every((m) => m.claim.includes("hmac")));
+    // Ensure the other-repo memory is absent: only acme-family survives the gate.
+    const ids = new Set(res.memories.map((m) => m.id));
+    const otherFamily = db.prepare("SELECT id FROM memories WHERE repo_family = 'other'").all() as Array<{ id: string }>;
+    for (const m of otherFamily) assert.ok(!ids.has(m.id), "other-family memory must be gated out");
+  });
+
+  test("silence gate drops weak vector-only hits", async () => {
+    await seed("we chose tailwind css for styling the dashboard", "acme", ["tailwind", "css"]);
+    // Query with no token overlap → cosine ~0 → below floor, no FTS hit → dropped.
+    const res = await search.searchMemory({ query: "database migration rollback strategy", repo: "acme", limit: 10 });
+    assert.equal(res.memories.length, 0, "weak vector-only hit must be silenced");
+  });
+
+  test("FTS exact-match bypasses the silence gate", async () => {
+    // Seed a memory whose retrieval keys carry a rare identifier. A query for
+    // that identifier is an FTS exact hit even if the dense cosine is weak.
+    await seed("the flaky test is caused by a race in the WorktreePruner", "acme", ["WorktreePruner", "race"]);
+    const res = await search.searchMemory({ query: "WorktreePruner", repo: "acme", limit: 10 });
+    assert.ok(res.memories.length >= 1, "FTS exact hit must survive even under the cosine floor");
+    assert.ok(res.memories[0].ftsHit);
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("migration idempotency", () => {
+  test("running migrate twice on an existing pre-v8 DB is a no-op", async () => {
+    const Database = (await import("better-sqlite3")).default;
+    const mem = new Database(":memory:");
+    mem.exec("CREATE TABLE poll_cursors(source TEXT); CREATE TABLE events(id TEXT); CREATE TABLE jobs(id TEXT);");
+    mem.exec("CREATE TABLE agent_sessions(id TEXT PRIMARY KEY, backend TEXT, repo TEXT, cwd TEXT, title TEXT, status TEXT, created_at INTEGER, updated_at INTEGER);");
+    mem.pragma("user_version = 7");
+    migrations.migrate(mem, { fresh: false });
+    assert.equal(mem.pragma("user_version", { simple: true }), 8);
+    const cols = (mem.prepare("PRAGMA table_info(agent_sessions)").all() as Array<{ name: string }>).map((c) => c.name);
+    assert.ok(cols.includes("last_distilled_seq"));
+    // second run must not throw and must not bump the version
+    migrations.migrate(mem, { fresh: false });
+    assert.equal(mem.pragma("user_version", { simple: true }), 8);
+    // observations + FTS present
+    const tables = (mem.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as Array<{ name: string }>).map((t) => t.name);
+    assert.ok(tables.includes("observations"));
+    assert.ok(tables.includes("memories"));
+    mem.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe("distiller end-to-end (injected LLM + judge)", () => {
+  before(() => store.setEmbedder(stubEmbedder));
+
+  test("slim → parse → insert → consolidate, with a fake transport", async () => {
+    llm.setLlmTransport(async () =>
+      JSON.stringify([
+        { claim: "Auth uses JWT stored in httpOnly cookies", kind: "decision", context: { repo: "acme" }, source: "user_stated", retrieval_keys: ["jwt", "cookie", "auth"] },
+      ]),
+    );
+    const events = [
+      { kind: "created", data: { repo: "acme", backend: "claude", title: "auth", branch: "main" } },
+      { kind: "user_prompt", data: { text: "Switch auth to JWT in httpOnly cookies, not localStorage." } },
+      { kind: "update", data: { sessionUpdate: "agent_message_chunk", content: { text: "Done. JWT now lives in an httpOnly cookie." } } },
+    ];
+    const out = await distiller.distillSession({ sessionId: "sess-1", repo: "acme", branch: "main", events, judge: async () => ({ verdict: "new" as const }) });
+    assert.equal(out.ran, true);
+    assert.equal(out.observations, 1);
+    const mem = db.prepare("SELECT * FROM memories WHERE claim LIKE '%JWT%'").get() as any;
+    assert.ok(mem, "a memory should have been created");
+    assert.equal(mem.repo_family, "acme");
+  });
+
+  test("FLOW_DISTILLER=0 disables the write path", async () => {
+    const prev = process.env.FLOW_DISTILLER;
+    process.env.FLOW_DISTILLER = "0";
+    try {
+      const out = await distiller.distillSession({ sessionId: "sess-2", repo: "acme", branch: "main", events: [{ kind: "user_prompt", data: { text: "hi" } }], judge: async () => ({ verdict: "new" as const }) });
+      assert.equal(out.ran, false);
+      assert.equal(out.reason, "disabled");
+    } finally {
+      process.env.FLOW_DISTILLER = prev;
+    }
+  });
+});

--- a/orchestrator/test/memory.test.ts
+++ b/orchestrator/test/memory.test.ts
@@ -27,6 +27,10 @@ let search: typeof import("../src/memory/search.js");
 let distiller: typeof import("../src/memory/distiller.js");
 let llm: typeof import("../src/memory/llm.js");
 let migrations: typeof import("../src/migrations.js");
+let anchors: typeof import("../src/memory/anchors.js");
+let headline: typeof import("../src/memory/headline.js");
+let cards: typeof import("../src/memory/cards.js");
+let findHits: typeof import("../src/memory/find-hits.js");
 let cosine: (a: Float32Array, b: Float32Array) => number;
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
@@ -53,8 +57,9 @@ function stubVec(text: string): Float32Array {
 const stubEmbedder = async (t: string) => stubVec(t);
 
 function clearMemory(): void {
-  db.exec("DELETE FROM observations; DELETE FROM memories;");
+  db.exec("DELETE FROM observations; DELETE FROM memories; DELETE FROM anchors; DELETE FROM slack_messages; DELETE FROM linear_tickets;");
   store.invalidateVectorCache();
+  headline?.invalidateHeadlineCache();
 }
 
 before(async () => {
@@ -70,6 +75,10 @@ before(async () => {
   distiller = await import("../src/memory/distiller.js");
   llm = await import("../src/memory/llm.js");
   migrations = await import("../src/migrations.js");
+  anchors = await import("../src/memory/anchors.js");
+  headline = await import("../src/memory/headline.js");
+  cards = await import("../src/memory/cards.js");
+  findHits = await import("../src/memory/find-hits.js");
   cosine = (await import("../src/embed.js")).cosine;
   store.setEmbedder(stubEmbedder);
 });
@@ -572,5 +581,375 @@ describe("distiller end-to-end (injected LLM + judge)", () => {
     } finally {
       process.env.FLOW_DISTILLER = prev;
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section A — anchor resolution. Deterministic file matching against a STUBBED
+// NodeAnchorProvider (no graph, no gateway). Covers: file match, most-specific
+// preference (endpoint over service), cap 3, idempotent re-resolve after a node
+// disappears → fallback to repo-level, never lost.
+describe("anchor resolution (Section A)", () => {
+  before(() => store.setEmbedder(stubEmbedder));
+
+  // A provider whose node set we control per-test. Returns nodes anchored to the
+  // given files; the specificity is derived by the ranker from id/path shape
+  // unless we set it explicitly.
+  function stubProvider(nodes: Array<{ node_id: string; paths: string[]; specificity?: number }>) {
+    anchors.setNodeAnchorProvider({
+      nodesForFiles: async (_repo, _files) => nodes,
+    });
+  }
+
+  async function seedMemory(claim: string, repo: string, contextFiles: string[], keys: string[] = []) {
+    const o = await store.insertObservation({
+      source: "session", repo, claim, kind: "decision", source_weight: "user_stated",
+      context_files: contextFiles, retrieval_keys: keys, session_id: "s1",
+    });
+    return consolidate.consolidateObservation(o, async () => ({ verdict: "new" as const }));
+  }
+
+  test("rankAnchors: pure file match, most-specific first, cap 3", () => {
+    // basename match: memory touches store.ts; nodes anchored at that path.
+    const files = ["orchestrator/src/store.ts", "utils.ts"];
+    const nodes = [
+      { node_id: "svc:orchestrator", paths: ["orchestrator/src/store.ts"], specificity: 10 },
+      { node_id: "api:orchestrator:POST /store", paths: ["orchestrator/src/store.ts"], specificity: 30 },
+      { node_id: "svc:utils", paths: ["utils.ts"], specificity: 10 },
+      { node_id: "svc:unrelated", paths: ["other/thing.ts"], specificity: 10 },
+    ];
+    const ranked = anchors.rankAnchors(files, nodes);
+    assert.ok(ranked.length <= anchors.MAX_ANCHORS_PER_ITEM, "cap 3");
+    assert.equal(ranked[0], "api:orchestrator:POST /store", "most specific (endpoint) ranks first");
+    assert.ok(ranked.includes("svc:utils"));
+    assert.ok(!ranked.includes("svc:unrelated"), "a node with no matching file is excluded");
+  });
+
+  test("cap of 3 enforced even when more than 3 nodes match", () => {
+    const files = ["a.ts"];
+    const nodes = Array.from({ length: 6 }, (_, i) => ({ node_id: `svc:n${i}`, paths: ["a.ts"], specificity: 6 - i }));
+    const ranked = anchors.rankAnchors(files, nodes);
+    assert.equal(ranked.length, 3, "never more than 3 anchors");
+  });
+
+  test("consolidation resolves a memory's anchors deterministically from context_files", async () => {
+    clearMemory();
+    stubProvider([
+      { node_id: "svc:store", paths: ["orchestrator/src/store.ts"], specificity: 10 },
+      { node_id: "api:store:GET /x", paths: ["orchestrator/src/store.ts"], specificity: 30 },
+    ]);
+    const res = await seedMemory("route writes through the db singleton", "acme", ["orchestrator/src/store.ts"], ["insertObservation"]);
+    const nodeIds = anchors.nodeIdsForItem("memory", res.memoryId);
+    assert.ok(nodeIds.includes("api:store:GET /x"), "most-specific node anchored");
+    assert.ok(nodeIds.length <= 3);
+  });
+
+  test("re-resolve after a node disappears drops the edge; item falls back to repo-level, never lost", async () => {
+    clearMemory();
+    stubProvider([{ node_id: "svc:gone", paths: ["orchestrator/src/store.ts"] }]);
+    const res = await seedMemory("some durable claim about the store", "acme", ["orchestrator/src/store.ts"]);
+    assert.deepEqual(anchors.nodeIdsForItem("memory", res.memoryId), ["svc:gone"], "anchored initially");
+
+    // Node disappears from the graph → provider no longer returns it.
+    stubProvider([]);
+    const after = await anchors.resolveMemoryAnchors(res.memoryId);
+    assert.deepEqual(after, [], "re-resolve drops the stale edge");
+    assert.deepEqual(anchors.nodeIdsForItem("memory", res.memoryId), [], "edge gone");
+
+    // The memory itself still exists (repo-level fallback = the memory is intact).
+    const mem = store.getMemory(res.memoryId);
+    assert.ok(mem, "memory is never lost when its anchor disappears");
+    assert.equal(mem.repo_family, "acme");
+  });
+
+  test("no file-ish context → no anchors (stays repo-level), not an error", async () => {
+    clearMemory();
+    stubProvider([{ node_id: "svc:x", paths: ["a.ts"] }]);
+    const res = await seedMemory("a preference with no files", "acme", [], ["justwords"]);
+    assert.deepEqual(anchors.nodeIdsForItem("memory", res.memoryId), []);
+  });
+
+  test("reresolveAllMemoryAnchors is idempotent (reindex-safe)", async () => {
+    clearMemory();
+    stubProvider([{ node_id: "svc:store", paths: ["store.ts"] }]);
+    const res = await seedMemory("claim about store", "acme", ["store.ts"]);
+    await anchors.reresolveAllMemoryAnchors();
+    await anchors.reresolveAllMemoryAnchors();
+    // idempotent: exactly one edge, not duplicated.
+    assert.deepEqual(anchors.nodeIdsForItem("memory", res.memoryId), ["svc:store"]);
+  });
+
+  // Reset to a no-op provider so later suites aren't affected.
+  test("teardown: restore no-op provider", () => {
+    anchors.setNodeAnchorProvider({ nodesForFiles: async () => [] });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section B — node headline index. Typed sections, hard char cap, +N more line,
+// graceful fallback (empty when no attachments). Anchors are written directly so
+// the test doesn't depend on the provider.
+describe("node headline index (Section B)", () => {
+  before(() => store.setEmbedder(stubEmbedder));
+
+  async function seedAnchoredMemory(claim: string, repo: string, nodeId: string, keys: string[] = []) {
+    const o = await store.insertObservation({
+      source: "session", repo, claim, kind: "gotcha", source_weight: "user_stated",
+      retrieval_keys: keys, session_id: "s1",
+    });
+    const res = await consolidate.consolidateObservation(o, async () => ({ verdict: "new" as const }));
+    anchors.setAnchors("memory", res.memoryId, [nodeId], "files");
+    headline.invalidateHeadlineCache(nodeId);
+    return res.memoryId;
+  }
+
+  test("renders typed MEMORIES section with tier glyph, kind, and [mem:id]; never blends sections", async () => {
+    clearMemory();
+    await seedAnchoredMemory("payments verified with an hmac signature", "acme", "svc:payments", ["hmac"]);
+    const h = headline.getNodeHeadline("svc:payments");
+    assert.ok(h.hasAttachments);
+    assert.match(h.rendered, /MEMORIES:/);
+    assert.match(h.rendered, /\[mem:/);
+    assert.match(h.rendered, /\[gotcha\]/);
+    // no TICKETS/THREADS headers when there are none.
+    assert.ok(!/TICKETS:/.test(h.rendered));
+    assert.ok(!/THREADS:/.test(h.rendered));
+  });
+
+  test("hard char cap (~1200) enforced; overflow becomes a working +N more query", async () => {
+    clearMemory();
+    // Seed many memories on one node; the render must cap and emit +N more.
+    for (let i = 0; i < 40; i++) {
+      await seedAnchoredMemory(`durable claim number ${i} about the payments service and its many behaviors and edge cases`, "acme", "svc:payments", [`k${i}`]);
+    }
+    const h = headline.getNodeHeadline("svc:payments");
+    assert.ok(h.rendered.length <= headline.HEADLINE_CHAR_CAP, `render ${h.rendered.length} within cap ${headline.HEADLINE_CHAR_CAP}`);
+    assert.match(h.rendered, /\+\d+ more: search_memory node:svc:payments type:memory/, "overflow is a working node-scoped query");
+  });
+
+  test("memories are strength-ranked (strong first)", async () => {
+    clearMemory();
+    // A weak memory (single agent_inferred observation) and a strong one (many
+    // people). Reinforce the strong one so its strength dominates.
+    const weak = await store.insertObservation({ source: "session", repo: "acme", claim: "weak claim about caching layer", kind: "gotcha", source_weight: "agent_inferred", session_id: "sw" });
+    const wr = await consolidate.consolidateObservation(weak, async () => ({ verdict: "new" as const }));
+    anchors.setAnchors("memory", wr.memoryId, ["svc:cache"], "files");
+
+    // Strong: three distinct people reinforce it.
+    const s1 = await store.insertObservation({ source: "session", repo: "acme", claim: "strong claim about caching invalidation", kind: "gotcha", source_weight: "error_proven", session_id: "sa" });
+    const sr = await consolidate.consolidateObservation(s1, async () => ({ verdict: "new" as const }));
+    for (const sess of ["sb", "sc"]) {
+      const o = await store.insertObservation({ source: "session", repo: "acme", claim: "strong claim about caching invalidation", kind: "gotcha", source_weight: "error_proven", session_id: sess });
+      await consolidate.consolidateObservation(o, async () => ({ verdict: "same" as const }));
+    }
+    anchors.setAnchors("memory", sr.memoryId, ["svc:cache"], "files");
+    headline.invalidateHeadlineCache("svc:cache");
+
+    const h = headline.getNodeHeadline("svc:cache");
+    const strongIdx = h.rendered.indexOf("invalidation");
+    const weakIdx = h.rendered.indexOf("caching layer");
+    assert.ok(strongIdx >= 0 && weakIdx >= 0);
+    assert.ok(strongIdx < weakIdx, "the stronger memory ranks above the weaker one");
+  });
+
+  test("unanchored node → empty headline, hasAttachments false (graceful)", () => {
+    clearMemory();
+    const h = headline.getNodeHeadline("svc:nothing-here");
+    assert.equal(h.hasAttachments, false);
+    assert.equal(h.rendered, "");
+    assert.deepEqual(h.counts, { memories: 0, tickets: 0, threads: 0 });
+  });
+
+  test("cache invalidates on consolidation so a new memory shows up", async () => {
+    clearMemory();
+    await seedAnchoredMemory("first claim on svc:api", "acme", "svc:api");
+    const before = headline.getNodeHeadline("svc:api");
+    assert.equal(before.counts.memories, 1);
+    // add another, invalidate, re-read.
+    await seedAnchoredMemory("second claim on svc:api", "acme", "svc:api");
+    const after = headline.getNodeHeadline("svc:api");
+    assert.equal(after.counts.memories, 2, "cache reflects the new anchored memory");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section C — drill-down cards for each id namespace + not_found.
+describe("drill-down cards (Section C)", () => {
+  before(() => store.setEmbedder(stubEmbedder));
+
+  test("mem:<id> card carries claim, strength+tier, breakdown, born, anchors, evidence [obs:id]", async () => {
+    clearMemory();
+    const o = await store.insertObservation({ source: "session", repo: "acme", branch: "main", claim: "auth uses jwt in httpOnly cookies", kind: "decision", source_weight: "user_stated", context_files: ["auth.ts"], retrieval_keys: ["jwt"], session_id: "s1" });
+    const res = await consolidate.consolidateObservation(o, async () => ({ verdict: "new" as const }));
+    anchors.setAnchors("memory", res.memoryId, ["svc:auth"], "files");
+
+    const card = cards.getCard("mem", res.memoryId);
+    assert.equal(card.status, "found");
+    const c = card.card as any;
+    assert.equal(c.kind, "memory");
+    assert.match(c.claim, /jwt/);
+    assert.ok(typeof c.strength.value === "number" && c.strength.tier);
+    assert.ok("people_count" in c.breakdown && "evidence_count" in c.breakdown && "contradiction_count" in c.breakdown);
+    assert.equal(c.born.repo, "acme");
+    assert.equal(c.born.branch, "main");
+    assert.deepEqual(c.anchors, ["svc:auth"], "anchors are node ids");
+    assert.ok(Array.isArray(c.evidence) && c.evidence[0].id.startsWith("obs:"));
+    assert.ok(c.context_files.includes("auth.ts"));
+  });
+
+  test("obs:<id> card carries full text, source, session, parent memory id", async () => {
+    clearMemory();
+    const o = await store.insertObservation({ source: "session", repo: "acme", claim: "the flaky test is a race in WorktreePruner", kind: "gotcha", source_weight: "error_proven", session_id: "sess-42" });
+    const res = await consolidate.consolidateObservation(o, async () => ({ verdict: "new" as const }));
+    const card = cards.getCard("obs", o.id);
+    assert.equal(card.status, "found");
+    const c = card.card as any;
+    assert.equal(c.kind, "observation");
+    assert.match(c.text, /WorktreePruner/);
+    assert.equal(c.source, "session");
+    assert.equal(c.session, "sess-42");
+    assert.equal(c.parent_memory, `mem:${res.memoryId}`);
+  });
+
+  test("lin:<identifier> card: title/status/description(truncated)/permalink + anchored nodes", async () => {
+    clearMemory();
+    db.prepare("INSERT INTO linear_tickets (id, identifier, title, description, state, url, updated_at) VALUES (?,?,?,?,?,?,?)")
+      .run("t1", "ACME-123", "Fix the webhook retry", "x".repeat(600), "In Progress", "https://linear.app/acme/ACME-123", 1700000000);
+    // A corpus observation derived from the ticket, anchored to a node.
+    const o = await store.insertObservation({ source: "linear", repo: "acme", claim: "ACME-123 webhook retry work", kind: "gotcha", source_weight: "user_stated", retrieval_keys: ["ACME-123"] });
+    anchors.setAnchors("observation", o.id, ["svc:webhooks"], "files");
+
+    const card = cards.getCard("lin", "ACME-123");
+    assert.equal(card.status, "found");
+    const c = card.card as any;
+    assert.equal(c.identifier, "ACME-123");
+    assert.equal(c.status, "In Progress");
+    assert.ok(c.description.length <= 401 && c.description.endsWith("…"), "description truncated");
+    assert.match(c.permalink, /ACME-123/);
+    assert.ok(c.anchored_nodes.includes("svc:webhooks"));
+  });
+
+  test("slackthread:<ts> card: root text, participants, messages, permalink", async () => {
+    clearMemory();
+    db.prepare("INSERT INTO slack_messages (id, channel, user_id, text, ts, thread_ts, permalink) VALUES (?,?,?,?,?,?,?)")
+      .run("m1", "C1", "U1", "should we switch to JWT?", "1700000000.001", null, "https://slack/1");
+    db.prepare("INSERT INTO slack_messages (id, channel, user_id, text, ts, thread_ts, permalink) VALUES (?,?,?,?,?,?,?)")
+      .run("m2", "C1", "U2", "yes, httpOnly cookies", "1700000001.002", "1700000000.001", "https://slack/2");
+    const card = cards.getCard("slackthread", "1700000000.001");
+    assert.equal(card.status, "found");
+    const c = card.card as any;
+    assert.equal(c.kind, "thread");
+    assert.match(c.root_text, /JWT/);
+    assert.ok(c.participants.includes("U1") && c.participants.includes("U2"));
+    assert.equal(c.messages.length, 2);
+    assert.match(c.permalink, /slack/);
+  });
+
+  test("unknown id / missing row → not_found (never throws)", () => {
+    assert.equal(cards.getCard("mem", "nope").status, "not_found");
+    assert.equal(cards.getCard("lin", "NOPE-999").status, "not_found");
+    assert.equal(cards.getCard("bogus", "x").status, "not_found");
+  });
+
+  test("parseCardId splits namespaces (node ids with colons stay intact for lin/slackthread)", () => {
+    assert.deepEqual(cards.parseCardId("mem:abc-123"), { type: "mem", id: "abc-123" });
+    assert.deepEqual(cards.parseCardId("slackthread:1700000000.001"), { type: "slackthread", id: "1700000000.001" });
+    assert.equal(cards.parseCardId("svc:users"), null, "graph node ids are not card namespaces");
+    assert.equal(cards.parseCardId("noColon"), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section E — node-scoped search composes with type filter + keywords.
+describe("node-scoped search (Section E)", () => {
+  before(() => store.setEmbedder(stubEmbedder));
+
+  async function seedAnchored(claim: string, repo: string, nodeId: string | null, keys: string[] = []) {
+    const o = await store.insertObservation({ source: "session", repo, claim, kind: "decision", source_weight: "user_stated", retrieval_keys: keys, session_id: "s1" });
+    const res = await consolidate.consolidateObservation(o, async () => ({ verdict: "new" as const }));
+    if (nodeId) anchors.setAnchors("memory", res.memoryId, [nodeId], "files");
+    return res.memoryId;
+  }
+
+  test("parseSearchTokens pulls node:/type: out; node ids with colons survive", () => {
+    const p = search.parseSearchTokens("node:api:dashboard:GET /agents type:memory hmac verify");
+    assert.equal(p.node, "api:dashboard:GET /agents");
+    assert.equal(p.type, "memory");
+    assert.equal(p.query, "hmac verify");
+  });
+
+  test("node: token filters to items anchored to that node", async () => {
+    clearMemory();
+    const onNode = await seedAnchored("payments verified with hmac on svc:payments", "acme", "svc:payments", ["hmac"]);
+    await seedAnchored("unrelated caching claim elsewhere", "acme", "svc:cache", ["cache"]);
+    const res = await search.searchMemory({ query: "node:svc:payments hmac", repo: "acme", limit: 10 });
+    const ids = res.memories.map((m) => m.id);
+    assert.ok(ids.includes(onNode));
+    assert.equal(ids.length, 1, "only the node-anchored memory surfaces");
+  });
+
+  test("empty query under a node scope returns the node's memories (the +N more query)", async () => {
+    clearMemory();
+    await seedAnchored("first anchored claim", "acme", "svc:payments", ["k1"]);
+    await seedAnchored("second anchored claim", "acme", "svc:payments", ["k2"]);
+    const res = await search.searchMemory({ query: "node:svc:payments", repo: "acme", limit: 10 });
+    assert.equal(res.memories.length, 2, "the anchored set IS the answer for a bare node scope");
+  });
+
+  test("type:memory composes with node scope; keeps only memory hits", async () => {
+    clearMemory();
+    await seedAnchored("anchored memory claim", "acme", "svc:payments", ["hmac"]);
+    const res = await search.searchMemory({ query: "node:svc:payments type:memory hmac", repo: "acme", limit: 10 });
+    assert.ok(res.memories.length >= 1);
+    assert.equal(res.corpus.length, 0, "type:memory excludes corpus");
+  });
+
+  test("node scope drops memories anchored to OTHER nodes even on a keyword hit", async () => {
+    clearMemory();
+    await seedAnchored("hmac claim on the wrong node", "acme", "svc:other", ["hmac"]);
+    const res = await search.searchMemory({ query: "node:svc:payments hmac", repo: "acme", limit: 10 });
+    assert.equal(res.memories.length, 0, "keyword hit on a non-scoped node is filtered out");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Section D (orchestrator half) — find_entity memory hits + type quota. The
+// gateway merge is tested on the gateway side; here we verify the quota and the
+// typed terse line shape produced by find-hits.ts (reusing search ranking/gates).
+describe("find_entity memory hits + quota (Section D)", () => {
+  before(() => store.setEmbedder(stubEmbedder));
+
+  async function seed(claim: string, repo: string, keys: string[]) {
+    const o = await store.insertObservation({ source: "session", repo, claim, kind: "gotcha", source_weight: "user_stated", retrieval_keys: keys, session_id: "s1" });
+    return consolidate.consolidateObservation(o, async () => ({ verdict: "new" as const }));
+  }
+
+  test("terse typed line shape: [Memory:<kind>] headline (tier) [mem:id]", async () => {
+    clearMemory();
+    await seed("payments verified with hmac signature", "acme", ["hmac"]);
+    const hits = await findHits.memoryHitsForQuery("hmac", "acme");
+    assert.ok(hits.length >= 1);
+    assert.match(hits[0].line, /^\[Memory:gotcha\] .+ \((strong|medium|weak)\) \[mem:[0-9a-f-]+\]$/);
+  });
+
+  test("quota caps memory hits at 3 for an untyped query", async () => {
+    clearMemory();
+    for (let i = 0; i < 6; i++) await seed(`hmac related claim ${i}`, "acme", ["hmac", `k${i}`]);
+    const hits = await findHits.memoryHitsForQuery("hmac", "acme");
+    assert.equal(hits.length, findHits.MEMORY_HIT_QUOTA, "untyped query is capped at the quota");
+  });
+
+  test("quota LIFTS when the query carries a type filter", async () => {
+    clearMemory();
+    for (let i = 0; i < 6; i++) await seed(`hmac related claim ${i}`, "acme", ["hmac", `k${i}`]);
+    const hits = await findHits.memoryHitsForQuery("type:memory hmac", "acme", { limit: 10 });
+    assert.ok(hits.length > findHits.MEMORY_HIT_QUOTA, "a typed query lifts the quota");
+  });
+
+  test("the 0.55 silence gate still applies to hits (no keyword → no noise)", async () => {
+    clearMemory();
+    await seed("we chose tailwind css for styling", "acme", ["tailwind"]);
+    const hits = await findHits.memoryHitsForQuery("database migration rollback", "acme");
+    assert.equal(hits.length, 0, "a weak vector-only match is silenced, so no memory hit blends in");
   });
 });

--- a/orchestrator/test/memory.test.ts
+++ b/orchestrator/test/memory.test.ts
@@ -524,16 +524,17 @@ describe("migration idempotency", () => {
     mem.exec("CREATE TABLE agent_sessions(id TEXT PRIMARY KEY, backend TEXT, repo TEXT, cwd TEXT, title TEXT, status TEXT, created_at INTEGER, updated_at INTEGER);");
     mem.pragma("user_version = 7");
     migrations.migrate(mem, { fresh: false });
-    assert.equal(mem.pragma("user_version", { simple: true }), 8);
+    assert.equal(mem.pragma("user_version", { simple: true }), migrations.LATEST_VERSION);
     const cols = (mem.prepare("PRAGMA table_info(agent_sessions)").all() as Array<{ name: string }>).map((c) => c.name);
     assert.ok(cols.includes("last_distilled_seq"));
     // second run must not throw and must not bump the version
     migrations.migrate(mem, { fresh: false });
-    assert.equal(mem.pragma("user_version", { simple: true }), 8);
-    // observations + FTS present
+    assert.equal(mem.pragma("user_version", { simple: true }), migrations.LATEST_VERSION);
+    // observations + memories + anchors (migration 9) present
     const tables = (mem.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as Array<{ name: string }>).map((t) => t.name);
     assert.ok(tables.includes("observations"));
     assert.ok(tables.includes("memories"));
+    assert.ok(tables.includes("anchors"), "migration 9 creates the anchors table");
     mem.close();
   });
 });

--- a/scripts/backfill-corpus-observations.mjs
+++ b/scripts/backfill-corpus-observations.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+// backfill-corpus-observations.mjs — one-shot: turn existing slack_messages and
+// linear_tickets rows into memory `observations` so search_memory sees history
+// that predates the corpus-enrichment write path.
+//
+// Idempotent: skips a row whose observation already exists (matched on a stable
+// synthetic id derived from source+source_id). Embeddings are left NULL here —
+// this script does not load the model; the observations are still FTS-searchable
+// immediately and can be re-embedded by a later maintenance pass. (Running the
+// live orchestrator with the enrichment path is the embedded route; this script
+// is the catch-up for pre-existing rows.)
+//
+// Usage:
+//   DB_PATH=/path/to/flow.db node scripts/backfill-corpus-observations.mjs [--limit N] [--dry]
+//
+// SAFETY: point DB_PATH at the target DB explicitly. Never runs against a DB it
+// wasn't told about; refuses if DB_PATH is unset.
+
+import Database from "better-sqlite3";
+import { randomUUID } from "node:crypto";
+
+const DB_PATH = process.env.DB_PATH;
+if (!DB_PATH) {
+  console.error("Refusing to run: set DB_PATH to the target flow.db explicitly.");
+  process.exit(1);
+}
+const argv = process.argv.slice(2);
+const dry = argv.includes("--dry");
+const limIdx = argv.indexOf("--limit");
+const limit = limIdx >= 0 ? Number(argv[limIdx + 1]) : Infinity;
+
+// repo_family normalization must match orchestrator/src/memory/repo-family.ts.
+const SUFFIXES = ["backend","frontend","api","server","client","web","app","service","svc","ui","worker","core","lib","sdk","infra","mobile"];
+function repoFamily(repo) {
+  if (!repo) return null;
+  let name = String(repo).trim().toLowerCase();
+  if (!name) return null;
+  const slash = name.lastIndexOf("/");
+  if (slash >= 0) name = name.slice(slash + 1);
+  name = name.replace(/\.git$/, "");
+  for (const s of SUFFIXES) {
+    const re = new RegExp(`[-_]${s}$`);
+    if (re.test(name)) { name = name.replace(re, ""); break; }
+  }
+  return name || null;
+}
+
+const db = new Database(DB_PATH);
+db.pragma("foreign_keys = ON");
+
+// A synthetic, stable observation id per corpus row so re-runs are idempotent.
+const existsStmt = db.prepare("SELECT 1 FROM observations WHERE id = ?");
+const insertStmt = db.prepare(`
+  INSERT INTO observations
+    (id, source, repo, repo_family, branch, session_id, claim, kind, source_weight,
+     context_files, retrieval_keys, embedding, memory_id)
+  VALUES (@id, @source, @repo, @repo_family, NULL, NULL, @claim, 'gotcha', 'user_stated',
+          NULL, NULL, NULL, NULL)
+`);
+
+function backfill(rows, source, textOf, repoOf) {
+  let inserted = 0, skipped = 0;
+  const tx = db.transaction(() => {
+    for (const r of rows) {
+      const id = `backfill:${source}:${r.id}`;
+      if (existsStmt.get(id)) { skipped++; continue; }
+      const text = (textOf(r) || "").trim();
+      if (!text) { skipped++; continue; }
+      const repo = repoOf(r) ?? null;
+      if (!dry) {
+        insertStmt.run({ id, source, repo, repo_family: repoFamily(repo), claim: text.slice(0, 1000) });
+      }
+      inserted++;
+    }
+  });
+  tx();
+  return { inserted, skipped };
+}
+
+const slackRows = db.prepare("SELECT id, text FROM slack_messages LIMIT ?").all(Number.isFinite(limit) ? limit : -1);
+const slack = backfill(slackRows, "slack", (r) => r.text, () => null);
+
+const linearRows = db.prepare("SELECT id, identifier, title, description FROM linear_tickets LIMIT ?").all(Number.isFinite(limit) ? limit : -1);
+const linear = backfill(
+  linearRows,
+  "linear",
+  (r) => [r.title, r.description].filter(Boolean).join(" — "),
+  () => null,
+);
+
+console.log(`${dry ? "[dry] " : ""}slack:  +${slack.inserted} (skipped ${slack.skipped})`);
+console.log(`${dry ? "[dry] " : ""}linear: +${linear.inserted} (skipped ${linear.skipped})`);
+db.close();


### PR DESCRIPTION
# Memory v1: passive session distillation + evidence-based knowledge store + retrieval surface

> **Two commits land on this PR shortly** (a benchmark is currently running against the branch's services): (1) rename `search_memory` → `search_knowledge` (decided; the text below already uses the new name), (2) the final memory-benchmark results table where marked. Everything else is complete and green.

## What this is

Flow learns from coding sessions passively. At session end (close or 45-min idle), a small-model **distiller** reads the transcript and extracts durable observations — gotchas, decisions, how-tos, constraints — with symptom-shaped retrieval keys (verbatim error strings, file paths). A **consolidator** merges observations into memories: cosine below 0.50 auto-creates; everything else goes to a haiku judge (`same|new|refines|contradicts`) because embeddings cannot detect negation (measured: contradictions embed *more* similarly than rewordings — a naive similarity merge would silently fold "never do X" into "always do X" 87% of the time). Memory **strength is computed, never granted**: distinct people dominate repetition, error-proven beats user-stated beats inferred, contradictions halve strength, 45-day recency half-life; weak memories sink automatically. No agent-facing write verbs, no review queues, no human gates.

Retrieval is **pull-only** (no injection, no auto-attach): `search_knowledge` greps memories + Slack/Linear corpus on meaningful tokens (stopwords stripped — a query can't match a memory on a shared "on") with embeddings as fuzzy assist, hard repo-family gate, and a 0.55 cosine silence gate with FTS exact-match bypass. Memories anchor to graph nodes (deterministic file→node resolution, most-specific-first, cap 3); `get_entity` on a node appends a ≤300-token **headline index** (typed MEMORIES/TICKETS/THREADS one-liners, never bodies) whose "+N more" line is a working node-scoped query; `mem:`/`obs:`/`lin:` ids drill down to evidence cards through the same verb. `find_entity` merges up to 3 quota'd memory hits. All read verbs accept batched inputs.

## Evidence (all offline evals + live proofs on real data, artifacts in flow-benchmarks/)

- **Distiller precision 95.7%** (sonnet) over 12 real session transcripts; never leaked a secret (2 transcripts contained live keys); records conclusions, not mid-session reversed beliefs. `memory-evals/distiller/`
- **Consolidator: zero fatal merges** across 70 adversarial pairs (incl. lexically-near negations); banded design auto-resolves 21% for free. `memory-evals/consolidator/`
- **Retrieval eval** (minimal-context): no safe auto-inject threshold exists — drove the pull-only + anchor-gate + silence-gate design. `memory-evals/retrieval/`
- **Self-play lifecycle** (live MCP, real distiller): agent that hit a trap → memory formed → fresh agent avoided it: **−44% turns, −21% tokens** vs baseline; empty-store control isolates the win to memory content. `memory-evals/selfplay/`
- **Live trigger + embeddings**: session→closed fired the distiller automatically (~20s, non-blocking); 768-dim embeddings stored at write time; warm search latency **9ms median** (300ms budget). `memory-evals/live/`
- **Memory-dependent benchmark** (11 questions answerable only from memory, 3 arms × 2 paired runs, blind-judged):

<!-- FINAL TABLE HERE when run completes: accuracy / tokens / cost / search rate / retrieval hit rate per arm M0/M1/M2 -->

## Tests

Orchestrator 219/219 (was 154 before this branch), gateway 23/23 (new suite, runs without FalkorDB), gateway `tsc` clean. All tests offline: `:memory:` DBs, stub embedder, fake judge, injected LLM transport.

## Deliberately out (decided, not deferred)

Push injection, auto-attach at orient, human-gated procedures, review queues, branch-note verbs, per-turn tailing, repo-committed config.

## Known v1 pragmatics

- Corpus observations match their linear/slack rows by identifier/ts (no FK yet); corpus-ingest auto-anchoring wired but not invoked (ingest-path owner's call).
- Runtime never emits `closed` today — the idle sweep is the live trigger path; the `closed` hook is wired for when the transition exists.
- Search runs FTS-primary; embedding assist improves as the embedder does (Gemma's compressed cosine range documented in evals).
