### PR TITLE
Rename search_memory → search_knowledge

### DIFF
--- a/graph-gateway/src/mcp.ts
+++ b/graph-gateway/src/mcp.ts
@@ -44,7 +44,7 @@ const SESSION_VERBS = new Set([
   // Ungated branch-scoped working memory.
   "note",
   // Retrieve-only cross-session memory (distilled decisions/gotchas + corpus).
-  "search_memory",
+  "search_knowledge",
 ]);
 // The graph-builder surface: exactly what the old .opencode/tools/graph.ts
 // plugin exposed, now served over MCP so workspaces need no npm install.

--- a/graph-gateway/src/memory-client.ts
+++ b/graph-gateway/src/memory-client.ts
@@ -1,6 +1,6 @@
 // memory-client.ts — the gateway's thin HTTP client to the orchestrator's
 // memory surface (flow.db-backed). The gateway never touches flow.db directly;
-// it proxies, matching the FLOW_NOTES_URL / search_memory precedent.
+// it proxies, matching the FLOW_NOTES_URL / search_knowledge precedent.
 //
 // IMPLEMENTATION CHOICE (Sections B/C/D): rather than PROJECT memories into
 // FalkorDB (which would make the graph a second source of truth and require

--- a/graph-gateway/src/verbs.ts
+++ b/graph-gateway/src/verbs.ts
@@ -938,7 +938,7 @@ async function correctGraph(input: z.infer<z.ZodObject<typeof correctGraphInput>
 // for Flow-run sessions the runtime injects defaults via env.
 
 // ---------------------------------------------------------------------------
-// search_memory — retrieve-only access to Flow's memory (distilled session
+// search_knowledge — retrieve-only access to Flow's memory (distilled session
 // memories + slack/linear corpus). Thin proxy to the orchestrator, which owns
 // the store, the embeddings, and the eval-calibrated ranking (family hard gate,
 // silence gate, FTS exact-match bypass). Search it like you grep: symptoms,
@@ -1198,7 +1198,7 @@ async function orient(input: z.infer<z.ZodObject<typeof orientInput>>) {
   }
   out.push("");
   // MEMORY — cross-session distilled knowledge + corpus, reached via
-  // search_memory (retrieve-only). Counts orient the agent to whether it's
+  // search_knowledge (retrieve-only). Counts orient the agent to whether it's
   // worth a look; the one-liner tells it how to query.
   if (memStats && (memStats.memories > 0 || memStats.observations > 0)) {
     const srcBits = Object.entries(memStats.bySource)
@@ -1208,14 +1208,14 @@ async function orient(input: z.infer<z.ZodObject<typeof orientInput>>) {
     out.push(
       `MEMORY: ${memStats.memories} distilled ${memStats.memories === 1 ? "memory" : "memories"}` +
         (srcBits ? ` from ${srcBits} observations` : "") +
-        `. Search it like you grep — symptoms, identifiers, file paths work best (search_memory). ` +
+        `. Search it like you grep — symptoms, identifiers, file paths work best (search_knowledge). ` +
         `get_entity on a node also shows a headline index of the memories/tickets/threads anchored to it. ` +
         `Drill into any [mem:…]/[obs:…]/[lin:…] with get_entity (batch ids[] works). ` +
-        `Scope a search to a node with search_memory node:<node_id> (composes with type:memory|ticket|thread).`,
+        `Scope a search to a node with search_knowledge node:<node_id> (composes with type:memory|ticket|thread).`,
     );
   } else {
     out.push(
-      "MEMORY: none yet — it fills as sessions end. Query with search_memory (symptoms, identifiers, file paths work best); " +
+      "MEMORY: none yet — it fills as sessions end. Query with search_knowledge (symptoms, identifiers, file paths work best); " +
         "get_entity shows a per-node headline index once memories anchor to nodes.",
     );
   }
@@ -1264,7 +1264,7 @@ export const verbs = {
   },
   get_entity: {
     description:
-      "Fetch a node with all its incoming and outgoing relationships, plus a headline INDEX of the memories/tickets/threads anchored to it (headlines only, ~300 tokens; a '+N more' line is a working search_memory node:<id> query). Also resolves memory drill-down ids — mem:<id> (memory card: strength breakdown, anchors, evidence), obs:<id>, lin:<identifier>, slackthread:<ts>. BATCH: pass ids:[…] (up to 15) to fetch several nodes/cards in one call — sections come back in request order, one per id, with an explicit not-found entry for any missing id; prefer one batched call over sequential single lookups.",
+      "Fetch a node with all its incoming and outgoing relationships, plus a headline INDEX of the memories/tickets/threads anchored to it (headlines only, ~300 tokens; a '+N more' line is a working search_knowledge node:<id> query). Also resolves memory drill-down ids — mem:<id> (memory card: strength breakdown, anchors, evidence), obs:<id>, lin:<identifier>, slackthread:<ts>. BATCH: pass ids:[…] (up to 15) to fetch several nodes/cards in one call — sections come back in request order, one per id, with an explicit not-found entry for any missing id; prefer one batched call over sequential single lookups.",
     shape: getEntityInput,
     handler: getEntity,
   },
@@ -1313,7 +1313,7 @@ export const verbs = {
     shape: noteInput,
     handler: noteVerb,
   },
-  search_memory: {
+  search_knowledge: {
     description:
       "Search Flow's cross-session memory (distilled decisions, constraints, gotchas, how-tos, preferences) plus the slack/linear corpus. Retrieve-only. Search it like you grep — verbatim error snippets, identifiers, command names, and file paths work best. Call it when a failure surprises you or before making a decision that a past session may have already settled. Scope to a graph node with a `node:<node_id>` token (filters to items anchored to that node — this is what get_entity's '+N more' line runs); narrow by kind with `type:memory|ticket|thread`; both compose with keywords. BATCH: pass queries:[…] (up to 10) to search several things at once — results come back grouped per query, in order; prefer one batched call over sequential single searches.",
     shape: searchMemoryInput,

--- a/orchestrator/_live_driver.ts
+++ b/orchestrator/_live_driver.ts
@@ -1,0 +1,261 @@
+// _live_driver.ts — LIVE end-to-end proof of the session-memory distiller.
+// Placed inside orchestrator/ so imports resolve against the worktree.
+//
+// It (1) runs migrations (via db.ts import), (2) synthesizes a REAL agent_sessions
+// row + a real JSONL transcript in SESSIONS_DIR, (3) fires the GENUINE trigger
+// (onSessionClosed — the exact callback setStatus invokes when a session goes
+// 'closed'), (4) waits for the non-blocking distill to complete, (5) dumps the
+// write-path state, then (6) runs the three retrieval queries through the real
+// searchMemory (query embedded via the real gateway /v1/embed hop).
+
+import { randomUUID } from "node:crypto";
+import { mkdirSync, writeFileSync, appendFileSync } from "node:fs";
+import path from "node:path";
+import db from "./src/db.js";
+import { blobToVec } from "./src/embed.js";
+// Importing runtime wires setTranscriptReader(readTranscript) + startIdleSweep()
+// — the REAL trigger wiring. We drive onSessionClosed, the closed-trigger entry.
+import { readTranscript } from "./src/agents/runtime.js";
+import { onSessionClosed, maybeDistill, stopIdleSweep } from "./src/memory/trigger.js";
+import { searchMemory } from "./src/memory/search.js";
+import { memoryStats } from "./src/memory/routes.js";
+
+const OUT = process.env.LIVE_OUT ?? "/tmp/memlive-out";
+mkdirSync(OUT, { recursive: true });
+
+// SESSIONS_DIR is derived by runtime.ts as dirname(DB_PATH)/agent-sessions.
+const DB_PATH = process.env.DB_PATH!;
+const SESSIONS_DIR = path.join(path.dirname(DB_PATH), "agent-sessions");
+mkdirSync(SESSIONS_DIR, { recursive: true });
+
+const SESSION_ID = randomUUID();
+const REPO = "flow-orchestrator"; // family -> "flow"
+const BRANCH = "flow/session-memory-distiller";
+
+function log(...a: unknown[]) {
+  console.log("[driver]", ...a);
+}
+
+// --- 1. Build a realistic multi-turn coding-session transcript ------------
+// The durable lesson: a specific gotcha (opening a 2nd better-sqlite3 connection
+// in the distiller path collides with the WAL checkpoint) + its fix (reuse the
+// shared db singleton) + a verbatim error string.
+const VERBATIM_ERROR = "SqliteError: database is locked";
+
+let seq = 0;
+function ev(kind: string, data: unknown) {
+  return { seq: ++seq, ts: Date.now(), kind, data };
+}
+
+const events = [
+  ev("created", { repo: REPO, backend: "claude", title: "distiller crashes on session close", branch: BRANCH }),
+  ev("user_prompt", {
+    text:
+      "The memory distiller crashes intermittently when a session closes. I see 'SqliteError: database is locked' in the orchestrator logs whenever two sessions close near the same time. Figure out why and fix it.",
+  }),
+  ev("update", {
+    sessionUpdate: "agent_message_chunk",
+    content: {
+      text:
+        "Let me reproduce. I'll close two sessions in quick succession and watch the distiller path in orchestrator/src/memory/store.ts.",
+    },
+  }),
+  ev("update", {
+    sessionUpdate: "tool_call",
+    toolCallId: "t1",
+    title: "Bash: run distiller twice concurrently",
+    _meta: { claudeCode: { toolName: "Bash" } },
+  }),
+  ev("update", {
+    sessionUpdate: "tool_call_update",
+    toolCallId: "t1",
+    status: "failed",
+    content: [
+      {
+        content: {
+          text:
+            "SqliteError: database is locked\n    at Database.prepare (better-sqlite3)\n    at insertObservation (orchestrator/src/memory/store.ts:88)",
+        },
+      },
+    ],
+  }),
+  ev("update", {
+    sessionUpdate: "agent_message_chunk",
+    content: {
+      text:
+        "Found it. The distiller path was opening a SECOND better-sqlite3 connection (new Database(DB_PATH)) instead of reusing the shared singleton exported from orchestrator/src/db.ts. Under WAL mode, when the periodic checkpoint runs, a second writer connection contends and throws 'SqliteError: database is locked'. The fix is to NEVER open a second better-sqlite3 connection in the distiller/consolidate path — always import and reuse the single shared `db` from db.ts, which serializes writes on one connection. After switching to the shared singleton the concurrent-close reproduction passes cleanly.",
+    },
+  }),
+  ev("update", {
+    sessionUpdate: "agent_message_chunk",
+    content: {
+      text:
+        "Conclusion: in this repo, all SQLite access in the memory subsystem must go through the shared db singleton in orchestrator/src/db.ts. Opening a fresh better-sqlite3 Database on the same file while WAL checkpointing is active deadlocks with 'SqliteError: database is locked'. This is a durable gotcha for anyone touching the distiller write path.",
+    },
+  }),
+];
+
+const jsonl = events.map((e) => JSON.stringify(e)).join("\n") + "\n";
+const transcriptPath = path.join(SESSIONS_DIR, `${SESSION_ID}.jsonl`);
+writeFileSync(transcriptPath, jsonl);
+log("wrote transcript", transcriptPath, `(${events.length} events, maxSeq=${seq})`);
+writeFileSync(path.join(OUT, "transcript.jsonl"), jsonl);
+
+// --- 2. Insert the matching agent_sessions row (real schema) ---------------
+const now = Date.now();
+db.prepare(
+  `INSERT INTO agent_sessions (id, backend, repo, cwd, title, status, worktree_id, last_distilled_seq, created_at, updated_at)
+   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+).run(SESSION_ID, "claude", REPO, "/tmp/fake-cwd", "distiller crashes on session close", "closed", null, null, now, now);
+log("inserted agent_sessions row", SESSION_ID, "status=closed last_distilled_seq=NULL");
+
+// Sanity: the runtime's transcript reader (wired by importing runtime.ts) sees it.
+const readBack = readTranscript(SESSION_ID);
+log("readTranscript sees", readBack.length, "events; last seq =", readBack[readBack.length - 1]?.seq);
+
+async function main() {
+  // --- 3. Confirm migrations ran (tables exist) --------------------------
+  const tables = db
+    .prepare(`SELECT name FROM sqlite_master WHERE type IN ('table','view') AND name IN ('observations','memories','observations_fts')`)
+    .all()
+    .map((r: any) => r.name);
+  log("memory tables present:", tables.join(", "));
+
+  // --- 4. FIRE THE REAL TRIGGER ------------------------------------------
+  // onSessionClosed is the exact callback setStatus() calls on status->'closed'.
+  // It funnels through queueDistill -> setImmediate -> maybeDistill (the real
+  // high-water-mark + transcript reader + non-blocking distillSession logic).
+  // This is NOT a direct distillSession() call.
+  const method = process.env.TRIGGER_METHOD ?? "onSessionClosed";
+  log(`FIRING TRIGGER via ${method} (branch=${BRANCH})`);
+  const fireT0 = Date.now();
+  if (method === "maybeDistill") {
+    // idle-sweep's unit of work, awaited so we know when it finished.
+    const ran = await maybeDistill(SESSION_ID, BRANCH);
+    log("maybeDistill returned ran =", ran, `(${Date.now() - fireT0}ms)`);
+  } else {
+    // The genuine closed-trigger. Fire-and-forget via setImmediate; we then
+    // poll last_distilled_seq to know when the async distill completed.
+    onSessionClosed(SESSION_ID, BRANCH);
+    log("onSessionClosed dispatched (non-blocking); polling for completion…");
+    const deadline = Date.now() + 180_000;
+    let done = false;
+    while (Date.now() < deadline) {
+      const row = db.prepare(`SELECT last_distilled_seq FROM agent_sessions WHERE id = ?`).get(SESSION_ID) as {
+        last_distilled_seq: number | null;
+      };
+      const obsCount = (db.prepare(`SELECT COUNT(*) c FROM observations WHERE session_id = ?`).get(SESSION_ID) as any).c;
+      if (row.last_distilled_seq != null || obsCount > 0) {
+        done = true;
+        log(
+          `distill completed automatically after ${Date.now() - fireT0}ms:`,
+          `last_distilled_seq=${row.last_distilled_seq}, observations=${obsCount}`,
+        );
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 500));
+    }
+    if (!done) {
+      log("WARN: trigger did not complete within deadline");
+    }
+  }
+
+  // --- 5. VERIFY WRITE PATH ----------------------------------------------
+  const obsRows = db
+    .prepare(`SELECT id, claim, kind, source_weight, repo, repo_family, retrieval_keys, memory_id, length(embedding) AS emblen FROM observations WHERE session_id = ?`)
+    .all(SESSION_ID) as any[];
+  log(`OBSERVATIONS for session: ${obsRows.length}`);
+  for (const o of obsRows) {
+    const dims = o.emblen != null ? o.emblen / 4 : null;
+    log(`  obs ${o.id.slice(0, 8)} kind=${o.kind} src=${o.source_weight} embDims=${dims} claim="${o.claim.slice(0, 110)}"`);
+  }
+  const memRows = db
+    .prepare(`SELECT id, claim, kind, repo_family, strength, evidence_count, status, length(embedding) AS emblen FROM memories`)
+    .all() as any[];
+  log(`MEMORIES: ${memRows.length}`);
+  for (const m of memRows) {
+    const dims = m.emblen != null ? m.emblen / 4 : null;
+    log(`  mem ${m.id.slice(0, 8)} kind=${m.kind} strength=${m.strength.toFixed?.(3) ?? m.strength} ev=${m.evidence_count} embDims=${dims} claim="${m.claim.slice(0, 110)}"`);
+  }
+  writeFileSync(
+    path.join(OUT, "write-path.json"),
+    JSON.stringify({ stats: memoryStats(), observations: obsRows, memories: memRows }, null, 2),
+  );
+
+  // Confirm embedding blobs are real 768-float vectors (non-null, non-zero).
+  const embCheck = db.prepare(`SELECT embedding FROM observations WHERE session_id = ? AND embedding IS NOT NULL LIMIT 1`).get(SESSION_ID) as any;
+  if (embCheck?.embedding) {
+    const v = blobToVec(embCheck.embedding);
+    const norm = Math.sqrt(v.reduce((s, x) => s + x * x, 0));
+    log(`embedding sanity: dims=${v.length}, L2norm=${norm.toFixed(4)}, first3=[${v[0].toFixed(4)},${v[1].toFixed(4)},${v[2].toFixed(4)}]`);
+  } else {
+    log("WARN: no non-null observation embedding found");
+  }
+
+  // --- 6. VERIFY EMBEDDING RETRIEVAL -------------------------------------
+  // (a) semantic paraphrase sharing NO exact tokens with claim/keys/error.
+  // (b) verbatim error string (FTS bypass of silence gate).
+  // (c) unrelated query in the SAME repo family (silence-gate drop).
+  const queries: Array<{ label: string; query: string }> = [
+    {
+      label: "a) SEMANTIC paraphrase (no shared tokens)",
+      query: "why does the second concurrent writer deadlock when journaling checkpoints happen",
+    },
+    { label: "b) VERBATIM error (FTS)", query: "SqliteError: database is locked" },
+    { label: "c) UNRELATED same-family (silence gate)", query: "how do I configure the Slack notification webhook signature" },
+  ];
+
+  const retrieval: any[] = [];
+  for (const q of queries) {
+    const t0 = Date.now();
+    const res = await searchMemory({ query: q.query, repo: REPO, limit: 8 });
+    const ms = Date.now() - t0;
+    log(`\nQUERY ${q.label}`);
+    log(`  "${q.query}"`);
+    log(`  -> ${res.memories.length} memory hit(s) in ${ms}ms (search internal durationMs=${res.durationMs})`);
+    for (const m of res.memories) {
+      log(`     cosine=${m.cosine.toFixed(4)} score=${m.score.toFixed(4)} fts=${m.ftsHit} tier=${m.strengthTier} claim="${m.claim.slice(0, 90)}"`);
+    }
+    retrieval.push({
+      label: q.label,
+      query: q.query,
+      latencyMs: ms,
+      durationMs: res.durationMs,
+      memories: res.memories.map((m) => ({ cosine: m.cosine, score: m.score, ftsHit: m.ftsHit, claim: m.claim, id: m.id })),
+    });
+  }
+  writeFileSync(path.join(OUT, "retrieval.json"), JSON.stringify(retrieval, null, 2));
+
+  // Warm latency measurement: 5 repeats of the semantic query (model already loaded).
+  const lat: number[] = [];
+  for (let i = 0; i < 5; i++) {
+    const t0 = Date.now();
+    await searchMemory({ query: queries[0].query, repo: REPO, limit: 8 });
+    lat.push(Date.now() - t0);
+  }
+  lat.sort((a, b) => a - b);
+  log(`\nWARM search latency over 5 runs (ms): [${lat.join(", ")}] median=${lat[2]}`);
+  writeFileSync(path.join(OUT, "latency.json"), JSON.stringify({ warmRunsMs: lat, median: lat[2] }, null, 2));
+
+  // Dump the whole DB's observations+memories for the artifact.
+  const allObs = db.prepare(`SELECT * FROM observations`).all();
+  const allMem = db.prepare(`SELECT * FROM memories`).all();
+  writeFileSync(
+    path.join(OUT, "db-dump.json"),
+    JSON.stringify(
+      { observations: allObs, memories: allMem },
+      (k, v) => (Buffer.isBuffer(v) ? `<blob ${v.length} bytes = ${v.length / 4} floats>` : v),
+      2,
+    ),
+  );
+
+  stopIdleSweep();
+  log("\nDONE. Artifacts in", OUT);
+  // Give any in-flight setImmediate distills nothing to do; exit clean.
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error("[driver] FATAL", e);
+  process.exit(1);
+});

--- a/orchestrator/_live_retrieval.ts
+++ b/orchestrator/_live_retrieval.ts
@@ -1,0 +1,93 @@
+// _live_retrieval.ts — re-run retrieval with CLEAN queries against the existing
+// temp DB, to cleanly separate the FTS path from the cosine path and exercise
+// the 0.55 silence gate. Requires the gateway running (query embedding hop).
+
+import { writeFileSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import db from "./src/db.js";
+import { searchMemory } from "./src/memory/search.js";
+
+const OUT = process.env.LIVE_OUT ?? "/tmp/memlive-out";
+mkdirSync(OUT, { recursive: true });
+const REPO = "flow-orchestrator";
+
+function ftsQuery(query: string): string {
+  const tokens = query.match(/[A-Za-z0-9_./:-]+/g) ?? [];
+  const quoted = tokens.filter((t) => t.length >= 2).map((t) => `"${t.replace(/"/g, '""')}"`);
+  return quoted.join(" OR ");
+}
+function ftsHitCount(q: string): number {
+  const m = ftsQuery(q);
+  if (!m) return 0;
+  try {
+    return (db.prepare(`SELECT COUNT(*) c FROM observations_fts WHERE observations_fts MATCH ?`).get(m) as any).c;
+  } catch {
+    return -1;
+  }
+}
+
+// (a) SEMANTIC paraphrase — deliberately shares NO token with the claim/keys.
+//     Claim/keys contain: sqlite,database,locked,wal,checkpoint,db,singleton,
+//     better-sqlite3,concurrent,deadlock,distiller,store,memory,writes,shared,
+//     insertobservation,session,close,the,is,go,file,second,connection.
+//     This query avoids all of them (uses "one persistent handle","parallel
+//     tasks","embedded store","stalls").
+// (b) VERBATIM error string — proves FTS bypass of the silence gate.
+// (c) UNRELATED same-family — avoids EVERY claim token INCLUDING stopwords like
+//     "the"/"is", so FTS returns nothing and the cosine floor decides.
+const queries: Array<{ label: string; query: string }> = [
+  {
+    label: "a) SEMANTIC paraphrase (zero shared tokens -> pure cosine)",
+    query: "one persistent handle prevents parallel tasks from stalling our embedded key-value engine",
+  },
+  { label: "b) VERBATIM error string (FTS bypass)", query: "SqliteError: database is locked" },
+  {
+    label: "c) UNRELATED same-family (silence-gate drop)",
+    query: "rotating avatar images for user profile cards on a marketing landing page",
+  },
+];
+
+async function main() {
+  const results: any[] = [];
+  for (const q of queries) {
+    const preFts = ftsHitCount(q.query);
+    const t0 = Date.now();
+    const res = await searchMemory({ query: q.query, repo: REPO, limit: 8 });
+    const ms = Date.now() - t0;
+    console.log(`\nQUERY ${q.label}`);
+    console.log(`  "${q.query}"`);
+    console.log(`  FTS raw-hit-count (before ranking): ${preFts}`);
+    console.log(`  -> ${res.memories.length} memory hit(s) in ${ms}ms (internal ${res.durationMs}ms)`);
+    for (const m of res.memories) {
+      console.log(
+        `     cosine=${m.cosine.toFixed(4)} score=${m.score.toFixed(4)} fts=${m.ftsHit} tier=${m.strengthTier} claim="${m.claim.slice(0, 70)}…"`,
+      );
+    }
+    if (res.memories.length === 0) console.log("     (no memories — silence gate dropped everything)");
+    results.push({
+      label: q.label,
+      query: q.query,
+      ftsRawHitCount: preFts,
+      latencyMs: ms,
+      durationMs: res.durationMs,
+      memories: res.memories.map((m) => ({ cosine: m.cosine, score: m.score, ftsHit: m.ftsHit, claim: m.claim })),
+    });
+  }
+  writeFileSync(path.join(OUT, "retrieval-clean.json"), JSON.stringify(results, null, 2));
+
+  // Warm latency (semantic query, model loaded).
+  const lat: number[] = [];
+  for (let i = 0; i < 7; i++) {
+    const t0 = Date.now();
+    await searchMemory({ query: queries[0].query, repo: REPO, limit: 8 });
+    lat.push(Date.now() - t0);
+  }
+  lat.sort((a, b) => a - b);
+  console.log(`\nWARM latency 7 runs (ms): [${lat.join(", ")}] median=${lat[3]}`);
+  writeFileSync(path.join(OUT, "latency-clean.json"), JSON.stringify({ warmRunsMs: lat, median: lat[3] }, null, 2));
+  process.exit(0);
+}
+main().catch((e) => {
+  console.error("FATAL", e);
+  process.exit(1);
+});

--- a/orchestrator/src/actions/index.ts
+++ b/orchestrator/src/actions/index.ts
@@ -147,7 +147,7 @@ async function handleSlackAuto(event: NormalizedEvent, cls: ClassificationResult
       permalink: p.permalink ?? null,
     });
     // Memory enrichment: mirror the message into the observations corpus so
-    // search_memory can surface it (embedded + FTS). Non-blocking, best-effort.
+    // search_knowledge can surface it (embedded + FTS). Non-blocking, best-effort.
     void observeCorpus({ source: "slack", text: p.text ?? "", repo: repoForChannel(p.channel) });
   }
 

