### PR TITLE
Citations + shared LLM transport layer (pipeline rework, phases 1–2)

### DIFF
--- a/orchestrator/package.json
+++ b/orchestrator/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts",
-    "test": "node --import tsx/esm --test test/fake-opencode.ts test/orchestrator.test.ts test/adapters.test.ts test/outbox-approve.test.ts test/llmlog.test.ts test/smoke.ts test/notify.test.ts test/pollers.test.ts test/poller.test.ts test/settings.test.ts test/sources.test.ts test/agent-diff.test.ts test/worktrees.test.ts test/memory.test.ts",
+    "test": "node --import tsx/esm --test test/fake-opencode.ts test/orchestrator.test.ts test/adapters.test.ts test/outbox-approve.test.ts test/llmlog.test.ts test/smoke.ts test/notify.test.ts test/pollers.test.ts test/poller.test.ts test/settings.test.ts test/sources.test.ts test/agent-diff.test.ts test/worktrees.test.ts test/memory.test.ts test/llm.test.ts",
     "verify": "npm test",
     "verify:real": "tsx test/real-integrations.ts",
     "verify:session": "tsx test/real-session.ts"

--- a/orchestrator/src/actions/index.ts
+++ b/orchestrator/src/actions/index.ts
@@ -148,7 +148,13 @@ async function handleSlackAuto(event: NormalizedEvent, cls: ClassificationResult
     });
     // Memory enrichment: mirror the message into the observations corpus so
     // search_knowledge can surface it (embedded + FTS). Non-blocking, best-effort.
-    void observeCorpus({ source: "slack", text: p.text ?? "", repo: repoForChannel(p.channel) });
+    void observeCorpus({
+      source: "slack",
+      text: p.text ?? "",
+      repo: repoForChannel(p.channel),
+      source_id: event.id,
+      source_url: p.permalink ?? null,
+    });
   }
 
   if (c === "knowledge_claim" || c === "correction") {

--- a/orchestrator/src/adapters/linear.ts
+++ b/orchestrator/src/adapters/linear.ts
@@ -285,8 +285,16 @@ function mirrorTicket(issue: LinearIssueForPoller): void {
   });
   // Memory enrichment: mirror the ticket into the observations corpus so
   // search_knowledge can surface it. repo_family inferred from the team prefix.
+  // source_id keys the dedupe: a ticket re-mirrors on every update, refreshing
+  // its one observation instead of stacking duplicates.
   const text = [issue.title, issue.description].filter(Boolean).join(" — ");
-  void observeCorpus({ source: "linear", text, repo: repoForTicket(issue.identifier ?? null) });
+  void observeCorpus({
+    source: "linear",
+    text,
+    repo: repoForTicket(issue.identifier ?? null),
+    source_id: issue.id,
+    source_url: issue.url ?? null,
+  });
 }
 
 // ------------------------------------------------------------------

