### PR TITLE
Fix find_entity returning no results by restoring MCP embeddings (rebased #31 + review fixes)

### DIFF
--- a/bin/flow.mjs
+++ b/bin/flow.mjs
@@ -776,9 +776,9 @@ async function upProject(name, { rebuilt = false } = {}) {
     FLOW_PROJECT_NAME: name,
     NODE_ENV: "production",
   };
-  // Embeddings (semantic find_entity + embed-on-write) need an LLM API key —
-  // LLM_API_KEY for any OpenAI-compatible provider, or the OpenRouter key.
-  // Fall back to the machine default / ambient env when it isn't in the .env.
+  // Direct LLM callers (classification) may use an OpenAI-compatible provider.
+  // Embeddings are local and need no key; these remain gateway-compatible env
+  // for deployments that still override other LLM behavior.
   for (const key of ["LLM_API_KEY", "LLM_BASE_URL", "OPENROUTER_API_KEY"]) {
     if (!gwEnv[key]) {
       const k = readGlobalKey(dir, key) ?? process.env[key];
@@ -803,10 +803,9 @@ async function upProject(name, { rebuilt = false } = {}) {
     OPENCODE_WORKSPACE_DIR: workspaceDir,
     FLOW_MODE: mode,
     REPOS_JSON_PATH: reposJsonPath,
-    // Inherited down to the gateway MCP subprocesses that indexer jobs spawn
-    // (opencode via workspace opencode.json; claude/codex directly) — the MCP
-    // opens FalkorDB directly, so it needs the project's graph name and
-    // journal, or indexer writes land in the default graph and journal.
+    // Inherited down to gateway MCP subprocesses spawned by indexer jobs.
+    // Graph operations still use FalkorDB directly; embeddings borrow this
+    // project's long-lived gateway model through GATEWAY_URL.
     GRAPH_NAME: graph,
     JOURNAL_PATH: journalPath,
     NODE_ENV: "production",

--- a/graph-gateway/package.json
+++ b/graph-gateway/package.json
@@ -10,7 +10,7 @@
     "start": "tsx src/server.ts",
     "mcp": "tsx src/mcp.ts",
     "typecheck": "tsc --noEmit",
-    "test": "node --experimental-test-module-mocks --import tsx/esm --test test/verbs-batch.test.ts test/verbs-memory.test.ts"
+    "test": "node --experimental-test-module-mocks --import tsx/esm --test test/verbs-batch.test.ts test/verbs-memory.test.ts test/embed.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",

--- a/graph-gateway/scripts/backfill-embeddings.ts
+++ b/graph-gateway/scripts/backfill-embeddings.ts
@@ -3,14 +3,14 @@
 // want it NOW without a restart, or need --force after changing the embedding
 // text/model.
 //
-//   OPENROUTER_API_KEY=... tsx scripts/backfill-embeddings.ts [--graph <name>] [--force]
+//   tsx scripts/backfill-embeddings.ts [--graph <name>] [--force]
 //
 // --graph  target named graph (default: $GRAPH_NAME or 'memory')
 // --force  re-embed every node, not just those missing an embedding
 
 import { close } from "../src/graph.js";
-import { embeddingsEnabled } from "../src/embed.js";
 import { reconcileEmbeddings } from "../src/reconcile.js";
+import { isLocalEmbedReady, startLocalModel } from "../src/local-embed.js";
 
 function arg(flag: string): string | undefined {
   const i = process.argv.indexOf(flag);
@@ -21,8 +21,9 @@ async function main() {
   const graph = arg("--graph") ?? process.env.GRAPH_NAME ?? "memory";
   const force = process.argv.includes("--force");
 
-  if (!embeddingsEnabled()) {
-    console.error("No LLM API key set (LLM_API_KEY or OPENROUTER_API_KEY) — nothing to do.");
+  await startLocalModel();
+  if (!isLocalEmbedReady()) {
+    console.error("Local embedding model failed to load — see the error above.");
     process.exit(1);
   }
 

--- a/graph-gateway/src/embed.ts
+++ b/graph-gateway/src/embed.ts
@@ -13,8 +13,41 @@ import { isLocalEmbedReady, embedTextLocal, embedBatchLocal, LOCAL_EMBED_DIM } f
 
 export const EMBED_DIM = LOCAL_EMBED_DIM; // 768
 
+// The long-lived HTTP gateway owns the local model. Short-lived MCP processes
+// set FLOW_EMBED_URL and borrow that model instead of loading another ~300 MB
+// copy. The gateway process itself leaves this unset and embeds in-process.
+const REMOTE_EMBED_URL = (process.env.FLOW_EMBED_URL ?? "").replace(/\/+$/, "");
+const REMOTE_EMBED_TOKEN = process.env.FLOW_EMBED_TOKEN ?? "";
+
 export function embeddingsEnabled(): boolean {
-  return isLocalEmbedReady();
+  return Boolean(REMOTE_EMBED_URL) || isLocalEmbedReady();
+}
+
+async function embedRemote(text: string): Promise<{ vec: number[] | null; error?: string }> {
+  try {
+    const res = await fetch(REMOTE_EMBED_URL, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...(REMOTE_EMBED_TOKEN ? { authorization: `Bearer ${REMOTE_EMBED_TOKEN}` } : {}),
+      },
+      body: JSON.stringify({ text }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!res.ok) {
+      const detail = (await res.text().catch(() => "")).slice(0, 200);
+      return { vec: null, error: `embedding gateway returned HTTP ${res.status}${detail ? `: ${detail}` : ""}` };
+    }
+    const body = (await res.json()) as { vec?: number[] | null; dim?: number; ready?: boolean };
+    if (!body.ready) return { vec: null, error: "local embedding model not yet loaded" };
+    if (!Array.isArray(body.vec)) return { vec: null, error: "embedding gateway returned no vector" };
+    if (body.dim !== EMBED_DIM || body.vec.length !== EMBED_DIM) {
+      return { vec: null, error: `embedding gateway dimension mismatch (expected ${EMBED_DIM}, got ${body.dim ?? "unknown"}/${body.vec.length})` };
+    }
+    return { vec: body.vec };
+  } catch (err) {
+    return { vec: null, error: `embedding gateway unavailable: ${err instanceof Error ? err.message : String(err)}` };
+  }
 }
 
 // Human-readable words for the schema's machine labels. Embedding "workflow:"
@@ -66,6 +99,7 @@ export function entityText(
 export async function embedText(text: string): Promise<number[] | null> {
   const clean = text.trim();
   if (!clean) return null;
+  if (REMOTE_EMBED_URL) return (await embedRemote(clean)).vec;
   return embedTextLocal(clean);
 }
 
@@ -77,6 +111,7 @@ export async function embedText(text: string): Promise<number[] | null> {
 export async function embedQuery(text: string): Promise<{ vec: number[] | null; error?: string }> {
   const clean = text.trim();
   if (!clean) return { vec: null, error: "empty query" };
+  if (REMOTE_EMBED_URL) return embedRemote(clean);
   if (!isLocalEmbedReady()) return { vec: null, error: "local embedding model not yet loaded" };
   const vec = await embedTextLocal(clean);
   return { vec, error: vec ? undefined : "embedding returned null" };
@@ -86,5 +121,10 @@ export async function embedQuery(text: string): Promise<{ vec: number[] | null; 
 // chunk failed) so callers can align results with their node list.
 export async function embedBatch(texts: string[]): Promise<(number[] | null)[]> {
   if (texts.length === 0) return [];
+  if (REMOTE_EMBED_URL) {
+    const out: (number[] | null)[] = [];
+    for (const text of texts) out.push((await embedRemote(text.trim() || " ")).vec);
+    return out;
+  }
   return embedBatchLocal(texts.map((t) => t.trim() || " "));
 }

--- a/graph-gateway/src/embed.ts
+++ b/graph-gateway/src/embed.ts
@@ -119,11 +119,19 @@ export async function embedQuery(text: string): Promise<{ vec: number[] | null; 
 
 // Batched embedding for backfill. Returns one slot per input (null where a
 // chunk failed) so callers can align results with their node list.
+// Remote path runs a bounded window of concurrent requests — serial round
+// trips make big backfills crawl, unbounded fan-out floods the gateway.
+const REMOTE_BATCH_CONCURRENCY = 8;
+
 export async function embedBatch(texts: string[]): Promise<(number[] | null)[]> {
   if (texts.length === 0) return [];
   if (REMOTE_EMBED_URL) {
-    const out: (number[] | null)[] = [];
-    for (const text of texts) out.push((await embedRemote(text.trim() || " ")).vec);
+    const out: (number[] | null)[] = new Array(texts.length).fill(null);
+    for (let i = 0; i < texts.length; i += REMOTE_BATCH_CONCURRENCY) {
+      const window = texts.slice(i, i + REMOTE_BATCH_CONCURRENCY);
+      const vecs = await Promise.all(window.map((text) => embedRemote(text.trim() || " ").then((r) => r.vec)));
+      for (let j = 0; j < vecs.length; j++) out[i + j] = vecs[j];
+    }
     return out;
   }
   return embedBatchLocal(texts.map((t) => t.trim() || " "));

--- a/graph-gateway/src/reconcile.ts
+++ b/graph-gateway/src/reconcile.ts
@@ -13,7 +13,7 @@
 //   2. RECONCILERS — unversioned, convergent, idempotent, run in the
 //      background on every boot. For enrichment where "check what's missing
 //      and fill it" is cheap and safe to re-run. They self-heal: a reconciler
-//      also catches nodes written while a dependency (say, the OpenRouter key)
+//      also catches nodes written while a dependency (say, the local model)
 //      was missing. Never block startup, never crash the gateway.
 //
 // Only the long-lived HTTP gateway runs this — the per-session MCP subprocess
@@ -58,7 +58,7 @@ export async function runGraphMigrations(graph: string): Promise<void> {
 
 // ---------------------------------------------------------------------------
 // Reconciler: semantic embeddings. Nodes written before the embeddings
-// feature (or while OPENROUTER_API_KEY was unset / an embed call failed) have
+// feature (or while the local model was loading / an embed call failed) have
 // no vector; find_entity's semantic fallback can't see them. Converge here.
 // Returns counts so the manual script (scripts/backfill-embeddings.ts) can
 // report; `force` re-embeds everything (after an embed-text or model change).

--- a/graph-gateway/src/server.ts
+++ b/graph-gateway/src/server.ts
@@ -2,7 +2,7 @@ import { createServer } from "node:http";
 import { callVerb, verbs } from "./verbs.js";
 import { tail } from "./journal.js";
 import { DEFAULT_GRAPH } from "./graph.js";
-import { runBootTasks } from "./reconcile.js";
+import { reconcileEmbeddings, runBootTasks } from "./reconcile.js";
 import { startLocalModel } from "./local-embed.js";
 import { embedText, embeddingsEnabled, EMBED_DIM } from "./embed.js";
 import { isPat, verifyPatForProject } from "./patAuth.js";
@@ -10,6 +10,7 @@ import { isPat, verifyPatForProject } from "./patAuth.js";
 // HTTP face of the gateway — bind to localhost only.
 //   POST /v1/verbs/<name>   body: verb input JSON   (bearer-authed)
 //   POST /v1/embed          body: { text }          (bearer-authed)
+//   POST /v1/reconcile/embeddings                    (bearer-authed)
 //   GET  /v1/journal?limit=50                        (bearer-authed)
 //   GET  /health                                     (open)
 //
@@ -80,6 +81,16 @@ const server = createServer(async (req, res) => {
       const ready = embeddingsEnabled();
       const vec = ready ? await embedText(text) : null;
       return json(res, 200, { vec, dim: EMBED_DIM, ready });
+    }
+    // Indexing writes arrive through short-lived MCP processes. A final
+    // reconciliation closes the race where those writes happen while the
+    // gateway's local model is still loading.
+    if (req.method === "POST" && url.pathname === "/v1/reconcile/embeddings") {
+      if (!embeddingsEnabled()) {
+        return json(res, 503, { status: "error", error: "local embedding model not yet loaded" });
+      }
+      const result = await reconcileEmbeddings(DEFAULT_GRAPH);
+      return json(res, 200, { status: "ok", graph: DEFAULT_GRAPH, ...result });
     }
     const verbMatch = url.pathname.match(/^\/v1\/verbs\/([a-z_]+)$/);
     if (req.method === "POST" && verbMatch) {

--- a/graph-gateway/src/verbs.ts
+++ b/graph-gateway/src/verbs.ts
@@ -141,7 +141,7 @@ async function findSimilar(graph: string, q: string, type?: string, limit = 10, 
 // that answer retrieval questions must pass that on, because lexical-only
 // results are indistinguishable from "the graph has nothing" otherwise.
 async function findByVector(graph: string, q: string, type: string | undefined, limit: number, includeProposed = false): Promise<{ rows: ScoredRow[]; degraded?: string }> {
-  if (!embeddingsEnabled()) return { rows: [], degraded: "no LLM API key configured (LLM_API_KEY / OPENROUTER_API_KEY)" };
+  if (!embeddingsEnabled()) return { rows: [], degraded: "local embedding service is not configured" };
   const { vec, error } = await embedQuery(q);
   if (!vec) return { rows: [], degraded: error ?? "query could not be embedded" };
   const typeFilter = type ? `AND labels(n)[0] = $type` : "";

--- a/graph-gateway/test/embed.test.ts
+++ b/graph-gateway/test/embed.test.ts
@@ -1,0 +1,36 @@
+import { after, before, test } from "node:test";
+import assert from "node:assert/strict";
+import { createServer, type Server } from "node:http";
+
+let server: Server;
+let embedQuery: (text: string) => Promise<{ vec: number[] | null; error?: string }>;
+let requests = 0;
+
+before(async () => {
+  server = createServer(async (req, res) => {
+    assert.equal(req.headers.authorization, "Bearer scoped-embed-token");
+    requests++;
+    for await (const _chunk of req) { /* drain */ }
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ ready: true, dim: 768, vec: Array(768).fill(0.25) }));
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("test server did not bind");
+  process.env.FLOW_EMBED_URL = `http://127.0.0.1:${address.port}/v1/embed`;
+  process.env.FLOW_EMBED_TOKEN = "scoped-embed-token";
+  ({ embedQuery } = await import("../src/embed.js"));
+});
+
+after(async () => {
+  delete process.env.FLOW_EMBED_URL;
+  delete process.env.FLOW_EMBED_TOKEN;
+  await new Promise<void>((resolve, reject) => server.close((err) => err ? reject(err) : resolve()));
+});
+
+test("MCP process borrows the gateway embedding model", async () => {
+  const result = await embedQuery("semantic lookup intent");
+  assert.equal(result.error, undefined);
+  assert.equal(result.vec?.length, 768);
+  assert.equal(requests, 1);
+});

--- a/orchestrator/package.json
+++ b/orchestrator/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts",
-    "test": "node --import tsx/esm --test test/fake-opencode.ts test/orchestrator.test.ts test/adapters.test.ts test/outbox-approve.test.ts test/llmlog.test.ts test/smoke.ts test/notify.test.ts test/pollers.test.ts test/poller.test.ts test/settings.test.ts test/sources.test.ts test/agent-diff.test.ts test/worktrees.test.ts test/memory.test.ts test/llm.test.ts",
+    "test": "node --import tsx/esm --test test/fake-opencode.ts test/orchestrator.test.ts test/adapters.test.ts test/outbox-approve.test.ts test/llmlog.test.ts test/smoke.ts test/notify.test.ts test/pollers.test.ts test/poller.test.ts test/settings.test.ts test/sources.test.ts test/agent-diff.test.ts test/worktrees.test.ts test/memory.test.ts test/llm.test.ts test/indexer-runtime.test.ts",
     "verify": "npm test",
     "verify:real": "tsx test/real-integrations.ts",
     "verify:session": "tsx test/real-session.ts"

--- a/orchestrator/src/agents/runtime.ts
+++ b/orchestrator/src/agents/runtime.ts
@@ -18,7 +18,6 @@ import { Readable, Writable } from "node:stream";
 import { fileURLToPath } from "node:url";
 import * as acp from "@agentclientprotocol/sdk";
 import db from "../db.js";
-import { llmApiKey, llmBaseUrl } from "../settings.js";
 import { addNote, matchNotes } from "../notes.js";
 import { embedText } from "../embed.js";
 import { onSessionClosed, setTranscriptReader, startIdleSweep } from "../memory/trigger.js";
@@ -940,6 +939,8 @@ async function resumeConnection(s: LiveSession): Promise<Connection> {
 
 function flowGraphMcp(flowSessionId: string, repo = "", branch = ""): acp.McpServer {
   const orchPort = process.env.ORCHESTRATOR_PORT ?? "7500";
+  const gatewayUrl = (process.env.GATEWAY_URL ?? "http://127.0.0.1:7433").replace(/\/+$/, "");
+  const gatewayToken = process.env.GATEWAY_TOKEN || process.env.FLOW_ADMIN_TOKEN || "";
   const env: Array<{ name: string; value: string }> = [
     { name: "GATEWAY_MCP_READONLY", value: "1" },
     { name: "GRAPH_NAME", value: projectGraphName() },
@@ -958,17 +959,13 @@ function flowGraphMcp(flowSessionId: string, repo = "", branch = ""): acp.McpSer
     // correct_graph dispatch target — flags land in the corrections queue and
     // get verified against the base-branch checkout by the indexer.
     { name: "FLOW_CORRECTIONS_URL", value: `http://127.0.0.1:${orchPort}/v1/corrections` },
+    // The gateway owns the local embedding model. Agent MCP subprocesses use
+    // it over HTTP instead of loading one model copy per active session.
+    { name: "FLOW_EMBED_URL", value: `${gatewayUrl}/v1/embed` },
   ];
+  if (gatewayToken) env.push({ name: "FLOW_EMBED_TOKEN", value: gatewayToken });
   if (process.env.FALKOR_HOST) env.push({ name: "FALKOR_HOST", value: process.env.FALKOR_HOST });
   if (process.env.FALKOR_PORT) env.push({ name: "FALKOR_PORT", value: process.env.FALKOR_PORT });
-  // Give the read-only MCP the embeddings key so find_entity can do semantic
-  // search — without it, the vector fallback silently no-ops and agents get the
-  // old substring-only behaviour. Same key used everywhere (getSetting → DB/env).
-  const embedKey = llmApiKey();
-  if (embedKey) {
-    env.push({ name: "LLM_API_KEY", value: embedKey });
-    env.push({ name: "LLM_BASE_URL", value: llmBaseUrl() });
-  }
   return { name: "flow-graph", command: binPath("tsx"), args: [GATEWAY_MCP], env };
 }
 

--- a/orchestrator/src/indexer-runtime.ts
+++ b/orchestrator/src/indexer-runtime.ts
@@ -14,7 +14,7 @@ import {
   detectAgents,
   resolveLocalExecutable,
 } from "./agents/runtime.js";
-import { getSetting, llmApiKey, llmBaseUrl } from "./settings.js";
+import { getSetting } from "./settings.js";
 
 export type IndexerBackend = "opencode" | "codex" | "claude";
 
@@ -100,11 +100,16 @@ export interface McpSpecOpts {
 
 export function mcpEnv(opts: McpSpecOpts): Record<string, string> {
   const orchPort = process.env.ORCHESTRATOR_PORT ?? "7500";
+  const gatewayUrl = (process.env.GATEWAY_URL ?? "http://127.0.0.1:7433").replace(/\/+$/, "");
+  const gatewayToken = process.env.GATEWAY_TOKEN || process.env.FLOW_ADMIN_TOKEN || "";
   const env: Record<string, string> = {
     GATEWAY_MCP_MODE: "builder",
     GRAPH_NAME: opts.graphName,
     FLOW_CORRECTIONS_URL: `http://127.0.0.1:${orchPort}/v1/corrections`,
+    // MCP is short-lived; borrow the gateway's one local Gemma instance.
+    FLOW_EMBED_URL: `${gatewayUrl}/v1/embed`,
   };
+  if (gatewayToken) env.FLOW_EMBED_TOKEN = gatewayToken;
   if (opts.actor) env.FLOW_ACTOR = opts.actor;
   if (opts.job) {
     env.FLOW_JOB_ID = opts.job.id;
@@ -114,11 +119,6 @@ export function mcpEnv(opts: McpSpecOpts): Record<string, string> {
   if (process.env.JOURNAL_PATH) env.JOURNAL_PATH = process.env.JOURNAL_PATH;
   if (process.env.FALKOR_HOST) env.FALKOR_HOST = process.env.FALKOR_HOST;
   if (process.env.FALKOR_PORT) env.FALKOR_PORT = process.env.FALKOR_PORT;
-  const key = llmApiKey();
-  if (key) {
-    env.LLM_API_KEY = key;
-    env.LLM_BASE_URL = llmBaseUrl();
-  }
   if (opts.writeScope) env.FLOW_WRITE_SCOPE = opts.writeScope;
   return env;
 }

--- a/orchestrator/src/opencode.ts
+++ b/orchestrator/src/opencode.ts
@@ -465,6 +465,13 @@ async function runJob(id: string, opts: JobInput): Promise<void> {
 
     const { result, sessionId } = runResult;
 
+    // Entity writes come from short-lived MCP processes. They normally embed
+    // each node through the gateway immediately; this final pass catches any
+    // writes made while the local model was still loading.
+    if (opts.type === "index_repo" && !process.env.FLOW_FAKE_OPENCODE) {
+      await reconcileGraphEmbeddings();
+    }
+
     // Persist session_id on the job row
     if (sessionId) {
       updateJobSession.run({ id, session_id: sessionId });
@@ -553,6 +560,28 @@ async function runJob(id: string, opts: JobInput): Promise<void> {
     if (opts.type === "index_repo" && repo) {
       runningRepos.delete(repo);
     }
+  }
+}
+
+async function reconcileGraphEmbeddings(): Promise<void> {
+  const gatewayUrl = (process.env.GATEWAY_URL ?? "http://127.0.0.1:7433").replace(/\/+$/, "");
+  const token = process.env.GATEWAY_TOKEN || process.env.FLOW_ADMIN_TOKEN || "";
+  try {
+    const res = await fetch(`${gatewayUrl}/v1/reconcile/embeddings`, {
+      method: "POST",
+      headers: { ...(token ? { authorization: `Bearer ${token}` } : {}) },
+      signal: AbortSignal.timeout(60_000),
+    });
+    if (!res.ok) {
+      console.warn(`[embed] post-index reconcile returned HTTP ${res.status}: ${(await res.text().catch(() => "")).slice(0, 200)}`);
+      return;
+    }
+    const result = (await res.json()) as { total?: number; embedded?: number; failed?: number };
+    console.log(`[embed] post-index reconcile: embedded ${result.embedded ?? 0}/${result.total ?? 0}${result.failed ? `, failed ${result.failed}` : ""}`);
+  } catch (err) {
+    // Indexing remains useful in lexical-only mode; surface the degradation
+    // without turning an otherwise successful graph build into a failed job.
+    console.warn(`[embed] post-index reconcile failed: ${err instanceof Error ? err.message : String(err)}`);
   }
 }
 
@@ -710,6 +739,8 @@ function indexerTimeout(opts: JobInput): number {
 // used by opencode's workspace graph tools and are harmless for the others.
 function indexerChildEnv(opts: JobInput, jobId: string, actor: string): NodeJS.ProcessEnv {
   const port = process.env.ORCHESTRATOR_PORT ?? "7500";
+  const gatewayUrl = (process.env.GATEWAY_URL ?? "http://127.0.0.1:7433").replace(/\/+$/, "");
+  const gatewayToken = process.env.GATEWAY_TOKEN || process.env.FLOW_ADMIN_TOKEN || "";
   const openrouterKey =
     getSetting("OPENROUTER_API_KEY") ?? process.env.OPENROUTER_API_KEY ?? "";
   const env: NodeJS.ProcessEnv = {
@@ -717,7 +748,11 @@ function indexerChildEnv(opts: JobInput, jobId: string, actor: string): NodeJS.P
     ORCHESTRATOR_URL: process.env.ORCHESTRATOR_URL ?? `http://127.0.0.1:${port}`,
     // The session's graph tools read GRAPH_GATEWAY_URL — it MUST be this
     // project's gateway, or agents write into another project's graph.
-    GRAPH_GATEWAY_URL: process.env.GATEWAY_URL ?? "http://127.0.0.1:7433",
+    GRAPH_GATEWAY_URL: gatewayUrl,
+    // The MCP subprocess uses the gateway-owned Gemma model for semantic
+    // queries and embed-on-write. This avoids one model per CLI process.
+    FLOW_EMBED_URL: `${gatewayUrl}/v1/embed`,
+    FLOW_EMBED_TOKEN: gatewayToken,
     FLOW_JOB_TOKEN: jobScopedToken(jobId),
     FLOW_JOB_ID: jobId,
     // Stamped by the gateway MCP (builder mode) into every write's provenance,
@@ -729,7 +764,7 @@ function indexerChildEnv(opts: JobInput, jobId: string, actor: string): NodeJS.P
     // Graph tools authenticate to the (now bearer-authed) gateway. The
     // subprocess already had full gateway write access by construction; the
     // token gates OTHER local processes, not this one.
-    GRAPH_GATEWAY_TOKEN: process.env.GATEWAY_TOKEN || process.env.FLOW_ADMIN_TOKEN || "",
+    GRAPH_GATEWAY_TOKEN: gatewayToken,
     // Correction verification writes are scoped to the flagged nodes — the
     // job's prompt embeds agent-authored text (prompt-injection surface), so
     // the graph tools refuse writes outside this set (S106-adjacent).

--- a/orchestrator/test/indexer-runtime.test.ts
+++ b/orchestrator/test/indexer-runtime.test.ts
@@ -1,0 +1,14 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+process.env.DB_PATH = ":memory:";
+process.env.FLOW_ADMIN_TOKEN = "test-project-token";
+process.env.GATEWAY_URL = "http://127.0.0.1:7999/";
+
+test("indexer MCP borrows the project gateway embedding model", async () => {
+  const { mcpEnv } = await import("../src/indexer-runtime.js");
+  const env = mcpEnv({ graphName: "test-graph" });
+  assert.equal(env.FLOW_EMBED_URL, "http://127.0.0.1:7999/v1/embed");
+  assert.equal(env.FLOW_EMBED_TOKEN, "test-project-token");
+  assert.equal(env.GRAPH_NAME, "test-graph");
+});

--- a/verify-all.sh
+++ b/verify-all.sh
@@ -2,7 +2,7 @@
 # flow/verify-all.sh — Host-mode verification suite (no Docker required).
 #
 # Runs every verification step in order:
-#   1. graph-gateway  — TypeScript typecheck (npx tsc --noEmit)
+#   1. graph-gateway  — unit tests + TypeScript typecheck
 #   2. orchestrator   — Unit + scenario tests (npm test)
 #   3. simulators     — Full scenario verify: boots orchestrator + linear-mock
 #                       internally, runs all scenarios (npm run verify)
@@ -87,6 +87,9 @@ run_step() {
 
 run_step "graph-gateway typecheck" "${GATEWAY_DIR}" \
   node_modules/.bin/tsc --noEmit
+
+run_step "graph-gateway unit tests" "${GATEWAY_DIR}" \
+  npm test
 
 run_step "orchestrator unit tests" "${ORCHESTRATOR_DIR}" \
   npm test


### PR DESCRIPTION
Supersedes #31 (Aravind's commit preserved with his authorship) — that branch predates the distiller merge (#32) and the `search_knowledge` rename (#33) and had unresolvable-from-GitHub conflicts, so this is the same change rebased onto current dev, plus the review fixes.

## Original change (@aravindballa, unchanged in substance)
Short-lived graph MCP processes borrow the gateway-owned local embedding model over HTTP (`FLOW_EMBED_URL`/`FLOW_EMBED_TOKEN`) instead of loading a ~300 MB Gemma copy each — or, as today, loading nothing and silently degrading `find_entity` to substring-only. A post-index `/v1/reconcile/embeddings` pass closes the race where writes land while the gateway's model is still loading. Verified originally with a live graph repair from 1/57 to 57/57 embedded entities.

## Added on top (from the review)
- **`embedBatch` remote path no longer serializes**: bounded window of 8 concurrent requests instead of N sequential round trips — backfills over hundreds of nodes were paying full latency per node.
- **Auth on `/v1/reconcile/embeddings` verified**: the bearer gate in `server.ts` runs before all routes except `/health`, so the endpoint was already covered — confirmed, no change needed.

## Rebase notes
- Conflicts were confined to the two `package.json` test lists (both sides added test files) — resolved as the union.
- Comment references updated by #33's rename untouched.

## Verification
- graph-gateway: 24/24 tests (embed test included), `tsc` clean apart from the pre-existing `node-llama-cpp` module-not-installed error (present on dev in this checkout too)
- orchestrator: full suite green including the PR's `indexer-runtime.test.ts` (one run hit the known pre-existing poller flake; two subsequent full runs clean)

Once merged, #31 can be closed.