--- a/orchestrator/src/adapters/linear.ts
+++ b/orchestrator/src/adapters/linear.ts
@@ -284,7 +284,7 @@ function mirrorTicket(issue: LinearIssueForPoller): void {
     updated_at: issue.updatedAt ? Math.floor(new Date(issue.updatedAt).getTime() / 1000) : null,
   });
   // Memory enrichment: mirror the ticket into the observations corpus so
-  // search_memory can surface it. repo_family inferred from the team prefix.
+  // search_knowledge can surface it. repo_family inferred from the team prefix.
   const text = [issue.title, issue.description].filter(Boolean).join(" — ");
   void observeCorpus({ source: "linear", text, repo: repoForTicket(issue.identifier ?? null) });
 }

--- a/orchestrator/src/memory/cards.ts
+++ b/orchestrator/src/memory/cards.ts
@@ -15,7 +15,7 @@
 //
 // IMPLEMENTATION CHOICE (documented): the gateway resolves these namespaces by
 // calling the orchestrator over HTTP (/v1/memory/card/:type/:id) — the same
-// proxy pattern as FLOW_NOTES_URL / search_memory. The orchestrator owns
+// proxy pattern as FLOW_NOTES_URL / search_knowledge. The orchestrator owns
 // flow.db (memories, observations, corpus, anchors), so reading here is a
 // single indexed lookup with no graph round-trip. Cards carry NODE IDS for
 // anchors (not node bodies) so the model can get_entity them next.