--- a/orchestrator/src/llm.ts
+++ b/orchestrator/src/llm.ts
@@ -1,0 +1,146 @@
+// llm.ts — the ONE transport layer for single-shot LLM calls (prompt in →
+// text out; no tools, no workspace). Installed coding CLIs and API keys are
+// BOTH first-class:
+//
+//   cli  — the user's locally-installed claude CLI (no key needed; a local
+//          install will usually never set one)
+//   http — any OpenAI-compatible endpoint (LLM_BASE_URL with LLM_API_KEY /
+//          OPENROUTER_API_KEY; the headless/EC2 path, where no CLI exists)
+//
+// LLM_TRANSPORT setting picks: auto (default — CLI when one is installed,
+// else key), or force 'cli' / 'http'. Forcing a transport that isn't usable
+// surfaces a clear error rather than silently switching — same philosophy as
+// INDEXER_RUNTIME. New transports (e.g. a signed-in CLI on a server) slot in
+// as another LlmTransportKind; keep that door open.
+//
+// Features ask for a TIER (fast | smart), not a model — model ids are not
+// portable across transports ("claude-haiku-4-5" means nothing to OpenRouter).
+// Explicit per-feature overrides (DISTILLER_MODEL etc.) pass through as-is;
+// whoever sets one owns matching it to their transport.
+//
+// Every call logs to llm_log (kind = feature) — classifier-style visibility
+// for all callers. Agentic runs (indexer jobs) are NOT this layer: they need
+// tools + a workspace and dispatch via resolveIndexerBackend().
+
+import { execFile } from "node:child_process";
+import { detectAgents, resolveLocalExecutable } from "./agents/runtime.js";
+import { getSetting, llmApiKey, llmBaseUrl } from "./settings.js";
+import { logLLM } from "./llmlog.js";
+
+export type LlmTier = "fast" | "smart";
+export type LlmTransportKind = "cli" | "http";
+
+export interface LlmCallOpts {
+  tier: LlmTier;
+  feature: string; // llm_log kind, e.g. "distiller" | "judge"
+  model?: string; // explicit override — wins over the tier map, transport-specific id
+  timeoutMs?: number;
+}
+
+// Per-transport tier defaults. CLI ids match what `claude --model` accepts;
+// HTTP ids are the OpenRouter names for the same models (like-for-like).
+const CLI_TIER_MODELS: Record<LlmTier, string> = {
+  fast: "claude-haiku-4-5",
+  smart: "claude-sonnet-4-6",
+};
+const HTTP_TIER_MODELS: Record<LlmTier, string> = {
+  fast: "anthropic/claude-haiku-4.5",
+  smart: "anthropic/claude-sonnet-4.6",
+};
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+// Which transport this process would use right now. null = none usable (no
+// CLI installed, no key set) — callers degrade per-feature, they don't crash.
+export async function resolveLlmTransport(): Promise<LlmTransportKind | null> {
+  const forced = getSetting("LLM_TRANSPORT") ?? "auto";
+  if (forced === "cli" || forced === "http") return forced;
+  const detected = await detectAgents();
+  // Bundled adapters aren't standalone CLIs — only a real executable counts.
+  const cli = detected.some((a) => a.id === "claude" && (a.source === "local" || a.source === "explicit"));
+  if (cli) return "cli";
+  if (llmApiKey()) return "http";
+  return null;
+}
+
+function modelFor(transport: LlmTransportKind, opts: LlmCallOpts): string {
+  if (opts.model) return opts.model;
+  const setting = getSetting(opts.tier === "fast" ? "LLM_MODEL_FAST" : "LLM_MODEL_SMART");
+  if (setting) return setting;
+  return (transport === "cli" ? CLI_TIER_MODELS : HTTP_TIER_MODELS)[opts.tier];
+}
+
+async function completeCli(prompt: string, model: string, timeoutMs: number): Promise<string> {
+  const bin = (await resolveLocalExecutable("claude")) ?? "claude";
+  return await new Promise<string>((resolvePromise, reject) => {
+    execFile(
+      bin,
+      ["-p", prompt, "--model", model, "--output-format", "json"],
+      { maxBuffer: 16 * 1024 * 1024, timeout: timeoutMs },
+      (err, stdout) => {
+        if (err) return reject(err);
+        try {
+          const env = JSON.parse(stdout) as { result?: string };
+          resolvePromise(typeof env.result === "string" ? env.result : stdout);
+        } catch {
+          // Not the JSON envelope — return raw stdout (parsers are tolerant).
+          resolvePromise(stdout);
+        }
+      },
+    );
+  });
+}
+
+async function completeHttp(prompt: string, model: string, timeoutMs: number): Promise<string> {
+  const apiKey = llmApiKey();
+  if (!apiKey) {
+    throw new Error("http LLM transport needs an API key — set LLM_API_KEY or OPENROUTER_API_KEY (Settings)");
+  }
+  const res = await fetch(`${llmBaseUrl()}/chat/completions`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      messages: [{ role: "user", content: prompt }],
+      temperature: 0,
+    }),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!res.ok) {
+    throw new Error(`LLM HTTP ${res.status}: ${(await res.text().catch(() => "")).slice(0, 300)}`);
+  }
+  const data = (await res.json()) as { choices?: Array<{ message?: { content?: string } }> };
+  const content = data.choices?.[0]?.message?.content;
+  if (!content) throw new Error("LLM returned an empty response");
+  return content;
+}
+
+// Single-shot completion through whichever transport is usable. Throws on
+// failure or no-transport; callers own their degrade (the distiller skips the
+// session, etc.). One attempt — retry policy stays with the caller.
+export async function complete(prompt: string, opts: LlmCallOpts): Promise<string> {
+  const transport = await resolveLlmTransport();
+  if (!transport) {
+    throw new Error(
+      "no LLM transport available — install a coding CLI (claude) or set LLM_API_KEY/OPENROUTER_API_KEY (Settings)",
+    );
+  }
+  const model = modelFor(transport, opts);
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const t0 = Date.now();
+  try {
+    const text =
+      transport === "cli"
+        ? await completeCli(prompt, model, timeoutMs)
+        : await completeHttp(prompt, model, timeoutMs);
+    logLLM({ kind: opts.feature, model: `${transport}:${model}`, ok: true, latencyMs: Date.now() - t0, prompt, response: text });
+    return text;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logLLM({ kind: opts.feature, model: `${transport}:${model}`, ok: false, latencyMs: Date.now() - t0, error: msg, prompt });
+    throw err;
+  }
+}

--- a/orchestrator/src/llmlog.ts
+++ b/orchestrator/src/llmlog.ts
@@ -1,6 +1,7 @@
 // llmlog.ts — LLM observability. Every live model interaction (classifier
-// calls, opencode jobs) is recorded so misclassifications and weird agent runs
-// can be debugged after the fact. Never called for fixture/fake test paths.
+// calls, opencode jobs, and every shared-layer call — distiller, judge) is
+// recorded so misclassifications and weird agent runs can be debugged after
+// the fact. Never called for fixture/fake test paths.
 //
 // GET /v1/llmlog?limit=&kind=&ref=  (bearer) — newest first, full prompt/response.
 