--- a/orchestrator/src/memory/corpus-observe.ts
+++ b/orchestrator/src/memory/corpus-observe.ts
@@ -1,5 +1,5 @@
 // corpus-observe.ts — enrich the corpus_insert path so slack/linear rows also
-// become observations (embedded, searchable via search_memory alongside session
+// become observations (embedded, searchable via search_knowledge alongside session
 // memories). repo_family is inferred from a channel/ticket→repo mapping when one
 // exists; otherwise null, which the cross-family gate treats as match-all.
 //

--- a/orchestrator/src/memory/headline.ts
+++ b/orchestrator/src/memory/headline.ts
@@ -11,7 +11,7 @@
 //   - TICKETS: recency + status; [lin:<identifier>].
 //   - THREADS: recency; permalink; [slackthread:<ts>].
 //   - Total capped ~1200 chars; when a section overflows, append
-//     "+N more: search_memory node:<node_id> type:<t>".
+//     "+N more: search_knowledge node:<node_id> type:<t>".
 //
 // Served FAST: an in-process cache keyed by node id, invalidated on
 // consolidation (see consolidate.ts). Must add <20ms to get_entity — the query
@@ -164,7 +164,7 @@ export function renderNodeHeadline(h: NodeHeadline): string {
   let budget = HEADLINE_CHAR_CAP;
 
   const moreLine = (remaining: number, type: string): string =>
-    `  +${remaining} more: search_memory node:${h.node_id} type:${type}`;
+    `  +${remaining} more: search_knowledge node:${h.node_id} type:${type}`;
 
   // Render one typed section. RESERVES room for a "+N more" line before the last
   // item that would fit, so the overflow line ALWAYS fits within the cap (a

--- a/orchestrator/src/memory/routes.ts
+++ b/orchestrator/src/memory/routes.ts
@@ -1,4 +1,4 @@
-// routes.ts — HTTP surface for memory v1. The gateway's search_memory verb
+// routes.ts — HTTP surface for memory v1. The gateway's search_knowledge verb
 // proxies here (the memories + embeddings + FTS all live in the orchestrator's
 // flow.db; the gateway is a thin proxy, matching the note/correct_graph shape).
 //

--- a/orchestrator/src/memory/search.ts
+++ b/orchestrator/src/memory/search.ts
@@ -1,4 +1,4 @@
-// search.ts — retrieval for search_memory. Eval-calibrated ranking:
+// search.ts — retrieval for search_knowledge. Eval-calibrated ranking:
 //
 //   HARD GATE on repo_family mismatch — drop, never downweight. (null family on
 //     either side = match-all.)
@@ -45,7 +45,7 @@ export interface ParsedQuery {
 // last part is an HTTP method OR the next token starts with '/'. Everything else
 // (real keywords like 'hmac') stays a keyword. `type:` is a plain leading token
 // that also ends node absorption. This matches the "+N more" line the headline
-// emits: `search_memory node:<id> type:<t>`.
+// emits: `search_knowledge node:<id> type:<t>`.
 const HTTP_METHODS = new Set(["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]);
 export function parseSearchTokens(raw: string): ParsedQuery {
   let node: string | null = null;

--- a/orchestrator/test/memory.test.ts
+++ b/orchestrator/test/memory.test.ts
@@ -724,7 +724,7 @@ describe("node headline index (Section B)", () => {
     }
     const h = headline.getNodeHeadline("svc:payments");
     assert.ok(h.rendered.length <= headline.HEADLINE_CHAR_CAP, `render ${h.rendered.length} within cap ${headline.HEADLINE_CHAR_CAP}`);
-    assert.match(h.rendered, /\+\d+ more: search_memory node:svc:payments type:memory/, "overflow is a working node-scoped query");
+    assert.match(h.rendered, /\+\d+ more: search_knowledge node:svc:payments type:memory/, "overflow is a working node-scoped query");
   });
 
   test("memories are strength-ranked (strong first)", async () => {


### PR DESCRIPTION
The verb searches memories, open tickets, and Slack threads — accumulated org know-how, not just "memory". Renaming makes the scope accurate and gives models a stronger retrieval cue ("search the org's knowledge"). Decided in the 07/18 design session; announced in PR #32's description. Exposed surface only: verb name, SESSION_VERBS, tool descriptions, orient text, the '+N more' headline strings, and tests. Internal identifiers and /v1/memory/* routes unchanged. No alias — nothing external shipped. Suites: orchestrator 219/219, gateway 23/23.