@@ -15,7 +16,7 @@ const insert = db.prepare(`
 `);
 
 export function logLLM(entry: {
-  kind: "classifier" | "opencode_job";
+  kind: string; // "classifier" | "opencode_job" | any shared-layer feature ("distiller", "judge", ...)
   ref?: string;
   model?: string;
   attempt?: number;

--- a/orchestrator/src/memory/cards.ts
+++ b/orchestrator/src/memory/cards.ts
@@ -79,15 +79,18 @@ function memoryCard(id: string): CardResult {
   if (!m) return { status: "not_found", type: "mem", id };
 
   // Evidence observations attached to this memory — one-liners with [obs:id].
+  // url is the citation back to the original artifact (slack permalink, linear
+  // ticket) when the observation carries one.
   const obsRows = db
     .prepare(
-      `SELECT id, source, claim, branch, context_files FROM observations
+      `SELECT id, source, claim, branch, context_files, source_url FROM observations
        WHERE memory_id = ? ORDER BY created_at DESC LIMIT 12`,
     )
-    .all(id) as Array<{ id: string; source: string; claim: string; branch: string | null; context_files: string | null }>;
+    .all(id) as Array<{ id: string; source: string; claim: string; branch: string | null; context_files: string | null; source_url: string | null }>;
   const evidence = obsRows.map((o) => ({
     id: `obs:${o.id}`,
     line: `[${o.source}] ${trunc(o.claim, LINE_TRUNC)}`,
+    ...(o.source_url ? { url: o.source_url } : {}),
   }));
 
   // Context files = union across attached observations.
@@ -132,6 +135,7 @@ function observationCard(id: string): CardResult {
         repo: string | null;
         branch: string | null;
         session_id: string | null;
+        source_url: string | null;
         claim: string;
         kind: string;
         source_weight: string;
@@ -150,6 +154,7 @@ function observationCard(id: string): CardResult {
       kind: "observation",
       text: o.claim,
       source: o.source,
+      source_url: o.source_url, // citation back to the original artifact
       observation_kind: o.kind,
       source_weight: o.source_weight,
       session: o.session_id,
@@ -181,7 +186,9 @@ function linearCard(identifier: string): CardResult {
   if (!t) return { status: "not_found", type: "lin", id: identifier };
 
   // Anchored nodes: any observation derived from this ticket that got anchored.
-  const anchoredNodes = anchoredNodesForCorpus("linear", identifier);
+  // t.id is the observation's source_id (exact FK); identifier covers rows
+  // written before source refs existed.
+  const anchoredNodes = anchoredNodesForCorpus("linear", identifier, [t.id]);
 
   return {
     status: "found",
@@ -234,7 +241,9 @@ function slackThreadCard(ts: string): CardResult {
         line: trunc(m.text, LINE_TRUNC),
         ts: m.ts,
       })),
-      anchored_nodes: anchoredNodesForCorpus("slack", rootTs),
+      // Slack corpus row ids ARE the observations' source_id (both are the
+      // originating event id), so the thread's messages give the exact keys.
+      anchored_nodes: anchoredNodesForCorpus("slack", rootTs, messages.map((m) => m.id)),
     },
   };
 }
@@ -249,14 +258,22 @@ interface SlackRow {
   permalink: string | null;
 }
 
-// Nodes anchored via a corpus observation matching this source + key. Corpus
-// observations don't carry an FK to the corpus row, so we match on the
-// identifier/ts appearing in the observation's retrieval_keys. Best-effort.
-function anchoredNodesForCorpus(source: string, key: string): string[] {
-  const rows = db
-    .prepare(`SELECT id, retrieval_keys, claim FROM observations WHERE source = ?`)
-    .all(source) as Array<{ id: string; retrieval_keys: string | null; claim: string }>;
+// Nodes anchored via a corpus observation matching this source + key. Since
+// migration 10 corpus observations carry source_id (exact FK to the corpus
+// row); sourceId matches those directly. Rows written before that fall back to
+// the identifier/ts appearing in retrieval_keys or the claim. Best-effort.
+function anchoredNodesForCorpus(source: string, key: string, sourceIds: string[] = []): string[] {
   const nodeIds = new Set<string>();
+  if (sourceIds.length) {
+    const ph = sourceIds.map(() => "?").join(",");
+    const exact = db
+      .prepare(`SELECT id FROM observations WHERE source = ? AND source_id IN (${ph})`)
+      .all(source, ...sourceIds) as Array<{ id: string }>;
+    for (const r of exact) for (const n of nodeIdsForItem("observation", r.id)) nodeIds.add(n);
+  }
+  const rows = db
+    .prepare(`SELECT id, retrieval_keys, claim FROM observations WHERE source = ? AND source_id IS NULL`)
+    .all(source) as Array<{ id: string; retrieval_keys: string | null; claim: string }>;
   for (const r of rows) {
     const keys = parseKeys(r.retrieval_keys);
     const hit = keys.some((k) => k === key || k === `ts:${key}`) || r.claim.includes(key);

--- a/orchestrator/src/memory/corpus-observe.ts
+++ b/orchestrator/src/memory/corpus-observe.ts
@@ -7,7 +7,7 @@
 // distilled claims) — they live in the observations table with memory_id NULL
 // and surface through FTS + vector search directly.
 
-import { insertObservation } from "./store.js";
+import { getObservationBySource, insertObservation, refreshObservation } from "./store.js";
 import { getSetting } from "../settings.js";
 
 // Optional mapping: JSON in setting CORPUS_REPO_MAP, e.g.
@@ -40,18 +40,35 @@ export function repoForTicket(identifier: string | null | undefined): string | n
 }
 
 // Best-effort: never throws, never blocks the corpus insert (callers `void` it).
+// source_id/source_url are the citation refs back to the original artifact
+// (slack event id + permalink, linear issue id + url). (source, source_id) is
+// also the dedupe key: re-mirrored sources (a linear ticket updates on every
+// poll) refresh their one observation instead of accumulating duplicates.
 export async function observeCorpus(o: {
   source: "slack" | "linear" | "meeting";
   text: string;
   repo?: string | null;
+  source_id?: string | null;
+  source_url?: string | null;
 }): Promise<void> {
   const text = o.text.trim();
   if (!text) return;
+  const claim = text.slice(0, 1000);
   try {
+    if (o.source_id) {
+      const existing = getObservationBySource(o.source, o.source_id);
+      if (existing) {
+        if (existing.claim === claim && existing.source_url === (o.source_url ?? null)) return;
+        await refreshObservation(existing.id, { claim, source_url: o.source_url ?? null });
+        return;
+      }
+    }
     await insertObservation({
       source: o.source,
       repo: o.repo ?? null,
-      claim: text.slice(0, 1000),
+      source_id: o.source_id ?? null,
+      source_url: o.source_url ?? null,
+      claim,
       kind: "gotcha", // corpus rows carry no distilled kind; a neutral bucket
       source_weight: "user_stated", // a human said it in slack/linear
       retrieval_keys: [],

--- a/orchestrator/src/memory/distiller.ts
+++ b/orchestrator/src/memory/distiller.ts
@@ -45,7 +45,7 @@ export async function distillSession(ctx: DistillContext): Promise<DistillOutcom
   const prompt = buildDistillerPrompt(slimmed);
   let reply: string;
   try {
-    reply = await callLlm(prompt, distillerModel());
+    reply = await callLlm(prompt, { tier: "smart", feature: "distiller", model: distillerModel() });
   } catch (err) {
     return { ran: false, observations: 0, actions: {}, reason: `llm-error: ${err instanceof Error ? err.message : String(err)}` };
   }

--- a/orchestrator/src/memory/judge.ts
+++ b/orchestrator/src/memory/judge.ts
@@ -30,6 +30,6 @@ function parseVerdict(reply: string): "same" | "new" | "refines" | "contradicts"
 export const haikuJudge: Judge = async (a, b) => {
   const prompt =
     `${JUDGE_PROMPT}\n\nA (existing memory): ${a.claim}\n\nB (new observation): ${b.claim}\n\nRelationship:`;
-  const reply = await callLlm(prompt, judgeModel());
+  const reply = await callLlm(prompt, { tier: "fast", feature: "judge", model: judgeModel() });
   return { verdict: parseVerdict(reply) };
 };

--- a/orchestrator/src/memory/llm.ts
+++ b/orchestrator/src/memory/llm.ts
@@ -1,60 +1,38 @@
-// llm.ts — one narrow wrapper around a single-shot `claude -p` CLI call, used by
-// the distiller (one call per session) and the consolidation judge (one call
-// per above-threshold observation). No tools, JSON output, env-overridable model.
+// llm.ts — the memory pipeline's seam onto the shared LLM transport layer
+// (../llm.ts), used by the distiller (one call per session) and the
+// consolidation judge (one call per above-threshold observation).
 //
 // The transport is INJECTABLE (setLlmTransport) so tests run entirely offline —
-// no CLI is spawned. Set FLOW_DISTILLER=0 to hard-disable the distiller path.
+// nothing is spawned or fetched. Set FLOW_DISTILLER=0 to hard-disable the
+// distiller path.
 //
-// Real transport: spawn the locally-installed `claude` executable with
-//   claude -p "<prompt>" --model <model> --output-format json
-// and return the `.result` string from the CLI's JSON envelope.
+// Models: features ask by TIER (distiller = smart, judge = fast); the shared
+// layer maps tier → model per transport (CLI vs HTTP ids differ). The
+// DISTILLER_MODEL / DISTILLER_JUDGE_MODEL env overrides pass through verbatim
+// when set — whoever sets one owns matching it to the active transport.
 
-import { execFile } from "node:child_process";
-import { resolveLocalExecutable } from "../agents/runtime.js";
+import { complete, type LlmCallOpts } from "../llm.js";
 
-export const DISTILLER_MODEL_DEFAULT = "claude-sonnet-4-6";
-export const JUDGE_MODEL_DEFAULT = "claude-haiku-4-5";
-
-export function distillerModel(): string {
-  return process.env.DISTILLER_MODEL || DISTILLER_MODEL_DEFAULT;
+// Env override or undefined (undefined = the shared layer's tier default).
+export function distillerModel(): string | undefined {
+  return process.env.DISTILLER_MODEL || undefined;
 }
-export function judgeModel(): string {
-  return process.env.DISTILLER_JUDGE_MODEL || JUDGE_MODEL_DEFAULT;
+export function judgeModel(): string | undefined {
+  return process.env.DISTILLER_JUDGE_MODEL || undefined;
 }
 
 export function distillerEnabled(): boolean {
   return process.env.FLOW_DISTILLER !== "0";
 }
 
-// A transport takes a prompt + model and returns the model's raw text reply.
-export type LlmTransport = (prompt: string, model: string) => Promise<string>;
+// A transport takes a prompt + call opts and returns the model's raw text
+// reply. The default is the shared layer; tests inject a stub.
+export type LlmTransport = (prompt: string, opts: LlmCallOpts) => Promise<string>;
 
-// Real CLI transport. Returns the `.result` field of `--output-format json`.
-const cliTransport: LlmTransport = async (prompt, model) => {
-  const bin = (await resolveLocalExecutable("claude")) ?? "claude";
-  return await new Promise<string>((resolve, reject) => {
-    execFile(
-      bin,
-      ["-p", prompt, "--model", model, "--output-format", "json"],
-      { maxBuffer: 16 * 1024 * 1024, timeout: 120_000 },
-      (err, stdout) => {
-        if (err) return reject(err);
-        try {
-          const env = JSON.parse(stdout) as { result?: string };
-          resolve(typeof env.result === "string" ? env.result : stdout);
-        } catch {
-          // Not the JSON envelope — return raw stdout (parser is tolerant).
-          resolve(stdout);
-        }
-      },
-    );
-  });
-};
-
-let _transport: LlmTransport = cliTransport;
+let _transport: LlmTransport = complete;
 export function setLlmTransport(fn: LlmTransport): void {
   _transport = fn;
 }
-export function callLlm(prompt: string, model: string): Promise<string> {
-  return _transport(prompt, model);
+export function callLlm(prompt: string, opts: LlmCallOpts): Promise<string> {
+  return _transport(prompt, opts);
 }

--- a/orchestrator/src/memory/store.ts
+++ b/orchestrator/src/memory/store.ts
@@ -27,6 +27,8 @@ export interface ObservationRow {
   repo_family: string | null;
   branch: string | null;
   session_id: string | null;
+  source_id: string | null;
+  source_url: string | null;
   claim: string;
   kind: string;
   source_weight: string;
@@ -58,10 +60,10 @@ export interface MemoryRow {
 
 const insertObservationStmt = db.prepare(`
   INSERT INTO observations
-    (id, source, repo, repo_family, branch, session_id, claim, kind, source_weight,
+    (id, source, repo, repo_family, branch, session_id, source_id, source_url, claim, kind, source_weight,
      context_files, retrieval_keys, embedding, memory_id)
   VALUES
-    (@id, @source, @repo, @repo_family, @branch, @session_id, @claim, @kind, @source_weight,
+    (@id, @source, @repo, @repo_family, @branch, @session_id, @source_id, @source_url, @claim, @kind, @source_weight,
      @context_files, @retrieval_keys, @embedding, @memory_id)
 `);
 
@@ -70,6 +72,8 @@ export interface NewObservation {
   repo?: string | null;
   branch?: string | null;
   session_id?: string | null;
+  source_id?: string | null;
+  source_url?: string | null;
   claim: string;
   kind: string;
   source_weight?: string;
@@ -96,6 +100,8 @@ export async function insertObservation(o: NewObservation): Promise<ObservationR
     repo_family: repoFamily(o.repo),
     branch: o.branch ?? null,
     session_id: o.session_id ?? null,
+    source_id: o.source_id ?? null,
+    source_url: o.source_url ?? null,
     claim: o.claim,
     kind: o.kind,
     source_weight: o.source_weight ?? "agent_inferred",
@@ -107,6 +113,30 @@ export async function insertObservation(o: NewObservation): Promise<ObservationR
   insertObservationStmt.run(row);
   invalidateVectorCache();
   return { ...row, created_at: Math.floor(Date.now() / 1000) };
+}
+
+// Corpus rows re-arrive on every source update (the linear poller re-mirrors a
+// ticket each time it changes) — (source, source_id) is the dedupe key.
+export function getObservationBySource(source: string, sourceId: string): ObservationRow | undefined {
+  return db
+    .prepare(`SELECT * FROM observations WHERE source = ? AND source_id = ? LIMIT 1`)
+    .get(source, sourceId) as ObservationRow | undefined;
+}
+
+// Refresh a corpus observation in place after its source changed. The FTS
+// mirror updates via the observations_au trigger.
+export async function refreshObservation(
+  id: string,
+  fields: { claim: string; source_url?: string | null },
+): Promise<void> {
+  const vec = await _embedder(fields.claim.slice(0, 2000));
+  db.prepare(`UPDATE observations SET claim = @claim, source_url = @source_url, embedding = @embedding WHERE id = @id`).run({
+    id,
+    claim: fields.claim,
+    source_url: fields.source_url ?? null,
+    embedding: vec ? vecToBlob(vec) : null,
+  });
+  invalidateVectorCache();
 }
 
 // Map a distiller RawObservation → NewObservation (source always 'session').

--- a/orchestrator/src/migrations.ts
+++ b/orchestrator/src/migrations.ts
@@ -161,6 +161,21 @@ export const MIGRATIONS: Migration[] = [
       db.exec(ANCHORS_SCHEMA);
     },
   },
+  {
+    id: 10,
+    name: "observations: citation source refs (source_id, source_url)",
+    up: (db) => {
+      // A DB below version 8 walks migration 8 first, which executes the
+      // SHARED MEMORY_SCHEMA string — already containing these columns — so a
+      // bare ALTER here would crash on "duplicate column". Guard on the actual
+      // table shape; anything else that fails still crashes boot loudly.
+      const cols = db.prepare(`SELECT name FROM pragma_table_info('observations')`).all() as Array<{ name: string }>;
+      const has = new Set(cols.map((c) => c.name));
+      if (!has.has("source_id")) db.exec("ALTER TABLE observations ADD COLUMN source_id TEXT");
+      if (!has.has("source_url")) db.exec("ALTER TABLE observations ADD COLUMN source_url TEXT");
+      db.exec("CREATE INDEX IF NOT EXISTS idx_observations_source ON observations(source, source_id)");
+    },
+  },
 ];
 
 // Anchors: the join between a memory/observation (flow.db PRIMARY) and a graph
@@ -200,6 +215,8 @@ export const MEMORY_SCHEMA = `
     repo_family    TEXT,            -- normalized repo (e.g. foo-backend -> foo); NULL = match-all
     branch         TEXT,
     session_id     TEXT,
+    source_id      TEXT,            -- id of the source artifact (slack event id, linear issue id); citation + dedupe key
+    source_url     TEXT,            -- permalink back to the original (slack permalink, linear url)
     claim          TEXT NOT NULL,
     kind           TEXT NOT NULL,   -- decision|constraint|gotcha|how_to|preference|plan
     source_weight  TEXT NOT NULL DEFAULT 'agent_inferred', -- user_stated|agent_inferred|error_proven
@@ -211,6 +228,7 @@ export const MEMORY_SCHEMA = `
   );
   CREATE INDEX IF NOT EXISTS idx_observations_family ON observations(repo_family, memory_id);
   CREATE INDEX IF NOT EXISTS idx_observations_memory ON observations(memory_id);
+  CREATE INDEX IF NOT EXISTS idx_observations_source ON observations(source, source_id);
 
   CREATE TABLE IF NOT EXISTS memories (
     id                 TEXT PRIMARY KEY,

--- a/orchestrator/src/settings.ts
+++ b/orchestrator/src/settings.ts
@@ -66,6 +66,28 @@ export const SETTINGS: SettingDef[] = [
     appliesTo: "classifier",
   },
   {
+    key: "LLM_TRANSPORT",
+    secret: false,
+    description:
+      "Transport for single-shot LLM calls (distiller, judge): auto (installed claude CLI first, else API key), or force 'cli' / 'http'",
+    default: "auto",
+    appliesTo: "pipeline",
+  },
+  {
+    key: "LLM_MODEL_FAST",
+    secret: false,
+    description:
+      "Overrides the fast-tier model for single-shot LLM calls (judge). Use an id valid for the active transport (CLI alias vs OpenRouter id)",
+    appliesTo: "pipeline",
+  },
+  {
+    key: "LLM_MODEL_SMART",
+    secret: false,
+    description:
+      "Overrides the smart-tier model for single-shot LLM calls (distiller). Use an id valid for the active transport (CLI alias vs OpenRouter id)",
+    appliesTo: "pipeline",
+  },
+  {
     key: "CLASSIFIER_MODEL",
     secret: false,
     description: "Model ID passed to OpenRouter for the event classifier",

--- a/orchestrator/test/llm.test.ts
+++ b/orchestrator/test/llm.test.ts
@@ -1,0 +1,163 @@
+// llm.test.ts — the shared single-shot LLM transport layer. Fully offline: the
+// http transport talks to a local fake OpenAI-compatible server; the cli
+// transport is never spawned (transport is forced to http via env).
+
+import { test, describe, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { createServer, type Server } from "node:http";
+
+// Env BEFORE importing anything that touches the DB.
+process.env.DB_PATH = ":memory:";
+process.env.FLOW_ADMIN_TOKEN = "test-admin-token-llm";
+process.env.LLM_TRANSPORT = "http";
+process.env.LLM_API_KEY = "test-llm-key";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+let llm: typeof import("../src/llm.js");
+let memoryLlm: typeof import("../src/memory/llm.js");
+let settings: typeof import("../src/settings.js");
+let db: any;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+let server: Server;
+interface SeenRequest {
+  auth: string | undefined;
+  model: string;
+  prompt: string;
+}
+let seen: SeenRequest[] = [];
+let replyWith = "fake completion text";
+let replyStatus = 200;
+
+before(async () => {
+  server = createServer(async (req, res) => {
+    const chunks: Buffer[] = [];
+    for await (const c of req) chunks.push(c as Buffer);
+    const body = JSON.parse(Buffer.concat(chunks).toString()) as {
+      model: string;
+      messages: Array<{ content: string }>;
+    };
+    seen.push({ auth: req.headers.authorization, model: body.model, prompt: body.messages[0]?.content ?? "" });
+    res.writeHead(replyStatus, { "content-type": "application/json" });
+    res.end(
+      replyStatus === 200
+        ? JSON.stringify({ choices: [{ message: { content: replyWith } }] })
+        : JSON.stringify({ error: "boom" }),
+    );
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const addr = server.address();
+  if (!addr || typeof addr === "string") throw new Error("fake LLM server did not bind");
+  process.env.LLM_BASE_URL = `http://127.0.0.1:${addr.port}`;
+
+  db = (await import("../src/db.js")).default;
+  llm = await import("../src/llm.js");
+  memoryLlm = await import("../src/memory/llm.js");
+  settings = await import("../src/settings.js");
+});
+
+after(async () => {
+  await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+});
+
+beforeEach(() => {
+  seen = [];
+  replyWith = "fake completion text";
+  replyStatus = 200;
+  db.exec("DELETE FROM llm_log");
+});
+
+describe("shared LLM transport layer", () => {
+  test("forced http: completes, sends bearer key, uses the smart-tier default model", async () => {
+    const text = await llm.complete("say hi", { tier: "smart", feature: "distiller" });
+    assert.equal(text, "fake completion text");
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].auth, "Bearer test-llm-key");
+    assert.equal(seen[0].model, "anthropic/claude-sonnet-4.6");
+    assert.equal(seen[0].prompt, "say hi");
+  });
+
+  test("fast tier resolves the fast default model", async () => {
+    await llm.complete("compare", { tier: "fast", feature: "judge" });
+    assert.equal(seen[0].model, "anthropic/claude-haiku-4.5");
+  });
+
+  test("LLM_MODEL_SMART setting overrides the tier default; explicit model wins over both", async () => {
+    settings.putSetting("LLM_MODEL_SMART", "minimax/minimax-m3");
+    try {
+      await llm.complete("a", { tier: "smart", feature: "distiller" });
+      assert.equal(seen[0].model, "minimax/minimax-m3");
+      await llm.complete("b", { tier: "smart", feature: "distiller", model: "meta/explicit-override" });
+      assert.equal(seen[1].model, "meta/explicit-override");
+    } finally {
+      settings.putSetting("LLM_MODEL_SMART", "");
+    }
+  });
+
+  test("every call lands in llm_log with kind = feature", async () => {
+    await llm.complete("log me", { tier: "fast", feature: "judge" });
+    const rows = db.prepare("SELECT kind, model, ok FROM llm_log").all() as Array<{ kind: string; model: string; ok: number }>;
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].kind, "judge");
+    assert.match(rows[0].model, /^http:/);
+    assert.equal(rows[0].ok, 1);
+  });
+
+  test("http error surfaces as a thrown error and a failed log row", async () => {
+    replyStatus = 500;
+    await assert.rejects(() => llm.complete("boom", { tier: "fast", feature: "judge" }), /LLM HTTP 500/);
+    const rows = db.prepare("SELECT ok, error FROM llm_log").all() as Array<{ ok: number; error: string }>;
+    assert.equal(rows[0].ok, 0);
+    assert.match(rows[0].error, /500/);
+  });
+
+  test("forced http without any key → clear configuration error, no request sent", async () => {
+    const savedKey = process.env.LLM_API_KEY;
+    delete process.env.LLM_API_KEY;
+    delete process.env.OPENROUTER_API_KEY;
+    settings.putSetting("LLM_API_KEY", ""); // no DB override; invalidates the settings cache
+    try {
+      await assert.rejects(
+        () => llm.complete("x", { tier: "fast", feature: "judge" }),
+        /LLM_API_KEY or OPENROUTER_API_KEY/,
+      );
+      assert.equal(seen.length, 0);
+    } finally {
+      process.env.LLM_API_KEY = savedKey;
+      settings.putSetting("LLM_API_KEY", ""); // invalidate again so the restored env is re-read
+    }
+  });
+
+  test("resolveLlmTransport honors the forced setting", async () => {
+    assert.equal(await llm.resolveLlmTransport(), "http");
+  });
+});
+
+describe("memory pipeline seam (memory/llm.ts)", () => {
+  test("callLlm default-delegates to the shared layer with tier + feature", async () => {
+    const text = await memoryLlm.callLlm("distill this", { tier: "smart", feature: "distiller" });
+    assert.equal(text, "fake completion text");
+    assert.equal(seen[0].model, "anthropic/claude-sonnet-4.6");
+  });
+
+  test("DISTILLER_MODEL env override passes through verbatim", async () => {
+    process.env.DISTILLER_MODEL = "custom/distiller-model";
+    try {
+      await memoryLlm.callLlm("distill", { tier: "smart", feature: "distiller", model: memoryLlm.distillerModel() });
+      assert.equal(seen[0].model, "custom/distiller-model");
+    } finally {
+      delete process.env.DISTILLER_MODEL;
+    }
+  });
+
+  test("injected transport bypasses the shared layer entirely (offline tests)", async () => {
+    memoryLlm.setLlmTransport(async () => "stubbed");
+    try {
+      const text = await memoryLlm.callLlm("anything", { tier: "fast", feature: "judge" });
+      assert.equal(text, "stubbed");
+      assert.equal(seen.length, 0);
+    } finally {
+      memoryLlm.setLlmTransport(llm.complete);
+    }
+  });
+});

--- a/orchestrator/test/memory.test.ts
+++ b/orchestrator/test/memory.test.ts
@@ -31,6 +31,7 @@ let anchors: typeof import("../src/memory/anchors.js");
 let headline: typeof import("../src/memory/headline.js");
 let cards: typeof import("../src/memory/cards.js");
 let findHits: typeof import("../src/memory/find-hits.js");
+let corpusObserve: typeof import("../src/memory/corpus-observe.js");
 let cosine: (a: Float32Array, b: Float32Array) => number;
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
@@ -79,6 +80,7 @@ before(async () => {
   headline = await import("../src/memory/headline.js");
   cards = await import("../src/memory/cards.js");
   findHits = await import("../src/memory/find-hits.js");
+  corpusObserve = await import("../src/memory/corpus-observe.js");
   cosine = (await import("../src/embed.js")).cosine;
   store.setEmbedder(stubEmbedder);
 });
@@ -856,6 +858,90 @@ describe("drill-down cards (Section C)", () => {
     assert.deepEqual(cards.parseCardId("slackthread:1700000000.001"), { type: "slackthread", id: "1700000000.001" });
     assert.equal(cards.parseCardId("svc:users"), null, "graph node ids are not card namespaces");
     assert.equal(cards.parseCardId("noColon"), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Citation source refs (migration 10): observations carry source_id/source_url
+// back to the original artifact; (source, source_id) dedupes re-mirrored rows.
+describe("citation source refs", () => {
+  before(() => store.setEmbedder(stubEmbedder));
+
+  test("observeCorpus stores source_id + source_url; obs card cites the url", async () => {
+    clearMemory();
+    await corpusObserve.observeCorpus({
+      source: "slack",
+      text: "the deploy failed because of the missing env var",
+      source_id: "ev-1",
+      source_url: "https://slack/permalink/1",
+    });
+    const o = store.getObservationBySource("slack", "ev-1");
+    assert.ok(o, "observation found by (source, source_id)");
+    assert.equal(o!.source_url, "https://slack/permalink/1");
+    const card = cards.getCard("obs", o!.id);
+    assert.equal((card.card as any).source_url, "https://slack/permalink/1");
+  });
+
+  test("re-mirrored source refreshes its one observation instead of duplicating (linear poller shape)", async () => {
+    clearMemory();
+    const base = { source: "linear" as const, source_id: "lin-uuid-1", source_url: "https://linear.app/acme/ACME-9" };
+    await corpusObserve.observeCorpus({ ...base, text: "ACME-9 — fix retries" });
+    await corpusObserve.observeCorpus({ ...base, text: "ACME-9 — fix retries (now with repro steps)" });
+    const rows = db.prepare("SELECT id, claim FROM observations WHERE source = 'linear' AND source_id = 'lin-uuid-1'").all();
+    assert.equal(rows.length, 1, "one observation per source artifact");
+    assert.match(rows[0].claim, /repro steps/, "claim refreshed to the latest mirror");
+    // FTS mirror followed the update (observations_au trigger).
+    const fts = db.prepare("SELECT id FROM observations_fts WHERE observations_fts MATCH 'repro'").all();
+    assert.equal(fts.length, 1);
+  });
+
+  test("unchanged re-mirror is a no-op (no re-embed, claim identical)", async () => {
+    clearMemory();
+    const base = { source: "linear" as const, source_id: "lin-uuid-2", source_url: "https://linear.app/acme/ACME-10", text: "ACME-10 — same text" };
+    await corpusObserve.observeCorpus(base);
+    const before = db.prepare("SELECT id, embedding FROM observations WHERE source_id = 'lin-uuid-2'").get();
+    await corpusObserve.observeCorpus(base);
+    const after = db.prepare("SELECT id, embedding FROM observations WHERE source_id = 'lin-uuid-2'").get();
+    assert.equal(after.id, before.id);
+    assert.deepEqual(after.embedding, before.embedding);
+  });
+
+  test("mem card evidence lines carry the citation url when the observation has one", async () => {
+    clearMemory();
+    const o = await store.insertObservation({
+      source: "slack",
+      repo: "acme",
+      claim: "we always gate deploys on the smoke suite",
+      kind: "decision",
+      source_weight: "user_stated",
+      source_id: "ev-2",
+      source_url: "https://slack/permalink/2",
+    });
+    const res = await consolidate.consolidateObservation(o, async () => ({ verdict: "new" as const }));
+    const card = cards.getCard("mem", res.memoryId);
+    const ev = (card.card as any).evidence;
+    assert.equal(ev[0].url, "https://slack/permalink/2", "evidence cites the original message");
+  });
+
+  test("lin card anchored_nodes uses the exact source_id FK (no retrieval_keys needed)", async () => {
+    clearMemory();
+    db.prepare("INSERT INTO linear_tickets (id, identifier, title, description, state, url, updated_at) VALUES (?,?,?,?,?,?,?)")
+      .run("t9", "ACME-77", "Harden pollers", null, "Todo", "https://linear.app/acme/ACME-77", 1700000000);
+    // Observation carries the FK but neither the identifier in its claim nor retrieval keys.
+    const o = await store.insertObservation({ source: "linear", claim: "harden the pollers against cursor loss", kind: "gotcha", source_weight: "user_stated", source_id: "t9", source_url: "https://linear.app/acme/ACME-77" });
+    anchors.setAnchors("observation", o.id, ["svc:pollers"], "semantic");
+    const card = cards.getCard("lin", "ACME-77");
+    assert.ok((card.card as any).anchored_nodes.includes("svc:pollers"));
+  });
+
+  test("pre-migration rows (source_id NULL) still fuzzy-match via retrieval_keys", async () => {
+    clearMemory();
+    db.prepare("INSERT INTO linear_tickets (id, identifier, title, description, state, url, updated_at) VALUES (?,?,?,?,?,?,?)")
+      .run("t10", "ACME-88", "Legacy row", null, "Todo", "https://linear.app/acme/ACME-88", 1700000000);
+    const o = await store.insertObservation({ source: "linear", claim: "ACME-88 legacy observation", kind: "gotcha", source_weight: "user_stated", retrieval_keys: ["ACME-88"] });
+    anchors.setAnchors("observation", o.id, ["svc:legacy"], "files");
+    const card = cards.getCard("lin", "ACME-88");
+    assert.ok((card.card as any).anchored_nodes.includes("svc:legacy"));
   });
 });
 


### PR DESCRIPTION
First two phases of the event-pipeline rework (per the architecture discussion on 2026-07-18).

## Phase 1 — Citation source refs (183eca2)
Observations now carry `source_id` + `source_url` back to the original artifact (Slack event id + permalink, Linear issue id + url) — migration 10.

- **Memories can now cite**: obs cards expose `source_url`, mem-card evidence lines carry the url.
- **Fixes a live bug**: the Linear poller re-mirrored a ticket on every update and inserted a *new* observation each time; `(source, source_id)` is now the dedupe key — one observation per artifact, refreshed in place (FTS follows via trigger, unchanged claims skip re-embedding).
- The corpus→anchors join (`anchoredNodesForCorpus`) uses the exact FK, keeping fuzzy retrieval_keys matching only for pre-migration rows.

## Phase 2 — Shared single-shot LLM transport layer (bd85309)
New `orchestrator/src/llm.ts`: `complete(prompt, {tier, feature, model?})`. Installed CLIs and API keys are **both first-class**:

- `cli` — the user's installed claude CLI (local default, no key needed)
- `http` — any OpenAI-compatible endpoint (headless/EC2 path)
- `LLM_TRANSPORT` setting: `auto` (CLI when installed, else key) or force either; forcing an unusable transport errors clearly instead of silently switching. New transports (e.g. signed-in CLI on a server) slot in as another `LlmTransportKind`.

Features ask by **tier** (`fast`/`smart`) since model ids aren't portable across transports; `LLM_MODEL_FAST/SMART` settings override the tier maps; per-feature env overrides pass through verbatim. Every call now lands in `llm_log` (distiller/judge calls were previously invisible).

**Fixes**: the distiller was hardcoded to `claude -p` and threw on every session close on deployments without the CLI (EC2).

## Tests
- 6 new citation tests + 10 new transport tests (fake OpenAI-compatible server, fully offline)
- Full orchestrator suite: 235/235 passing
- Pre-existing (untouched): 11 `tsc --noEmit` errors on dev; not part of the verify gate

## Next (queued, separate PRs)
Respond-only-when-tagged + classifier removal (kill path A), then GitHub PR-body corpus feeder.