### PR TITLE
Indexer lifecycle hardening: sequential cross-repo queue, repo_removed cleanup, durable event log, repo state machine

### DIFF
--- a/bin/flow.mjs
+++ b/bin/flow.mjs
@@ -48,7 +48,7 @@ import {
 } from "./lib/projects.mjs";
 import { probe, waitForHealth } from "./lib/health.mjs";
 import { ensureFalkordb } from "./lib/docker.mjs";
-import { deleteProjectGraph } from "./lib/falkordb.mjs";
+import { clearGraphTombstone, deleteProjectGraph } from "./lib/falkordb.mjs";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -714,6 +714,17 @@ async function upProject(name, { rebuilt = false } = {}) {
 
   // Parse project .env
   const projectEnv = parseEnvFile(join(dir, ".env"));
+
+  // This project is (re)using its graph on purpose — clear any deletion
+  // tombstone a previous `flow rm` left, or the gateway will refuse writes.
+  // Best-effort: if FalkorDB isn't up yet the services will say so loudly.
+  try {
+    const falkorHost = projectEnv.FALKOR_HOST ?? process.env.FALKOR_HOST ?? "localhost";
+    const falkorPort = Number(projectEnv.FALKOR_PORT ?? process.env.FALKOR_PORT ?? 6379);
+    await clearGraphTombstone({ graph, host: falkorHost, port: falkorPort });
+  } catch {
+    /* FalkorDB not reachable yet — nothing to clear */
+  }
 
   // Determine paths for this project
   const dbPath = join(dir, "flow.db");

--- a/bin/lib/falkordb.mjs
+++ b/bin/lib/falkordb.mjs
@@ -24,10 +24,38 @@ export async function deleteProjectGraph({ graph, host = "localhost", port = 637
     const existed = graphs.includes(graph);
     if (existed) await db.selectGraph(graph).delete();
 
-    // Gateway migrations live in a plain Redis key rather than in the graph.
+    // Gateway bookkeeping lives in plain Redis keys rather than in the graph.
     const connection = await db.connection;
     await connection.del(`flow:graph-version:${graph}`);
+    await connection.del(`flow:embed-stamp:${graph}`);
+    // Tombstone: FalkorDB auto-creates a graph on first query, so a client
+    // that survives the delete (an in-flight indexer CLI) would silently
+    // resurrect it as an untracked orphan. The gateway refuses writes to
+    // tombstoned graphs; `flow up` clears the tombstone when the graph name
+    // is legitimately used again.
+    await connection.set(`flow:graph-deleted:${graph}`, new Date().toISOString());
     return { existed };
+  } finally {
+    await db.close();
+  }
+}
+
+/**
+ * Clear a graph's deletion tombstone — called by `flow up` so a project that
+ * legitimately reuses the name (recreate after rm) can write again.
+ */
+export async function clearGraphTombstone({ graph, host = "localhost", port = 6379 }) {
+  const db = await FalkorDB.connect({
+    socket: {
+      host,
+      port: Number(port),
+      connectTimeout: 3000,
+      reconnectStrategy: false,
+    },
+  });
+  try {
+    const connection = await db.connection;
+    await connection.del(`flow:graph-deleted:${graph}`);
   } finally {
     await db.close();
   }

--- a/dashboard/scripts/smoke.mjs
+++ b/dashboard/scripts/smoke.mjs
@@ -13,6 +13,7 @@
 
 import http from "node:http";
 import { spawn, execSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import { setTimeout as sleep } from "node:timers/promises";
 
 const STUB_PORT = 17500;
@@ -306,11 +307,18 @@ async function main() {
   gatewayStub = await startGatewayStub();
 
   console.log("[smoke] Starting Next.js dev server on port", DASH_PORT);
+  // npm workspaces can hoist next's bin to the repo root (worktree checkouts
+  // do) — try the dashboard-local path first, then the hoisted one.
+  const dashDir = new URL("..", import.meta.url).pathname;
+  const nextBin =
+    ["node_modules/.bin/next", "../node_modules/.bin/next"]
+      .map((p) => dashDir + p)
+      .find((p) => existsSync(p)) ?? "node_modules/.bin/next";
   dashProc = spawn(
     "node",
-    ["node_modules/.bin/next", "dev", "--port", String(DASH_PORT)],
+    [nextBin, "dev", "--port", String(DASH_PORT)],
     {
-      cwd: new URL("..", import.meta.url).pathname,
+      cwd: dashDir,
       env: {
         ...process.env,
         ORCHESTRATOR_URL: `http://127.0.0.1:${STUB_PORT}`,

--- a/dashboard/src/app/api/index-log/route.ts
+++ b/dashboard/src/app/api/index-log/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSessionToken } from "@/lib/auth";
+import { orcFetch } from "@/lib/orchestrator";
+
+// GET /api/index-log?repo=<name>&limit=<n> — durable indexer lifecycle trail (proxied)
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const token = await getSessionToken();
+  if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const repo = req.nextUrl.searchParams.get("repo") ?? "";
+  const limit = req.nextUrl.searchParams.get("limit") ?? "";
+  const qs = new URLSearchParams();
+  if (repo) qs.set("repo", repo);
+  if (limit) qs.set("limit", limit);
+  try {
+    const res = await orcFetch(`/v1/index-log${qs.size ? `?${qs}` : ""}`, token);
+    return NextResponse.json(await res.json(), { status: res.status });
+  } catch (err) {
+    return NextResponse.json({ error: (err as Error).message }, { status: 502 });
+  }
+}

--- a/dashboard/src/app/api/repos/status/route.ts
+++ b/dashboard/src/app/api/repos/status/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { getSessionToken } from "@/lib/auth";
+import { orcFetch } from "@/lib/orchestrator";
+
+// GET /api/repos/status — per-repo indexer state machine (proxied)
+export async function GET(): Promise<NextResponse> {
+  const token = await getSessionToken();
+  if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  try {
+    const res = await orcFetch(`/v1/repos/status`, token);
+    return NextResponse.json(await res.json(), { status: res.status });
+  } catch (err) {
+    return NextResponse.json({ error: (err as Error).message }, { status: 502 });
+  }
+}

--- a/dashboard/src/components/SourcesFrontDoor.tsx
+++ b/dashboard/src/components/SourcesFrontDoor.tsx
@@ -29,6 +29,28 @@ export interface SourceEntry {
   lastIndexedAt?: string;
 }
 
+// Per-repo indexer state machine from /api/repos/status — richer than the
+// legacy !lastIndexedCommit guess, which can never show a reindex, a queued
+// job, or a failure.
+export interface RepoStatusEntry {
+  name: string;
+  branch: string;
+  status: "never_indexed" | "queued" | "indexing" | "indexed" | "failed";
+  lastIndexedCommit: string | null;
+  lastIndexedAt: string | null;
+  lastError: string | null;
+  upstreamDefaultBranch?: string;
+}
+
+// One row of the durable indexer trail (GET /api/index-log).
+interface IndexLogRow {
+  id: number;
+  event: string;
+  job_id: string | null;
+  detail: Record<string, unknown> | null;
+  created_at: number;
+}
+
 // One quiet chip per source, keyed on what the entry actually is.
 function sourceChip(s: SourceEntry): string {
   if (s.kind === "docs") return "docs · ingestion pending";
@@ -148,10 +170,66 @@ const branchSelectStyle: React.CSSProperties = {
   maxWidth: 140,
 };
 
-function SourceRow({ s, onChanged }: { s: SourceEntry; onChanged: () => void }) {
+// The durable indexer trail for one repo — when the last index ran, what got
+// queued behind what, why a job failed. Fetched once when the panel opens so
+// self-deployers can debug indexing without shell access.
+function IndexLogPanel({ repo }: { repo: string }) {
+  const { prefix } = useProject();
+  const [rows, setRows] = useState<IndexLogRow[] | null>(null);
+  useEffect(() => {
+    let alive = true;
+    fetch(prefix(`/api/index-log?repo=${encodeURIComponent(repo)}&limit=40`))
+      .then((r) => r.json())
+      .then((d) => { if (alive) setRows(((d as { rows?: IndexLogRow[] }).rows) ?? []); })
+      .catch(() => { if (alive) setRows([]); });
+    return () => { alive = false; };
+  }, [repo, prefix]);
+
+  const terse = (r: IndexLogRow): string => {
+    if (!r.detail) return "";
+    return Object.entries(r.detail)
+      .map(([k, v]) => `${k}=${typeof v === "string" ? v : JSON.stringify(v)}`)
+      .join(" ");
+  };
+
+  return (
+    <div
+      className="px-3 py-2 flex flex-col gap-1 max-h-56 overflow-y-auto"
+      style={{ borderTop: "1px solid var(--line)", background: "var(--paper)" }}
+      data-testid="index-log-panel"
+    >
+      {rows === null ? (
+        <span style={{ fontSize: 10, color: "var(--text-muted)" }}>Loading…</span>
+      ) : rows.length === 0 ? (
+        <span style={{ fontSize: 10, color: "var(--text-muted)" }}>No index events yet.</span>
+      ) : (
+        rows.map((r) => (
+          <div key={r.id} className="flex items-baseline gap-2" style={{ fontFamily: "var(--font-mono)", fontSize: 10 }}>
+            <span style={{ color: "var(--text-muted)", flexShrink: 0 }}>
+              {new Date(r.created_at * 1000).toLocaleString()}
+            </span>
+            <span style={{ color: r.event === "failed" ? "var(--danger)" : "var(--ink)", flexShrink: 0 }}>
+              {r.event}
+            </span>
+            <span style={{ color: "var(--text-muted)" }} className="truncate" title={terse(r)}>
+              {terse(r)}
+            </span>
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+function SourceRow({ s, st, onChanged }: { s: SourceEntry; st?: RepoStatusEntry; onChanged: () => void }) {
   const { prefix } = useProject();
   const chip = sourceChip(s);
-  const indexing = s.kind !== "docs" && !s.lastIndexedCommit;
+  // Prefer the orchestrator's state machine; fall back to the legacy guess
+  // when the status endpoint hasn't answered yet.
+  const status: RepoStatusEntry["status"] | undefined =
+    s.kind === "docs" ? undefined : st?.status ?? (!s.lastIndexedCommit ? "indexing" : "indexed");
+  const indexing = status === "indexing";
+  const [showLog, setShowLog] = useState(false);
 
   const [reindexing, setReindexing] = useState(false);
   const [reindexMsg, setReindexMsg] = useState("");
@@ -248,15 +326,36 @@ function SourceRow({ s, onChanged }: { s: SourceEntry; onChanged: () => void }) 
           >
             {s.name}
           </span>
-          {indexing ? (
+          {status === "indexing" ? (
             <span style={{ fontFamily: "var(--font-mono)" }} className="text-[10px] text-text-muted flex-shrink-0">
               indexing…
+            </span>
+          ) : status === "queued" ? (
+            <span style={{ fontFamily: "var(--font-mono)" }} className="text-[10px] text-text-muted flex-shrink-0">
+              reindex queued
+            </span>
+          ) : status === "failed" ? (
+            <span
+              style={{ fontFamily: "var(--font-mono)", color: "var(--danger)" }}
+              className="text-[10px] flex-shrink-0"
+              title={st?.lastError ?? undefined}
+            >
+              index failed
             </span>
           ) : timeAgo(s.lastIndexedAt) ? (
             <span style={{ fontFamily: "var(--font-mono)" }} className="text-[10px] text-text-muted flex-shrink-0">
               indexed {timeAgo(s.lastIndexedAt)}
             </span>
           ) : null}
+          {st?.upstreamDefaultBranch && (
+            <span
+              style={{ fontFamily: "var(--font-mono)" }}
+              className="text-[10px] text-text-muted flex-shrink-0"
+              title={`GitHub's default branch is now ${st.upstreamDefaultBranch}; Flow still indexes ${st.branch}. Change the branch if you want to follow it.`}
+            >
+              ⚠ default → {st.upstreamDefaultBranch}
+            </span>
+          )}
         </div>
         <div className="flex items-center gap-2 flex-shrink-0">
           <span
@@ -266,6 +365,8 @@ function SourceRow({ s, onChanged }: { s: SourceEntry; onChanged: () => void }) 
             {chip}
           </span>
           {indexing && <StatusPill kind="live">Indexing</StatusPill>}
+          {status === "queued" && <StatusPill kind="idle">Queued</StatusPill>}
+          {status === "failed" && <StatusPill kind="warn">Failed</StatusPill>}
 
           {/* Actions — only for non-docs sources */}
           {s.kind !== "docs" && (
@@ -290,6 +391,25 @@ function SourceRow({ s, onChanged }: { s: SourceEntry; onChanged: () => void }) 
                   {s.branch ?? "main"}
                 </button>
               ) : null}
+
+              {/* Index history toggle */}
+              <button
+                onClick={() => setShowLog((v) => !v)}
+                title="Index history"
+                style={{
+                  fontSize: 12,
+                  padding: "2px 6px",
+                  borderRadius: 4,
+                  border: "1px solid var(--line)",
+                  background: showLog ? "var(--sand)" : "var(--paper)",
+                  color: "var(--text-muted)",
+                  cursor: "pointer",
+                  lineHeight: 1,
+                }}
+                data-testid="index-log-toggle"
+              >
+                ≡
+              </button>
 
               {/* Reindex button */}
               <button
@@ -369,6 +489,9 @@ function SourceRow({ s, onChanged }: { s: SourceEntry; onChanged: () => void }) 
 
       {/* Live indexer activity — appears while an index job runs */}
       {s.kind !== "docs" && <IndexActivityStrip repo={s.name} active={indexing || watchActivity} />}
+
+      {/* Durable index history */}
+      {showLog && s.kind !== "docs" && <IndexLogPanel repo={s.name} />}
 
       {/* Branch edit inline panel */}
       {editingBranch && (
@@ -490,6 +613,36 @@ interface Props {
 
 export function SourcesFrontDoor({ variant, repos, mode, onChanged }: Props) {
   const [open, setOpen] = useState(false);
+  const { prefix } = useProject();
+
+  // Per-repo indexer state machine — polls faster while anything is running
+  // or queued so "indexing → indexed" flips without a page refresh.
+  const [statuses, setStatuses] = useState<Record<string, RepoStatusEntry>>({});
+  useEffect(() => {
+    if (variant !== "strip") return;
+    let alive = true;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const tick = async () => {
+      let busy = false;
+      try {
+        const res = await fetch(prefix("/api/repos/status"));
+        const d = (await res.json()) as { repos?: RepoStatusEntry[] };
+        if (!alive) return;
+        const map: Record<string, RepoStatusEntry> = {};
+        for (const r of d.repos ?? []) map[r.name] = r;
+        setStatuses(map);
+        busy = (d.repos ?? []).some((r) => r.status === "indexing" || r.status === "queued");
+      } catch {
+        /* orchestrator briefly unreachable — keep last statuses */
+      }
+      if (alive) timer = setTimeout(tick, busy ? 5000 : 30000);
+    };
+    void tick();
+    return () => {
+      alive = false;
+      if (timer) clearTimeout(timer);
+    };
+  }, [variant, prefix]);
 
   // ── First run: welcome + the two doors, full width ─────────────────────────
   if (variant === "hero") {
@@ -520,7 +673,7 @@ export function SourcesFrontDoor({ variant, repos, mode, onChanged }: Props) {
       {repos.length > 0 && (
         <div className="flex flex-col gap-1.5">
           {repos.map((s, i) => (
-            <SourceRow key={i} s={s} onChanged={onChanged} />
+            <SourceRow key={i} s={s} st={statuses[s.name]} onChanged={onChanged} />
           ))}
         </div>
       )}

--- a/graph-gateway/src/graph.ts
+++ b/graph-gateway/src/graph.ts
@@ -35,6 +35,18 @@ export async function raw() {
   return conn.connection;
 }
 
+// Deleted-graph tombstone (set by `flow rm`, cleared by `flow up`). FalkorDB
+// auto-creates a graph on first query, so without this check any surviving
+// writer (an in-flight indexer CLI holding this module in its MCP subprocess)
+// would silently resurrect a deleted graph as an untracked orphan. Returns
+// the refusal message, or null when the graph is writable.
+export async function deletedGraphError(graphName: string): Promise<string | null> {
+  const conn = await raw();
+  const tombstone = await conn.get(`flow:graph-deleted:${graphName}`);
+  if (!tombstone) return null;
+  return `graph '${graphName}' was deleted (${tombstone}) — refusing to write; if this graph should live again, run \`flow up\` for its project`;
+}
+
 export async function close(): Promise<void> {
   if (db) {
     await db.close();

--- a/graph-gateway/src/server.ts
+++ b/graph-gateway/src/server.ts
@@ -1,7 +1,7 @@
 import { createServer } from "node:http";
 import { callVerb, verbs } from "./verbs.js";
-import { tail } from "./journal.js";
-import { DEFAULT_GRAPH } from "./graph.js";
+import { record, tail } from "./journal.js";
+import { DEFAULT_GRAPH, deletedGraphError, run } from "./graph.js";
 import { runBootTasks } from "./reconcile.js";
 import { startLocalModel } from "./local-embed.js";
 import { embedText, embeddingsEnabled, EMBED_DIM } from "./embed.js";
@@ -80,6 +80,37 @@ const server = createServer(async (req, res) => {
       const ready = embeddingsEnabled();
       const vec = ready ? await embedText(text) : null;
       return json(res, 200, { vec, dim: EMBED_DIM, ready });
+    }
+    // Admin-only entity deletion — deliberately NOT a verb, so no MCP mode
+    // (session, builder, or full) can reach it; only bearer-authed services.
+    // Used by the orchestrator's repo_removed cleanup to drop the Repository
+    // node of a disconnected repo. DETACH DELETE, journaled like every write.
+    if (req.method === "POST" && url.pathname === "/v1/admin/delete-entity") {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) chunks.push(chunk as Buffer);
+      let body: { graph?: string; id?: string; actor?: string } = {};
+      try {
+        body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+      } catch {
+        return json(res, 400, { status: "error", error: "Body must be valid JSON" });
+      }
+      const id = typeof body.id === "string" ? body.id.trim() : "";
+      if (!id) return json(res, 400, { status: "error", error: "id is required" });
+      const graph = typeof body.graph === "string" && body.graph.trim() ? body.graph.trim() : DEFAULT_GRAPH;
+      // Even a MATCH auto-creates the graph in FalkorDB — don't resurrect a
+      // tombstoned graph just to delete a node from it.
+      if (await deletedGraphError(graph)) return json(res, 200, { status: "not_found", id });
+      const found = await run(graph, `MATCH (n {id: $id}) RETURN n.id`, { id });
+      if (found.length === 0) return json(res, 200, { status: "not_found", id });
+      await run(graph, `MATCH (n {id: $id}) DETACH DELETE n`, { id });
+      await record({
+        graph,
+        actor: body.actor ?? "admin",
+        verb: "admin_delete_entity",
+        input: { id },
+        status: "deleted",
+      });
+      return json(res, 200, { status: "deleted", id });
     }
     const verbMatch = url.pathname.match(/^\/v1\/verbs\/([a-z_]+)$/);
     if (req.method === "POST" && verbMatch) {

--- a/graph-gateway/src/verbs.ts
+++ b/graph-gateway/src/verbs.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { DEFAULT_GRAPH, run } from "./graph.js";
+import { DEFAULT_GRAPH, deletedGraphError, run } from "./graph.js";
 import { record } from "./journal.js";
 import { EDGE_TYPES, NODE_TYPES, isEdgeType, isNodeType } from "./schema.js";
 import { embedQuery, embedText, embeddingsEnabled, entityText } from "./embed.js";
@@ -294,6 +294,8 @@ const upsertEntityInput = {
 };
 
 async function upsertEntity(input: z.infer<z.ZodObject<typeof upsertEntityInput>>) {
+  const deleted = await deletedGraphError(input.graph);
+  if (deleted) return { status: "error", error: deleted };
   if (!isNodeType(input.type)) {
     return { status: "error", error: `Unknown node type '${input.type}'. Allowed: ${NODE_TYPES.join(", ")}` };
   }
@@ -398,6 +400,8 @@ const upsertRelationInput = {
 };
 
 async function upsertRelation(input: z.infer<z.ZodObject<typeof upsertRelationInput>>) {
+  const deleted = await deletedGraphError(input.graph);
+  if (deleted) return { status: "error", error: deleted };
   if (!isEdgeType(input.type)) {
     return { status: "error", error: `Unknown edge type '${input.type}'. Allowed: ${EDGE_TYPES.join(", ")}` };
   }
@@ -545,6 +549,8 @@ const mergeEntitiesInput = {
 // indexed). Rewires every edge from `remove` onto `keep`, fills props `keep`
 // lacks, folds the removed id/name into aliases, then deletes `remove`.
 async function mergeEntities(input: z.infer<z.ZodObject<typeof mergeEntitiesInput>>) {
+  const deleted = await deletedGraphError(input.graph);
+  if (deleted) return { status: "error", error: deleted };
   if (input.keep === input.remove) return { status: "error", error: "keep and remove are the same id" };
   const nodes = await run(
     input.graph,

--- a/graph-gateway/test/verbs-batch.test.ts
+++ b/graph-gateway/test/verbs-batch.test.ts
@@ -65,6 +65,7 @@ before(async () => {
       DEFAULT_GRAPH: "memory",
       run: async (g: string, c: string, p: Record<string, any> = {}) => mockRun(g, c, p),
       raw: async () => ({}),
+      deletedGraphError: async () => null,
       close: async () => {},
     },
   });

--- a/graph-gateway/test/verbs-memory.test.ts
+++ b/graph-gateway/test/verbs-memory.test.ts
@@ -52,6 +52,7 @@ before(async () => {
       DEFAULT_GRAPH: "memory",
       run: async (g: string, c: string, p: Record<string, any> = {}) => mockRun(g, c, p),
       raw: async () => ({}),
+      deletedGraphError: async () => null,
       close: async () => {},
     },
   });

--- a/index-workspace/.opencode/agents/graph-builder.md
+++ b/index-workspace/.opencode/agents/graph-builder.md
@@ -33,6 +33,7 @@ Durable human service context, NOT code positions:
 - **Procedure** nodes are human-blessed rules that enter through a separate proposal lane — NEVER create, edit, or delete them (or their `GOVERNS` edges) while indexing. They describe how humans want work done, not what the code does; reindexing cannot verify them.
 - **Note** nodes are Flow-promoted working memory (attributed utterances from sessions) — never create or edit them while indexing either; they enter via the branch-notes promotion pass.
 - Files and line numbers go in `evidence` properties only — never as nodes. Teams refactor constantly; a moved file is not a changed behavior.
+- On Repository nodes, `default_branch`, `head_commit`, and `indexed_at` are orchestrator-managed freshness props stamped after every successful index — never set or edit them yourself; a model-written value would go stale and mislead every later session.
 - Do not model every function, import graphs, or secrets. If code contains hardcoded sensitive values, model only the abstract resource.
 
 Every node needs a `description` a new teammate could learn from, and `aliases` for the names humans actually use ("user service", "billing"). These power retrieval later — they are not optional polish.

--- a/orchestrator/package.json
+++ b/orchestrator/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts",
-    "test": "node --import tsx/esm --test test/fake-opencode.ts test/orchestrator.test.ts test/adapters.test.ts test/outbox-approve.test.ts test/llmlog.test.ts test/smoke.ts test/notify.test.ts test/pollers.test.ts test/poller.test.ts test/settings.test.ts test/sources.test.ts test/agent-diff.test.ts test/worktrees.test.ts test/memory.test.ts",
+    "test": "node --import tsx/esm --test test/fake-opencode.ts test/orchestrator.test.ts test/adapters.test.ts test/outbox-approve.test.ts test/llmlog.test.ts test/smoke.ts test/notify.test.ts test/pollers.test.ts test/poller.test.ts test/settings.test.ts test/sources.test.ts test/agent-diff.test.ts test/worktrees.test.ts test/memory.test.ts test/index-queue.test.ts test/change-branch.test.ts test/repo-removed.test.ts test/index-incremental.test.ts",
     "verify": "npm test",
     "verify:real": "tsx test/real-integrations.ts",
     "verify:session": "tsx test/real-session.ts"

--- a/orchestrator/src/actions/index.ts
+++ b/orchestrator/src/actions/index.ts
@@ -236,7 +236,9 @@ async function handleGithubAuto(event: NormalizedEvent, cls: ClassificationResul
   const repoName = entry?.name ?? p.repo ?? "";
   const job = await enqueueJob({
     type: "index_repo",
-    input: { repo: repoName, url: entry?.url, branch: p.branch ?? entry?.branch, commit: p.commit },
+    // trigger:"push" opts the run into the incremental (diff-only) path when
+    // the last indexed commit is an ancestor of the new HEAD.
+    input: { repo: repoName, url: entry?.url, branch: p.branch ?? entry?.branch, commit: p.commit, trigger: "push" },
     repo: repoName,
   });
   audit(event.id, c, cls.confidence, "index_job", job.id, "ok");

--- a/orchestrator/src/adapters/github.ts
+++ b/orchestrator/src/adapters/github.ts
@@ -50,6 +50,20 @@ export function watchRepo(ownerRepo: string, branch: string): void {
   registeredRepos.set(ownerRepo, branch);
 }
 
+// Stop watching (repo_removed flow). Accepts either the exact "owner/repo"
+// key or a bare repo name — the caller may no longer know the URL because
+// the registry entry was already deleted by the dashboard.
+export function unwatchRepo(ownerRepoOrName: string): boolean {
+  if (registeredRepos.delete(ownerRepoOrName)) return true;
+  for (const key of registeredRepos.keys()) {
+    if (key.endsWith(`/${ownerRepoOrName}`)) {
+      registeredRepos.delete(key);
+      return true;
+    }
+  }
+  return false;
+}
+
 // "owner/repo" from an https or ssh GitHub URL; null for non-GitHub URLs.
 export function ownerRepoFromUrl(url: string): string | null {
   const m = /github\.com[/:]([^/\s]+)\/([^/\s]+?)(?:\.git)?\/?$/.exec(url.trim());

--- a/orchestrator/src/db.ts
+++ b/orchestrator/src/db.ts
@@ -5,7 +5,7 @@ import Database from "better-sqlite3";
 import { mkdirSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { migrate, MEMORY_SCHEMA, MEMORY_TRIGGERS, ANCHORS_SCHEMA } from "./migrations.js";
+import { migrate, MEMORY_SCHEMA, MEMORY_TRIGGERS, ANCHORS_SCHEMA, INDEX_LOG_SCHEMA } from "./migrations.js";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
@@ -271,6 +271,9 @@ db.exec(MEMORY_TRIGGERS);
 // a rebuildable projection. Kept byte-identical to the migration via the shared
 // ANCHORS_SCHEMA string.
 db.exec(ANCHORS_SCHEMA);
+// index_log: indexer lifecycle trail (migration 10). Kept byte-identical to
+// the migration via the shared INDEX_LOG_SCHEMA string.
+db.exec(INDEX_LOG_SCHEMA);
 
 // FTS triggers to keep virtual tables in sync with base tables
 db.exec(`

--- a/orchestrator/src/events.ts
+++ b/orchestrator/src/events.ts
@@ -127,7 +127,27 @@ export async function processEvent(event: NormalizedEvent): Promise<void> {
   // Deterministic dashboard commands skip the classifier entirely.
   if (event.source === "dashboard" && event.type === "reindex_request") {
     const p = event.payload as { repo?: string; branch?: string };
-    const { enqueueJob } = await import("./opencode.js");
+    const { enqueueJob, listWorkspaceRepos, registerSource } = await import("./opencode.js");
+    // Branch change: sync the durable registry and the in-memory push poller
+    // so merges to the new branch trigger reindexes immediately — the poller
+    // map is only re-seeded from repos.json at boot. watchRepo is idempotent,
+    // so re-watching on every reindex also heals a map that went stale when
+    // the dashboard edited repos.json directly.
+    if (p.repo && p.branch) {
+      const entry = listWorkspaceRepos().find((r) => r.name === p.repo);
+      if (entry) {
+        if (entry.branch !== p.branch) {
+          registerSource({ name: p.repo, branch: p.branch });
+          const { indexLog } = await import("./index-log.js");
+          indexLog(p.repo, "watch", undefined, { branch: p.branch, previous: entry.branch });
+        }
+        if (entry.url) {
+          const { watchRepo, ownerRepoFromUrl } = await import("./adapters/github.js");
+          const ownerRepo = ownerRepoFromUrl(entry.url);
+          if (ownerRepo) watchRepo(ownerRepo, p.branch);
+        }
+      }
+    }
     const job = await enqueueJob({
       type: "index_repo",
       input: { repo: p.repo ?? "", branch: p.branch },
@@ -136,6 +156,27 @@ export async function processEvent(event: NormalizedEvent): Promise<void> {
     db.prepare(
       `INSERT INTO audit_log (event_id, classification, confidence, action, target, status) VALUES (?, 'reindex_request', 1.0, 'index_job', ?, 'ok')`
     ).run(event.id, job.id);
+    return;
+  }
+
+  // Disconnecting a repo is a button click too — never classify it. The
+  // dashboard already dropped the registry entry; this cleans up everything
+  // else (poller watch, parked/queued jobs, clone dir, graph node) so a
+  // removed repo doesn't keep being polled, indexed, and served as knowledge.
+  if (event.source === "dashboard" && event.type === "repo_removed") {
+    const p = event.payload as { repoName?: string; repo?: string };
+    const name = (p.repoName ?? p.repo ?? "").trim();
+    if (!name) {
+      db.prepare(
+        `INSERT INTO audit_log (event_id, classification, confidence, action, target, status, detail) VALUES (?, 'repo_removed', 1.0, 'rejected', '-', 'error', ?)`
+      ).run(event.id, JSON.stringify({ error: "missing repoName" }));
+      return;
+    }
+    const { removeRepo } = await import("./opencode.js");
+    const summary = await removeRepo(name);
+    db.prepare(
+      `INSERT INTO audit_log (event_id, classification, confidence, action, target, status, detail) VALUES (?, 'repo_removed', 1.0, 'repo_cleanup', ?, 'ok', ?)`
+    ).run(event.id, name, JSON.stringify(summary));
     return;
   }
 
@@ -151,9 +192,18 @@ export async function processEvent(event: NormalizedEvent): Promise<void> {
       return;
     }
     // Register + watch + queue the index job via the shared connection path
-    // (also used by the sources front door), then audit.
+    // (also used by the sources front door), then audit. A name collision
+    // (two owners, same repo name) is refused, not silently overwritten.
     const { connectGithubRepo } = await import("./opencode.js");
-    const { entry, jobId } = await connectGithubRepo(p.url, p.branch);
+    let entry, jobId;
+    try {
+      ({ entry, jobId } = await connectGithubRepo(p.url, p.branch));
+    } catch (err) {
+      db.prepare(
+        `INSERT INTO audit_log (event_id, classification, confidence, action, target, status, detail) VALUES (?, 'repo_added', 1.0, 'rejected', '-', 'error', ?)`
+      ).run(event.id, JSON.stringify({ error: String(err) }));
+      return;
+    }
     // target = the human-facing repo name (the dashboard shows it verbatim);
     // the job id lives in detail for debugging.
     db.prepare(

--- a/orchestrator/src/index-log.ts
+++ b/orchestrator/src/index-log.ts
@@ -1,0 +1,65 @@
+// index-log.ts — durable, queryable trail of indexer lifecycle events.
+// Every transition (enqueued, parked, superseded, started, done, failed,
+// recovered, watch, removed) lands both on the console (grep for [indexer])
+// and in the index_log table, so a self-deployer can reconstruct what the
+// indexer did — when the last index ran, what got queued behind what, why a
+// job failed — without shell access. Read via GET /v1/index-log.
+
+import { db } from "./db.js";
+
+export type IndexLogEvent =
+  | "enqueued"    // job row created (detail: branch, trigger)
+  | "parked"      // arrived mid-index; waiting for the running job to finish
+  | "superseded"  // parked job replaced by a newer request
+  | "started"     // job began executing (detail: branch, backend)
+  | "done"        // index succeeded (detail: commit, duration_ms)
+  | "failed"      // job failed (detail: error, duration_ms)
+  | "recovered"   // boot-time recovery of a stalled/parked job
+  | "watch"       // poller branch watch added or changed
+  | "removed";    // repo removed; cleanup steps
+
+const insertLog = db.prepare(`
+  INSERT INTO index_log (repo, event, job_id, detail)
+  VALUES (@repo, @event, @job_id, @detail)
+`);
+
+export function indexLog(
+  repo: string,
+  event: IndexLogEvent,
+  jobId?: string,
+  detail?: Record<string, unknown>,
+): void {
+  const detailStr = detail && Object.keys(detail).length > 0 ? JSON.stringify(detail) : null;
+  console.log(
+    `[indexer] ${event} repo=${repo}${jobId ? ` job=${jobId}` : ""}${detailStr ? ` ${detailStr}` : ""}`,
+  );
+  // The trail must never take a job down with it.
+  try {
+    insertLog.run({ repo, event, job_id: jobId ?? null, detail: detailStr });
+  } catch (err) {
+    console.warn(`[indexer] index_log write failed: ${err}`);
+  }
+}
+
+export interface IndexLogRow {
+  id: number;
+  repo: string;
+  event: IndexLogEvent;
+  job_id: string | null;
+  detail: Record<string, unknown> | null;
+  created_at: number;
+}
+
+// Newest first. repo filter optional; limit capped at 500.
+export function readIndexLog(opts: { repo?: string; limit?: number } = {}): IndexLogRow[] {
+  const limit = Math.min(Math.max(opts.limit ?? 100, 1), 500);
+  const rows = opts.repo
+    ? db
+        .prepare(`SELECT * FROM index_log WHERE repo = ? ORDER BY id DESC LIMIT ?`)
+        .all(opts.repo, limit)
+    : db.prepare(`SELECT * FROM index_log ORDER BY id DESC LIMIT ?`).all(limit);
+  return (rows as (Omit<IndexLogRow, "detail"> & { detail: string | null })[]).map((r) => ({
+    ...r,
+    detail: r.detail ? (JSON.parse(r.detail) as Record<string, unknown>) : null,
+  }));
+}

--- a/orchestrator/src/index.ts
+++ b/orchestrator/src/index.ts
@@ -8,8 +8,9 @@ import { registerOutboxRoutes } from "./outbox-routes.js";
 import { registerPolicyRoutes } from "./policy.js";
 import { registerCorpusRoutes } from "./corpus.js";
 import db from "./db.js";
-import { getJob, enqueueJob, recoverStalledJobs } from "./opencode.js";
+import { getJob, enqueueJob, recoverStalledJobs, killRunningJobChildren, repoStatuses, checkDefaultBranchDrift } from "./opencode.js";
 import { activityForRepo } from "./job-activity.js";
+import { readIndexLog } from "./index-log.js";
 import { registerLinearWebhook, registerLinearPoller } from "./adapters/linear.js";
 import { registerGithubWebhook, registerGithubPoller, seedWatchedRepos } from "./adapters/github.js";
 import { registerMeetingRoutes, registerFirefliesPoller } from "./adapters/meetings.js";
@@ -178,6 +179,32 @@ app.get<{ Querystring: { repo?: string } }>(
 );
 
 // ------------------------------------------------------------------
+// Repo status — the per-repo state machine (never_indexed | queued |
+// indexing | indexed | failed) derived from the registry + jobs table.
+// The dashboard's source of truth for "is this repo fresh?".
+// ------------------------------------------------------------------
+app.get("/v1/repos/status", async (_req, reply) => {
+  return reply.send({ repos: repoStatuses() });
+});
+
+// ------------------------------------------------------------------
+// Indexer event log — the durable lifecycle trail (enqueued, parked,
+// superseded, started, done, failed, recovered, watch, removed) so a
+// self-deployer can reconstruct what the indexer did and when. Unlike
+// /v1/index-activity this survives restarts and job completion.
+// ------------------------------------------------------------------
+app.get<{ Querystring: { repo?: string; limit?: string } }>(
+  "/v1/index-log",
+  async (req, reply) => {
+    const rows = readIndexLog({
+      repo: req.query.repo || undefined,
+      limit: req.query.limit ? parseInt(req.query.limit, 10) : undefined,
+    });
+    return reply.send({ rows, count: rows.length });
+  }
+);
+
+// ------------------------------------------------------------------
 // Audit log
 // ------------------------------------------------------------------
 app.get<{ Querystring: { limit?: string } }>(
@@ -211,7 +238,21 @@ app.get<{ Querystring: { status?: string } }>(
 app.addHook("onClose", async () => {
   stopDrainer();
   stopAllPollers();
+  // Kill live indexer CLIs (and their process groups) — an orphaned indexer
+  // surviving a restart would keep writing to the graph while boot recovery
+  // re-queues a duplicate job for the same repo.
+  const killed = killRunningJobChildren();
+  if (killed > 0) console.warn(`[orchestrator] killed ${killed} live job child process(es) on shutdown`);
 });
+
+// Without these handlers a SIGTERM (flow down / flow rm / systemd stop)
+// hard-kills the process and onClose never runs — leaving indexer CLI
+// children orphaned and still writing to the graph.
+for (const sig of ["SIGTERM", "SIGINT"] as const) {
+  process.once(sig, () => {
+    void app.close().finally(() => process.exit(0));
+  });
+}
 
 // ------------------------------------------------------------------
 // Boot
@@ -237,6 +278,14 @@ const start = async (): Promise<void> => {
 
     // Start all registered pollers (no-ops if FLOW_POLL_DISABLE=1)
     startAllPollers();
+
+    // Default-branch drift check: shortly after boot, then daily. Records
+    // drift on the registry entry (never auto-switches); the dashboard shows
+    // "default → <branch>" so a human can decide. Skipped in tests.
+    if (!process.env.FLOW_FAKE_OPENCODE && process.env.FLOW_POLL_DISABLE !== "1") {
+      setTimeout(() => void checkDefaultBranchDrift(), 30_000);
+      setInterval(() => void checkDefaultBranchDrift(), 24 * 60 * 60 * 1000);
+    }
 
     // Boot Slack Socket Mode adapter (no-op if tokens absent)
     bootSlackAdapter().catch((err) =>

--- a/orchestrator/src/migrations.ts
+++ b/orchestrator/src/migrations.ts
@@ -161,7 +161,32 @@ export const MIGRATIONS: Migration[] = [
       db.exec(ANCHORS_SCHEMA);
     },
   },
+  {
+    id: 10,
+    name: "index_log: durable indexer lifecycle trail",
+    up: (db) => {
+      // Keep byte-identical to INDEX_LOG_SCHEMA in db.ts (see migration 8 note).
+      db.exec(INDEX_LOG_SCHEMA);
+    },
+  },
 ];
+
+// Indexer lifecycle trail — one row per transition (enqueued, parked,
+// superseded, started, done, failed, recovered, watch, removed) so
+// self-deployers can reconstruct what the indexer did and why without
+// shell access to the orchestrator log. Rows are append-only; detail is
+// JSON (branch, commit, duration_ms, error, ...). Read via GET /v1/index-log.
+export const INDEX_LOG_SCHEMA = `
+  CREATE TABLE IF NOT EXISTS index_log (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo       TEXT NOT NULL,
+    event      TEXT NOT NULL,
+    job_id     TEXT,
+    detail     TEXT,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch())
+  );
+  CREATE INDEX IF NOT EXISTS idx_index_log_repo ON index_log(repo, id);
+`;
 
 // Anchors: the join between a memory/observation (flow.db PRIMARY) and a graph
 // node (a rebuildable projection). flow.db owns the edge; any graph

--- a/orchestrator/src/opencode.ts
+++ b/orchestrator/src/opencode.ts
@@ -11,7 +11,7 @@
 
 import { spawn, spawnSync } from "node:child_process";
 import { createHmac, randomUUID } from "node:crypto";
-import { existsSync, lstatSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
@@ -29,6 +29,7 @@ import {
   resolveIndexerBackend,
 } from "./indexer-runtime.js";
 import { finishActivity, recordActivityLine, startActivity } from "./job-activity.js";
+import { indexLog } from "./index-log.js";
 import { resolveGithubDefaultBranch } from "./repo-branch.js";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
@@ -57,6 +58,26 @@ const OPENCODE_BIN = ((): string => {
 
 // Per-repo mutex: set of repos currently being indexed
 const runningRepos = new Set<string>();
+
+// Global index wait queue — FIFO across repos, at most one entry per repo.
+// Index jobs are SEQUENTIAL across repos by default (concurrency 1): the
+// whole point of a shared multi-repo graph is cross-repo connections, and a
+// builder can only attach contracts to another repo's entities if that
+// repo's subgraph is complete and stable when it looks. Two builders running
+// at once each see the other's half-written graph, and find-before-create
+// races into duplicate entities. A job that can't run yet (its repo is busy,
+// or all slots are taken) waits here; a newer request for the SAME repo
+// supersedes the waiting one in place (its row is failed) so exactly one
+// job — carrying the latest input — runs per repo. In-memory;
+// recoverStalledJobs re-enqueues waiting rows after a restart.
+const indexWaitQueue: { id: string; opts: JobInput; repo: string }[] = [];
+
+// Deliberate-tradeoff escape hatch: raising this trades cross-repo linking
+// quality for wall-clock speed on big fleets.
+function maxConcurrentIndexes(): number {
+  const v = Number(process.env.FLOW_MAX_CONCURRENT_INDEXES ?? "1");
+  return Number.isFinite(v) && v >= 1 ? Math.floor(v) : 1;
+}
 
 const insertJob = db.prepare(`
   INSERT INTO jobs (id, type, input, status, repo)
@@ -113,6 +134,9 @@ export interface RepoEntry {
   lastIndexedCommit?: string | null;
   lastIndexedAt?: string;
   addedAt?: string;
+  // Set by the drift check when GitHub's default branch no longer matches
+  // `branch` — surfaced in /v1/repos/status so a human can decide to switch.
+  upstreamDefaultBranch?: string;
   // Sources front door. A source plays up to two roles: BRAIN (indexed) and
   // WORK (where coding-agent sessions run). `kind` distinguishes an indexed
   // CODE repo from a DOCS folder; absent = code (back-compat with old rows).
@@ -218,6 +242,235 @@ export function updateRepoIndexCommit(name: string, commit: string): void {
   }
 }
 
+// Full cleanup for a disconnected repo. Idempotent — the dashboard deletes
+// the registry entry itself before posting repo_removed, so every step
+// tolerates already-gone state. Steps: drop the registry entry (no-op if the
+// dashboard got there first), stop the push poller, fail parked/queued index
+// jobs, remove the managed clone (a symlink is unlinked, never followed —
+// the target is the user's own checkout), and drop the repo:<name> node from
+// the graph via the gateway's admin endpoint (best-effort: graph cleanup
+// must not block filesystem cleanup if the gateway is down).
+export async function removeRepo(name: string): Promise<Record<string, unknown>> {
+  const summary: Record<string, unknown> = {};
+
+  const registry = readRepoRegistry();
+  const before = registry.repos.length;
+  registry.repos = registry.repos.filter((r) => r.name !== name);
+  if (registry.repos.length < before) {
+    writeFileSync(reposJsonPath(), JSON.stringify(registry, null, 2));
+    summary.registry = "removed";
+  }
+
+  const { unwatchRepo } = await import("./adapters/github.js");
+  if (unwatchRepo(name)) summary.watch = "removed";
+
+  // Waiting job dies with its repo; queued rows are failed so they never run.
+  const waitingIdx = indexWaitQueue.findIndex((e) => e.repo === name);
+  if (waitingIdx >= 0) {
+    const [waiting] = indexWaitQueue.splice(waitingIdx, 1);
+    updateJob.run({
+      id: waiting.id,
+      status: "failed",
+      result_json: JSON.stringify({ error: "repo_removed" }),
+    });
+    summary.parked_job = waiting.id;
+  }
+  const queued = db
+    .prepare(`SELECT id FROM jobs WHERE status = 'queued' AND type = 'index_repo' AND repo = ?`)
+    .all(name) as { id: string }[];
+  for (const row of queued) {
+    updateJob.run({ id: row.id, status: "failed", result_json: JSON.stringify({ error: "repo_removed" }) });
+  }
+  if (queued.length > 0) summary.queued_jobs_cancelled = queued.length;
+  // A running indexer for a removed repo must not keep writing to the graph.
+  const killed = killJobsForRepo(name);
+  if (killed.length > 0) summary.running_jobs_killed = killed;
+
+  const dest = resolve(WORKSPACE_DIR, "repos", name);
+  let isLink = false;
+  try {
+    isLink = lstatSync(dest).isSymbolicLink(); // lstat: a dangling symlink still counts
+  } catch {
+    /* nothing at dest */
+  }
+  if (isLink) {
+    unlinkSync(dest);
+    summary.checkout = "symlink removed";
+  } else if (existsSync(dest)) {
+    rmSync(dest, { recursive: true, force: true });
+    summary.checkout = "clone removed";
+  }
+
+  try {
+    const gatewayUrl = (process.env.GATEWAY_URL ?? "http://127.0.0.1:7433").replace(/\/+$/, "");
+    const token = process.env.GATEWAY_TOKEN || process.env.FLOW_ADMIN_TOKEN || "";
+    const res = await fetch(`${gatewayUrl}/v1/admin/delete-entity`, {
+      method: "POST",
+      headers: { "content-type": "application/json", ...(token ? { authorization: `Bearer ${token}` } : {}) },
+      body: JSON.stringify({ graph: projectGraphName(), id: `repo:${name}`, actor: "orchestrator:repo_removed" }),
+    });
+    summary.graph_node = ((await res.json()) as { status?: string }).status ?? "unknown";
+  } catch (err) {
+    summary.graph_node = `unreachable: ${String(err).split("\n")[0]}`;
+  }
+
+  indexLog(name, "removed", undefined, summary);
+  return summary;
+}
+
+// ------------------------------------------------------------------
+// Repo state machine — the single answer to "what is the indexer doing
+// with this repo right now, and when did it last succeed?" Derived from
+// the registry (durable truth) + jobs table + in-memory queue, never from
+// model-written graph props.
+// ------------------------------------------------------------------
+
+export interface RepoStatus {
+  name: string;
+  branch: string;
+  status: "never_indexed" | "queued" | "indexing" | "indexed" | "failed";
+  lastIndexedCommit: string | null;
+  lastIndexedAt: string | null;
+  lastError: string | null;
+  runningJobId: string | null;
+  queuedJobId: string | null;
+  upstreamDefaultBranch?: string;
+}
+
+export function repoStatuses(): RepoStatus[] {
+  const lastFailed = db.prepare(
+    `SELECT result_json FROM jobs
+     WHERE type = 'index_repo' AND repo = ? AND status = 'failed'
+     ORDER BY updated_at DESC LIMIT 1`,
+  );
+  const runningJob = db.prepare(
+    `SELECT id FROM jobs WHERE type = 'index_repo' AND repo = ? AND status = 'running' LIMIT 1`,
+  );
+  return readRepoRegistry().repos.map((entry) => {
+    const running = (runningJob.get(entry.name) as { id: string } | undefined)?.id ?? null;
+    const parked = indexWaitQueue.find((e) => e.repo === entry.name)?.id ?? null;
+    const indexed = Boolean(entry.lastIndexedCommit);
+    let lastError: string | null = null;
+    let status: RepoStatus["status"];
+    if (running) status = "indexing";
+    else if (parked) status = "queued";
+    else if (indexed) status = "indexed";
+    else {
+      const failed = lastFailed.get(entry.name) as { result_json: string | null } | undefined;
+      if (failed?.result_json) {
+        lastError = (JSON.parse(failed.result_json) as { error?: string }).error ?? null;
+        status = "failed";
+      } else {
+        status = "never_indexed";
+      }
+    }
+    return {
+      name: entry.name,
+      branch: entry.branch,
+      status,
+      lastIndexedCommit: entry.lastIndexedCommit ?? null,
+      lastIndexedAt: entry.lastIndexedAt ?? null,
+      lastError,
+      runningJobId: running,
+      queuedJobId: parked,
+      ...(entry.upstreamDefaultBranch ? { upstreamDefaultBranch: entry.upstreamDefaultBranch } : {}),
+    };
+  });
+}
+
+// Stamp code-maintained freshness props onto the graph's Repository node
+// after a successful index. These are OWNED by the orchestrator — the
+// graph-builder agent is told not to touch them — so `get_entity repo:<x>`
+// can never show a stale model-invented head_commit again. Best-effort:
+// graph metadata must not fail the job that just succeeded.
+async function stampRepoNode(name: string, branch: string, head: string | null): Promise<void> {
+  try {
+    const gatewayUrl = (process.env.GATEWAY_URL ?? "http://127.0.0.1:7433").replace(/\/+$/, "");
+    const token = process.env.GATEWAY_TOKEN || process.env.FLOW_ADMIN_TOKEN || "";
+    const res = await fetch(`${gatewayUrl}/v1/verbs/upsert_entity`, {
+      method: "POST",
+      headers: { "content-type": "application/json", ...(token ? { authorization: `Bearer ${token}` } : {}) },
+      body: JSON.stringify({
+        graph: projectGraphName(),
+        type: "Repository",
+        id: `repo:${name}`,
+        name,
+        confirm: true,
+        props: {
+          default_branch: branch,
+          ...(head ? { head_commit: head } : {}),
+          indexed_at: new Date().toISOString(),
+        },
+        provenance: { actor: "orchestrator:index_done", evidence: `index_repo job on ${branch}`, confidence: "high" },
+      }),
+    });
+    const body = (await res.json()) as { status?: string; error?: string };
+    if (body.status === "error") console.warn(`[indexer] repo-node stamp failed for ${name}: ${body.error}`);
+  } catch (err) {
+    console.warn(`[indexer] repo-node stamp unreachable for ${name}: ${String(err).split("\n")[0]}`);
+  }
+}
+
+// Default-branch drift: GitHub's default branch can change (main → dev) after
+// a repo is connected, and nothing else would ever notice — the poller keeps
+// watching the registered branch and the graph quietly goes stale against the
+// real default. This check (boot + daily) records the drift on the registry
+// entry so /v1/repos/status and the dashboard can surface "default → dev".
+// It NEVER auto-switches: changing the indexed branch is a human decision.
+export async function checkDefaultBranchDrift(): Promise<void> {
+  const { githubDefaultBranch } = await import("./repo-branch.js");
+  for (const entry of listWorkspaceRepos()) {
+    if (!entry.url || entry.kind === "docs") continue;
+    const upstream = await githubDefaultBranch(entry.url);
+    if (!upstream) continue; // API unreachable — keep whatever we knew
+    const registry = readRepoRegistry();
+    const current = registry.repos.find((r) => r.name === entry.name);
+    if (!current) continue;
+    if (upstream !== current.branch && current.upstreamDefaultBranch !== upstream) {
+      current.upstreamDefaultBranch = upstream;
+      writeFileSync(reposJsonPath(), JSON.stringify(registry, null, 2));
+      indexLog(entry.name, "watch", undefined, {
+        upstream_default: upstream,
+        indexing: current.branch,
+        note: "default branch drift — switch via change_branch if intended",
+      });
+    } else if (upstream === current.branch && current.upstreamDefaultBranch) {
+      delete current.upstreamDefaultBranch;
+      writeFileSync(reposJsonPath(), JSON.stringify(registry, null, 2));
+    }
+  }
+}
+
+// Full-pass vs incremental: after a push, if the last indexed commit is an
+// ancestor of the refreshed HEAD (same branch, no history rewrite) and the
+// diff is modest, the indexer only needs to read what changed. Returns null
+// whenever a full pass is the safe answer: first index, branch changed,
+// rewritten history, local/symlinked checkout, or a diff too big to trust
+// an incremental read. Mirrors index-workspace/scripts/update.mjs, which
+// pioneered this logic but was never wired into the event-driven pipeline.
+const INCREMENTAL_MAX_FILES = 200;
+export function incrementalContext(repo: string, branch: string): { from: string; to: string; stat: string } | null {
+  const entry = readRepoRegistry().repos.find((r) => r.name === repo);
+  const last = entry?.lastIndexedCommit;
+  if (!last || entry?.branch !== branch) return null;
+  const dest = resolve(WORKSPACE_DIR, "repos", repo);
+  if (!existsSync(dest) || lstatSync(dest).isSymbolicLink()) return null;
+  try {
+    const ancestor = spawnSync("git", ["-C", dest, "merge-base", "--is-ancestor", last, "HEAD"], { timeout: 5000 });
+    if (ancestor.status !== 0) return null;
+    const head = spawnSync("git", ["-C", dest, "rev-parse", "HEAD"], { encoding: "utf8", timeout: 5000 }).stdout?.trim();
+    if (!head || head === last) return null;
+    const stat = spawnSync("git", ["-C", dest, "diff", "--stat", `${last}..HEAD`], { encoding: "utf8", timeout: 10_000 }).stdout ?? "";
+    const trimmed = stat.trim();
+    if (!trimmed) return null;
+    const changedFiles = trimmed.split("\n").length - 1; // last line is the summary
+    if (changedFiles < 1 || changedFiles > INCREMENTAL_MAX_FILES) return null;
+    return { from: last, to: head, stat: trimmed };
+  } catch {
+    return null;
+  }
+}
+
 // Resolve the current HEAD of a managed checkout; null if missing/local.
 function repoHeadCommit(name: string): string | null {
   const dest = resolve(WORKSPACE_DIR, "repos", name);
@@ -242,7 +495,18 @@ export async function connectGithubRepo(
   localPath?: string,
 ): Promise<{ entry: RepoEntry; jobId: string }> {
   const name = url.replace(/\/+$/, "").split("/").pop()!.replace(/\.git$/, "");
-  const existingBranch = readRepoRegistry().repos.find((repo) => repo.name === name)?.branch?.trim();
+  const existing = readRepoRegistry().repos.find((repo) => repo.name === name);
+  // The registry is name-keyed and registerRepo updates-by-name, so adding
+  // owner2/web after owner1/web would silently overwrite owner1's entry and
+  // repoint its clone, jobs, and graph evidence. Refuse instead (mirrors
+  // assertNameFree on the sources front door). Re-adding the same URL is a
+  // harmless update.
+  if (existing?.url && existing.url !== url) {
+    throw new Error(
+      `a repo named "${name}" is already connected (${existing.url}) — remove it first or connect this one under a different name`,
+    );
+  }
+  const existingBranch = existing?.branch?.trim();
   const resolvedBranch = branch?.trim() || existingBranch || await resolveGithubDefaultBranch(url);
   const entry = registerRepo(url, resolvedBranch);
   if (localPath) registerSource({ name: entry.name, localPath });
@@ -307,7 +571,7 @@ async function ensureRepoClone(entry: { name: string; url?: string; branch?: str
 // For managed GitHub clones: fetch origin and reset to the registered branch
 // so index_repo runs against current base-branch HEAD. Local/symlinked checkouts
 // (user's own work surface) are never touched.
-async function refreshRepoCheckout(name: string, branch: string): Promise<void> {
+export async function refreshRepoCheckout(name: string, branch: string): Promise<void> {
   const dest = resolve(WORKSPACE_DIR, "repos", name);
   if (!existsSync(dest)) return;
   if (lstatSync(dest).isSymbolicLink()) return; // local tier — user's own checkout
@@ -315,6 +579,11 @@ async function refreshRepoCheckout(name: string, branch: string): Promise<void> 
   const env = token
     ? { ...process.env, GIT_ASKPASS: "echo", GIT_USERNAME: "x-access-token", GIT_PASSWORD: token }
     : process.env;
+  // Clones are made --single-branch, so the fetch refspec only covers the
+  // branch registered at clone time. After a branch change the new branch
+  // must be added to the refspec or `fetch origin <branch>` never creates
+  // refs/remotes/origin/<branch> and the reset below fails forever.
+  await spawnAsync("git", ["-C", dest, "remote", "set-branches", "--add", "origin", branch], env, 10_000);
   const fetch = await spawnAsync("git", ["-C", dest, "fetch", "origin", branch], env, 60_000);
   if (fetch.status !== 0) {
     throw new Error(`git fetch failed for ${name}: ${(fetch.stderr ?? fetch.error?.message ?? "unknown").split("\n")[0]}`);
@@ -334,8 +603,25 @@ export function recoverStalledJobs(): void {
     db.prepare(`UPDATE jobs SET status = 'failed', result_json = ?, updated_at = unixepoch() WHERE id = ?`)
       .run(JSON.stringify({ error: "stalled:process_restart" }), row.id);
   }
-  const reindex = stalled.filter((r) => r.type === "index_repo");
-  for (const row of reindex) {
+  // Parked index jobs died with the process too — the coalescing queue is
+  // in-memory, so their rows sit at 'queued' forever unless recovered here.
+  const parked = db
+    .prepare(`SELECT id, type, input, repo FROM jobs WHERE status = 'queued' AND type = 'index_repo'`)
+    .all() as { id: string; type: string; input: string; repo: string | null }[];
+  for (const row of parked) {
+    db.prepare(`UPDATE jobs SET status = 'failed', result_json = ?, updated_at = unixepoch() WHERE id = ?`)
+      .run(JSON.stringify({ error: "stalled:process_restart" }), row.id);
+  }
+  // One fresh job per repo — a repo with both a stalled-running and a parked
+  // row gets a single reindex (the rerun indexes the checkout's latest HEAD
+  // regardless of which input it carries; prefer the parked row's input since
+  // it is the newer request).
+  const reindexByRepo = new Map<string, { input: string; repo: string | null }>();
+  for (const row of [...stalled.filter((r) => r.type === "index_repo"), ...parked]) {
+    reindexByRepo.set(row.repo ?? row.id, row);
+  }
+  for (const [, row] of reindexByRepo) {
+    if (row.repo) indexLog(row.repo, "recovered", undefined, { reason: "process_restart" });
     void enqueueJob({ type: "index_repo", input: JSON.parse(row.input) as Record<string, unknown>, repo: row.repo ?? undefined });
   }
   // Corrections whose verification job died with the process: mark the row
@@ -356,8 +642,10 @@ export function recoverStalledJobs(): void {
       );
     }
   }
-  if (stalled.length > 0) {
-    console.warn(`[opencode] recovered ${stalled.length} stalled job(s); re-queued ${reindex.length} index job(s)`);
+  if (stalled.length > 0 || parked.length > 0) {
+    console.warn(
+      `[opencode] recovered ${stalled.length} stalled + ${parked.length} parked job(s); re-queued ${reindexByRepo.size} index job(s)`,
+    );
   }
 }
 
@@ -371,6 +659,11 @@ export async function enqueueJob(opts: JobInput): Promise<{ id: string }> {
     input: JSON.stringify(normalizedOpts.input),
     repo: normalizedOpts.repo ?? null,
   });
+  if (normalizedOpts.type === "index_repo" && normalizedOpts.repo) {
+    indexLog(normalizedOpts.repo, "enqueued", id, {
+      branch: (normalizedOpts.input as { branch?: string }).branch,
+    });
+  }
 
   // Execute async — don't await; callers get the job id and can poll
   setImmediate(() => void runJob(id, normalizedOpts));
@@ -429,29 +722,61 @@ export function getJob(id: string): Job | null {
 async function runJob(id: string, opts: JobInput): Promise<void> {
   const repo = opts.repo ?? "";
 
-  // Per-repo mutex for index_repo jobs
+  // Admission for index_repo jobs. A job that can't run yet — its repo is
+  // already indexing, or every concurrency slot is taken (default 1: repos
+  // index one at a time so each builder sees the previous repos' complete
+  // subgraphs and cross-repo links attach instead of duplicating) — waits in
+  // the FIFO queue instead of failing. Per repo only the newest request is
+  // kept: a waiting job carries stale input (old branch, old SHA) once a
+  // newer request exists, so the older row is failed as superseded. Push
+  // events that land during a long index are therefore indexed, not dropped.
   if (opts.type === "index_repo" && repo) {
-    if (runningRepos.has(repo)) {
-      updateJob.run({
-        id,
-        status: "failed",
-        result_json: JSON.stringify({ error: "mutex: repo already indexing" }),
+    const repoBusy = runningRepos.has(repo);
+    if (repoBusy || runningRepos.size >= maxConcurrentIndexes()) {
+      const waitingIdx = indexWaitQueue.findIndex((e) => e.repo === repo);
+      if (waitingIdx >= 0) {
+        const prev = indexWaitQueue[waitingIdx];
+        updateJob.run({
+          id: prev.id,
+          status: "failed",
+          result_json: JSON.stringify({ error: `superseded:${id}` }),
+        });
+        indexLog(repo, "superseded", prev.id, { by: id });
+        // Replace in place — the repo keeps its position in line.
+        indexWaitQueue[waitingIdx] = { id, opts, repo };
+      } else {
+        indexWaitQueue.push({ id, opts, repo });
+      }
+      indexLog(repo, "parked", id, {
+        branch: (opts.input as { branch?: string }).branch,
+        reason: repoBusy ? "repo already indexing" : `waiting for slot (${runningRepos.size}/${maxConcurrentIndexes()} busy)`,
       });
-      return;
+      return; // row stays 'queued'; a finishing job kicks it off
     }
     runningRepos.add(repo);
   }
 
   updateJob.run({ id, status: "running", result_json: null });
+  const startedAt = Date.now();
+  if (opts.type === "index_repo" && repo) {
+    indexLog(repo, "started", id, { branch: (opts.input as { branch?: string }).branch });
+  }
 
   try {
     // Index jobs need the checkout on disk before the agent can read it.
     if (opts.type === "index_repo" && !process.env.FLOW_FAKE_OPENCODE) {
-      const input = opts.input as { repo?: string; url?: string; branch?: string };
+      const input = opts.input as { repo?: string; url?: string; branch?: string; trigger?: string };
       if (input.repo) {
         const branch = requiredIndexBranch(input);
         await ensureRepoClone({ name: input.repo, url: input.url, branch });
         await refreshRepoCheckout(input.repo, branch);
+        // Push-triggered runs read only the diff when it's safe to; manual
+        // reindexes and first indexes always do the full pass (a human asking
+        // for a reindex means "re-derive it, don't trust the last run").
+        if (input.trigger === "push") {
+          const inc = incrementalContext(input.repo, branch);
+          if (inc) (opts.input as Record<string, unknown>).incremental = inc;
+        }
       }
     }
 
@@ -477,6 +802,15 @@ async function runJob(id: string, opts: JobInput): Promise<void> {
     if (opts.type === "index_repo" && repo) {
       const head = repoHeadCommit(repo);
       if (head) updateRepoIndexCommit(repo, head);
+      const inc = (opts.input as { incremental?: { from: string } }).incremental;
+      indexLog(repo, "done", id, {
+        ...(head ? { commit: head } : {}),
+        mode: inc ? `incremental from ${inc.from.slice(0, 10)}` : "full",
+        duration_ms: Date.now() - startedAt,
+      });
+      // Graph freshness props are code-maintained, not model-invented.
+      const branch = (opts.input as { branch?: string }).branch;
+      if (branch && !process.env.FLOW_FAKE_OPENCODE) void stampRepoNode(repo, branch, head);
     }
 
     // Base branch reindexed → the entities notes anchor to now exist: run the
@@ -542,6 +876,9 @@ async function runJob(id: string, opts: JobInput): Promise<void> {
       result_json: JSON.stringify({ error: String(err) }),
     });
     finishActivity(id, "failed");
+    if (opts.type === "index_repo" && repo) {
+      indexLog(repo, "failed", id, { error: String(err), duration_ms: Date.now() - startedAt });
+    }
     if (opts.type === "correct_graph") {
       const correctionId = (opts.input as { correction_id?: string }).correction_id;
       if (correctionId) {
@@ -552,6 +889,16 @@ async function runJob(id: string, opts: JobInput): Promise<void> {
   } finally {
     if (opts.type === "index_repo" && repo) {
       runningRepos.delete(repo);
+      // Release-then-run: hand the freed slot to the first waiting job whose
+      // repo isn't running (FIFO — with concurrency 1 that's simply the head
+      // of the line).
+      if (runningRepos.size < maxConcurrentIndexes()) {
+        const nextIdx = indexWaitQueue.findIndex((e) => !runningRepos.has(e.repo));
+        if (nextIdx >= 0) {
+          const [next] = indexWaitQueue.splice(nextIdx, 1);
+          setImmediate(() => void runJob(next.id, next.opts));
+        }
+      }
     }
   }
 }
@@ -568,11 +915,27 @@ interface BuiltPrompt {
 
 function buildPrompt(opts: JobInput): BuiltPrompt {
   switch (opts.type) {
-    case "index_repo":
+    case "index_repo": {
+      // Push-triggered runs with a known last-indexed ancestor read only the
+      // diff (see incrementalContext); everything else is a full pass.
+      const inc = (opts.input as { incremental?: { from: string; to: string; stat: string } }).incremental;
+      if (inc) {
+        return {
+          agent: "graph-builder",
+          prompt: `The repository repos/${opts.input.repo ?? "."} (branch ${requiredIndexBranch(opts.input)}) was updated from ${inc.from} to ${inc.to}. Changed files:
+
+${inc.stat}
+
+Read the actual diff with git (cd repos/${opts.input.repo ?? "."} && git diff ${inc.from}..${inc.to} -- <paths>) for anything that looks behavioral. Decide what changed in *behavior* terms — new/changed/removed capabilities, endpoints, resources, or usage-contract conditions. Refactors that move code without changing behavior need no graph writes.
+
+Update the knowledge graph accordingly: enrich or correct existing entities, update contracts whose uses/sensitive_to conditions changed, add new entities for genuinely new behavior, and update evidence on anything you re-verified. Finish with a short summary of what changed in the graph and why, or state that no durable behavior changed.`,
+        };
+      }
       return {
         agent: "graph-builder",
         prompt: `Index the repository at repos/${opts.input.repo ?? "."} (branch ${requiredIndexBranch(opts.input)}) into the knowledge graph. The graph may already contain entities from other repositories — check what exists before creating (graph_find_entity), reuse and enrich existing entities, and pay special attention to cross-repo dependencies. Write incrementally as you learn, per your instructions. Finish with a summary of what you modeled and any open questions.`,
       };
+    }
     case "enrich":
       return {
         agent: "graph-builder",
@@ -640,13 +1003,69 @@ export function jobScopedToken(jobId: string): string {
 // Async spawn: collect stdout/stderr without blocking the event loop (P0-C —
 // spawnSync froze the server for the whole job). Kills on timeout.
 interface SpawnResult { status: number | null; stdout: string; stderr: string; error?: Error }
-function spawnAsync(cmd: string, args: string[], env: NodeJS.ProcessEnv, timeoutMs: number, cwd?: string, onLine?: (line: string) => void): Promise<SpawnResult> {
+// Live CLI children by job id. Orchestrator shutdown kills these (and their
+// process groups — the MCP gateway subprocess a claude/codex indexer spawns
+// dies with its parent) so a restart can never leave an orphaned indexer
+// writing to the graph while the recovery pass re-queues a duplicate job.
+const jobChildren = new Map<string, ReturnType<typeof spawn>>();
+
+// SIGKILL the whole process group when the child is a group leader (job
+// spawns are detached); fall back to killing just the child.
+function killTree(child: ReturnType<typeof spawn>, signal: NodeJS.Signals = "SIGKILL"): void {
+  if (!child.pid) return;
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try { child.kill(signal); } catch { /* already gone */ }
+  }
+}
+
+// Kill every live job child (shutdown path). Best-effort and synchronous —
+// the process is about to exit.
+export function killRunningJobChildren(): number {
+  let killed = 0;
+  for (const [jobId, child] of jobChildren) {
+    killTree(child);
+    jobChildren.delete(jobId);
+    killed++;
+  }
+  return killed;
+}
+
+// Kill the running index job's child for one repo (repo_removed path).
+// Returns the killed job ids; their rows are failed by runJob's catch when
+// the CLI dies.
+export function killJobsForRepo(repo: string): string[] {
+  const rows = db
+    .prepare(`SELECT id FROM jobs WHERE status = 'running' AND type = 'index_repo' AND repo = ?`)
+    .all(repo) as { id: string }[];
+  const killed: string[] = [];
+  for (const row of rows) {
+    const child = jobChildren.get(row.id);
+    if (child) {
+      killTree(child);
+      jobChildren.delete(row.id);
+      killed.push(row.id);
+    }
+  }
+  return killed;
+}
+
+function spawnAsync(cmd: string, args: string[], env: NodeJS.ProcessEnv, timeoutMs: number, cwd?: string, onLine?: (line: string) => void, jobId?: string): Promise<SpawnResult> {
   return new Promise((resolve) => {
     // stdin MUST be 'ignore': with the default 'pipe', opencode sees an open
     // stdin and waits on it forever, producing zero output (the runs hang at
     // startup). This is why orchestrator-spawned jobs hung while manual
     // `nohup opencode … </dev/null` runs worked.
-    const child = spawn(cmd, args, { env, stdio: ["ignore", "pipe", "pipe"], ...(cwd ? { cwd } : {}) });
+    // Job spawns (jobId set) are detached into their own process group so a
+    // kill reaches the CLI's own children (MCP subprocess, git, etc.).
+    const child = spawn(cmd, args, {
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+      ...(cwd ? { cwd } : {}),
+      ...(jobId ? { detached: true } : {}),
+    });
+    if (jobId) jobChildren.set(jobId, child);
     let stdout = "";
     let stderr = "";
     let settled = false;
@@ -663,13 +1082,16 @@ function spawnAsync(cmd: string, args: string[], env: NodeJS.ProcessEnv, timeout
         try { onLine(line); } catch { /* feed is best-effort */ }
       }
     };
+    const cleanup = () => {
+      if (jobId) jobChildren.delete(jobId);
+    };
     const timer = setTimeout(() => {
-      if (!settled) { settled = true; child.kill("SIGKILL"); resolve({ status: null, stdout, stderr, error: new Error(`opencode timed out after ${timeoutMs}ms`) }); }
+      if (!settled) { settled = true; killTree(child); cleanup(); resolve({ status: null, stdout, stderr, error: new Error(`opencode timed out after ${timeoutMs}ms`) }); }
     }, timeoutMs);
     child.stdout.on("data", (d: Buffer) => { const s = d.toString(); stdout += s; feedLines(s); });
     child.stderr.on("data", (d: Buffer) => (stderr += d.toString()));
-    child.on("error", (error) => { if (!settled) { settled = true; clearTimeout(timer); resolve({ status: null, stdout, stderr, error }); } });
-    child.on("close", (status) => { if (!settled) { settled = true; clearTimeout(timer); resolve({ status, stdout, stderr }); } });
+    child.on("error", (error) => { if (!settled) { settled = true; clearTimeout(timer); cleanup(); resolve({ status: null, stdout, stderr, error }); } });
+    child.on("close", (status) => { if (!settled) { settled = true; clearTimeout(timer); cleanup(); resolve({ status, stdout, stderr }); } });
   });
 }
 
@@ -793,7 +1215,7 @@ async function runOpencodeBackend(opts: JobInput, jobId: string): Promise<{ resu
   startActivity(jobId, opts.repo ?? "", "opencode");
   const t0 = Date.now();
   const spawned = await spawnAsync(OPENCODE_BIN, args, env, timeoutMs, undefined, (line) =>
-    recordActivityLine(jobId, "opencode", line)
+    recordActivityLine(jobId, "opencode", line), jobId
   );
   const latencyMs = Date.now() - t0;
 
@@ -899,7 +1321,7 @@ async function runClaudeBackend(opts: JobInput, jobId: string): Promise<{ result
   startActivity(jobId, opts.repo ?? "", "claude");
   const t0 = Date.now();
   const spawned = await spawnAsync(executable, args, env, timeoutMs, WORKSPACE_DIR, (line) =>
-    recordActivityLine(jobId, "claude", line)
+    recordActivityLine(jobId, "claude", line), jobId
   );
   const latencyMs = Date.now() - t0;
 
@@ -995,7 +1417,7 @@ async function runCodexBackend(opts: JobInput, jobId: string): Promise<{ result:
   startActivity(jobId, opts.repo ?? "", "codex");
   const t0 = Date.now();
   const spawned = await spawnAsync(executable, args, env, timeoutMs, WORKSPACE_DIR, (line) =>
-    recordActivityLine(jobId, "codex", line)
+    recordActivityLine(jobId, "codex", line), jobId
   );
   const latencyMs = Date.now() - t0;
 

--- a/orchestrator/src/repo-branch.ts
+++ b/orchestrator/src/repo-branch.ts
@@ -4,8 +4,15 @@
 import { getSetting } from "./settings.js";
 
 export async function resolveGithubDefaultBranch(url: string): Promise<string> {
+  return (await githubDefaultBranch(url)) ?? "main";
+}
+
+// Strict variant: null when the branch genuinely can't be resolved (non-GitHub
+// URL, API error). The drift check needs this — a "main" fallback would flag
+// false drift on every non-main repo whenever the API hiccups.
+export async function githubDefaultBranch(url: string): Promise<string | null> {
   const match = /github\.com[/:]([^/\s]+)\/([^/\s]+?)(?:\.git)?\/?$/i.exec(url.trim());
-  if (!match) return "main";
+  if (!match) return null;
 
   const [, owner, name] = match;
   try {
@@ -18,10 +25,10 @@ export async function resolveGithubDefaultBranch(url: string): Promise<string> {
       },
       signal: AbortSignal.timeout(6000),
     });
-    if (!res.ok) return "main";
+    if (!res.ok) return null;
     const body = (await res.json()) as { default_branch?: string };
-    return body.default_branch?.trim() || "main";
+    return body.default_branch?.trim() || null;
   } catch {
-    return "main";
+    return null;
   }
 }

--- a/orchestrator/test/change-branch.test.ts
+++ b/orchestrator/test/change-branch.test.ts
@@ -1,0 +1,66 @@
+// change-branch.test.ts — a single-branch managed clone must survive the
+// registered branch changing (main → dev): refreshRepoCheckout adds the new
+// branch to the fetch refspec before fetching, so the reset to
+// origin/<new-branch> resolves. Without the set-branches fix the fetch never
+// creates the remote-tracking ref and every reindex after a branch change
+// fails until the clone dir is deleted by hand.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execSync } from "node:child_process";
+
+// Setup: workspace + in-memory DB before any imports that touch db
+const workspace = mkdtempSync(join(tmpdir(), "flow-change-branch-"));
+process.env.OPENCODE_WORKSPACE_DIR = workspace;
+process.env.DB_PATH = ":memory:";
+process.env.FLOW_ADMIN_TOKEN = "test-token-change-branch";
+process.env.FLOW_FAKE_OPENCODE = "1";
+process.env.FLOW_DRAIN_DISABLE = "1";
+
+import { test, describe, before, after } from "node:test";
+import assert from "node:assert/strict";
+
+function sh(cmd: string, cwd: string): string {
+  return execSync(cmd, { cwd, encoding: "utf8", env: { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null" } }).trim();
+}
+
+describe("change_branch survives single-branch clones", () => {
+  let origin: string;
+  let refreshRepoCheckout: (name: string, branch: string) => Promise<void>;
+
+  before(async () => {
+    ({ refreshRepoCheckout } = await import("../src/opencode.js"));
+
+    // Origin with two branches: main and dev (dev one commit ahead).
+    origin = join(workspace, "origin.git");
+    const seed = join(workspace, "seed");
+    execSync(`git init -q -b main ${seed}`, { env: { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null" } });
+    sh(`git config user.email t@t && git config user.name t`, seed);
+    writeFileSync(join(seed, "a.txt"), "one\n");
+    sh(`git add . && git commit -qm one`, seed);
+    sh(`git checkout -qb dev`, seed);
+    writeFileSync(join(seed, "b.txt"), "two\n");
+    sh(`git add . && git commit -qm two`, seed);
+    sh(`git checkout -q main`, seed);
+    execSync(`git clone -q --bare ${seed} ${origin}`, { env: { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null" } });
+
+    // Managed clone the way ensureRepoClone makes it: single-branch on main.
+    execSync(`git clone -q --single-branch --branch main ${origin} ${join(workspace, "repos", "sb-repo")}`, {
+      env: { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null" },
+    });
+  });
+
+  after(() => rmSync(workspace, { recursive: true, force: true }));
+
+  test("refresh onto a branch outside the original refspec succeeds", async () => {
+    const clone = join(workspace, "repos", "sb-repo");
+    // Sanity: the clone is genuinely single-branch — origin/dev is unknown.
+    assert.throws(() => sh(`git rev-parse origin/dev`, clone));
+
+    await refreshRepoCheckout("sb-repo", "dev");
+
+    // The checkout now sits on origin/dev's tip (the "two" commit).
+    assert.equal(sh(`git log -1 --format=%s`, clone), "two");
+  });
+});

--- a/orchestrator/test/fake-opencode.ts
+++ b/orchestrator/test/fake-opencode.ts
@@ -50,7 +50,13 @@ export async function run(
       };
     }
 
-    case "index_repo":
+    case "index_repo": {
+      // simulate_delay_ms: hold the job open so tests can observe the per-repo
+      // coalescing queue (parked/superseded jobs) while this one "runs".
+      const delayMs = opts.input.simulate_delay_ms as number | undefined;
+      if (delayMs && delayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
       return {
         result: {
           status: "ok",
@@ -61,6 +67,7 @@ export async function run(
         },
         sessionId,
       };
+    }
 
     case "enrich":
       return {

--- a/orchestrator/test/index-incremental.test.ts
+++ b/orchestrator/test/index-incremental.test.ts
@@ -1,0 +1,81 @@
+// index-incremental.test.ts — full-pass vs incremental decision for
+// push-triggered index runs. Incremental only when the last indexed commit
+// is a real ancestor of HEAD on the same registered branch; anything
+// surprising (first index, branch change, up-to-date) falls back to null =
+// full pass.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execSync } from "node:child_process";
+
+// Setup: workspace + in-memory DB before any imports that touch db
+const workspace = mkdtempSync(join(tmpdir(), "flow-incremental-"));
+process.env.OPENCODE_WORKSPACE_DIR = workspace;
+process.env.DB_PATH = ":memory:";
+process.env.FLOW_ADMIN_TOKEN = "test-token-incremental";
+process.env.FLOW_FAKE_OPENCODE = "1";
+process.env.FLOW_DRAIN_DISABLE = "1";
+
+import { test, describe, before, after } from "node:test";
+import assert from "node:assert/strict";
+
+const gitEnv = { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null" };
+function sh(cmd: string, cwd: string): string {
+  return execSync(cmd, { cwd, encoding: "utf8", env: gitEnv }).trim();
+}
+
+let incrementalContext: (repo: string, branch: string) => { from: string; to: string; stat: string } | null;
+let c1 = "";
+let c2 = "";
+
+before(async () => {
+  const repoDir = join(workspace, "repos", "inc-repo");
+  execSync(`git init -q -b main ${repoDir}`, { env: gitEnv });
+  sh(`git config user.email t@t && git config user.name t`, repoDir);
+  writeFileSync(join(repoDir, "a.txt"), "one\n");
+  sh(`git add . && git commit -qm one`, repoDir);
+  c1 = sh(`git rev-parse HEAD`, repoDir);
+  writeFileSync(join(repoDir, "b.txt"), "two\n");
+  sh(`git add . && git commit -qm two`, repoDir);
+  c2 = sh(`git rev-parse HEAD`, repoDir);
+
+  writeFileSync(
+    join(workspace, "repos.json"),
+    JSON.stringify({ repos: [{ name: "inc-repo", url: "x", branch: "main", lastIndexedCommit: c1 }] }),
+  );
+
+  ({ incrementalContext } = await import("../src/opencode.js"));
+});
+
+after(() => rmSync(workspace, { recursive: true, force: true }));
+
+describe("incremental index decision", () => {
+  test("ancestor on the same branch → diff context", () => {
+    const inc = incrementalContext("inc-repo", "main");
+    assert.ok(inc);
+    assert.equal(inc.from, c1);
+    assert.equal(inc.to, c2);
+    assert.match(inc.stat, /b\.txt/);
+  });
+
+  test("branch mismatch → full pass", () => {
+    assert.equal(incrementalContext("inc-repo", "dev"), null);
+  });
+
+  test("unknown repo → full pass", () => {
+    assert.equal(incrementalContext("nope", "main"), null);
+  });
+
+  test("already at HEAD → no incremental run", () => {
+    const registry = { repos: [{ name: "inc-repo", url: "x", branch: "main", lastIndexedCommit: c2 }] };
+    writeFileSync(join(workspace, "repos.json"), JSON.stringify(registry));
+    assert.equal(incrementalContext("inc-repo", "main"), null);
+  });
+
+  test("non-ancestor last commit (rewritten history) → full pass", () => {
+    const registry = { repos: [{ name: "inc-repo", url: "x", branch: "main", lastIndexedCommit: "0".repeat(40) }] };
+    writeFileSync(join(workspace, "repos.json"), JSON.stringify(registry));
+    assert.equal(incrementalContext("inc-repo", "main"), null);
+  });
+});

--- a/orchestrator/test/index-queue.test.ts
+++ b/orchestrator/test/index-queue.test.ts
@@ -1,0 +1,130 @@
+// index-queue.test.ts — per-repo coalescing queue for index_repo jobs:
+// a job arriving mid-index parks instead of failing, the newest parked
+// request supersedes the older one, the parked job runs when the running
+// one releases, and every transition lands in the index_log trail.
+
+// Setup: in-memory DB before any imports that touch db
+process.env.DB_PATH = ":memory:";
+process.env.FLOW_ADMIN_TOKEN = "test-token-queue";
+process.env.FLOW_FAKE_OPENCODE = "1";
+process.env.FLOW_DRAIN_DISABLE = "1";
+
+import { test, describe, before } from "node:test";
+import assert from "node:assert/strict";
+import type { Job } from "../src/opencode.js";
+
+let enqueueJob: (opts: {
+  type: "index_repo";
+  input: Record<string, unknown>;
+  repo?: string;
+}) => Promise<{ id: string }>;
+let getJob: (id: string) => Job | null;
+let readIndexLog: (opts?: { repo?: string; limit?: number }) => {
+  repo: string;
+  event: string;
+  job_id: string | null;
+  detail: Record<string, unknown> | null;
+}[];
+
+before(async () => {
+  const opencode = await import("../src/opencode.js");
+  enqueueJob = opencode.enqueueJob;
+  getJob = opencode.getJob;
+  ({ readIndexLog } = await import("../src/index-log.js"));
+});
+
+async function waitFor(cond: () => boolean, ms = 5000): Promise<void> {
+  const deadline = Date.now() + ms;
+  while (!cond()) {
+    if (Date.now() > deadline) throw new Error("waitFor: condition not met in time");
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+describe("per-repo index queue", () => {
+  test("mid-index job parks and runs after; newest parked request wins", async () => {
+    const a = await enqueueJob({
+      type: "index_repo",
+      input: { repo: "queue-r1", branch: "main", url: "x", simulate_delay_ms: 400 },
+    });
+    await waitFor(() => getJob(a.id)?.status === "running");
+
+    // Both arrive mid-index: b parks, then c supersedes b.
+    const b = await enqueueJob({
+      type: "index_repo",
+      input: { repo: "queue-r1", branch: "main", url: "x" },
+    });
+    const c = await enqueueJob({
+      type: "index_repo",
+      input: { repo: "queue-r1", branch: "dev", url: "x" },
+    });
+
+    await waitFor(() => getJob(b.id)?.status === "failed");
+    const bErr = JSON.parse(getJob(b.id)!.result_json!) as { error: string };
+    assert.equal(bErr.error, `superseded:${c.id}`);
+
+    await waitFor(() => getJob(a.id)?.status === "done");
+    await waitFor(() => getJob(c.id)?.status === "done");
+
+    // c ran with its own (newest) input — the dev-branch request survived.
+    assert.equal(getJob(c.id)!.input.branch, "dev");
+
+    // The trail tells the whole story, oldest → newest.
+    const events = readIndexLog({ repo: "queue-r1" })
+      .reverse()
+      .map((r) => r.event);
+    // b and c are both enqueued before either setImmediate fires, so the
+    // park/supersede pair lands after both enqueued rows.
+    assert.deepEqual(events, [
+      "enqueued", // a
+      "started",  // a
+      "enqueued", // b
+      "enqueued", // c
+      "parked",   // b
+      "superseded", // b by c
+      "parked",   // c
+      "done",     // a
+      "started",  // c
+      "done",     // c
+    ]);
+  });
+
+  test("cross-repo index jobs run one at a time — graph coherence default", async () => {
+    const first = await enqueueJob({
+      type: "index_repo",
+      input: { repo: "queue-r2", branch: "main", url: "x", simulate_delay_ms: 300 },
+    });
+    const second = await enqueueJob({
+      type: "index_repo",
+      input: { repo: "queue-r3", branch: "main", url: "x" },
+    });
+
+    await waitFor(() => getJob(first.id)?.status === "running");
+    // r3 waits for the slot: a builder must see r2's COMPLETE subgraph to
+    // attach cross-repo links instead of racing into duplicates.
+    assert.equal(getJob(second.id)?.status, "queued");
+    await waitFor(() => getJob(first.id)?.status === "done");
+    await waitFor(() => getJob(second.id)?.status === "done");
+  });
+
+  test("FLOW_MAX_CONCURRENT_INDEXES>1 opts into parallel repos", async () => {
+    process.env.FLOW_MAX_CONCURRENT_INDEXES = "2";
+    try {
+      const slow = await enqueueJob({
+        type: "index_repo",
+        input: { repo: "queue-r4", branch: "main", url: "x", simulate_delay_ms: 300 },
+      });
+      const fast = await enqueueJob({
+        type: "index_repo",
+        input: { repo: "queue-r5", branch: "main", url: "x" },
+      });
+
+      await waitFor(() => getJob(fast.id)?.status === "done");
+      // r5 finished while r4 is still running — two slots, two repos.
+      assert.equal(getJob(slow.id)?.status, "running");
+      await waitFor(() => getJob(slow.id)?.status === "done");
+    } finally {
+      delete process.env.FLOW_MAX_CONCURRENT_INDEXES;
+    }
+  });
+});

--- a/orchestrator/test/repo-removed.test.ts
+++ b/orchestrator/test/repo-removed.test.ts
@@ -1,0 +1,91 @@
+// repo-removed.test.ts — removing a repo actually disconnects it: registry
+// entry dropped, poller watch removed, parked/queued index jobs cancelled,
+// managed clone deleted. Also: adding owner2/web while owner1/web holds the
+// name is refused instead of silently overwriting the registry entry.
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Setup: workspace + in-memory DB before any imports that touch db
+const workspace = mkdtempSync(join(tmpdir(), "flow-repo-removed-"));
+process.env.OPENCODE_WORKSPACE_DIR = workspace;
+process.env.DB_PATH = ":memory:";
+process.env.FLOW_ADMIN_TOKEN = "test-token-repo-removed";
+process.env.FLOW_FAKE_OPENCODE = "1";
+process.env.FLOW_DRAIN_DISABLE = "1";
+
+import { test, describe, before, after } from "node:test";
+import assert from "node:assert/strict";
+import type { Job } from "../src/opencode.js";
+
+let enqueueJob: (opts: { type: "index_repo"; input: Record<string, unknown>; repo?: string }) => Promise<{ id: string }>;
+let getJob: (id: string) => Job | null;
+let removeRepo: (name: string) => Promise<Record<string, unknown>>;
+let connectGithubRepo: (url: string, branch?: string) => Promise<unknown>;
+let listWorkspaceRepos: () => { name: string }[];
+let watchRepo: (ownerRepo: string, branch: string) => void;
+let registeredRepos: Map<string, string>;
+
+before(async () => {
+  writeFileSync(
+    join(workspace, "repos.json"),
+    JSON.stringify({ repos: [{ name: "web", url: "https://github.com/owner1/web", branch: "main" }] }),
+  );
+  mkdirSync(join(workspace, "repos", "web"), { recursive: true });
+  writeFileSync(join(workspace, "repos", "web", "README.md"), "clone contents\n");
+
+  const opencode = await import("../src/opencode.js");
+  ({ enqueueJob, getJob, removeRepo, connectGithubRepo, listWorkspaceRepos } = opencode);
+  ({ watchRepo, registeredRepos } = await import("../src/adapters/github.js"));
+});
+
+after(() => rmSync(workspace, { recursive: true, force: true }));
+
+async function waitFor(cond: () => boolean, ms = 5000): Promise<void> {
+  const deadline = Date.now() + ms;
+  while (!cond()) {
+    if (Date.now() > deadline) throw new Error("waitFor: condition not met in time");
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+describe("repo lifecycle: collision guard + removal cleanup", () => {
+  test("connecting a same-named repo from another owner is refused", async () => {
+    await assert.rejects(
+      () => connectGithubRepo("https://github.com/owner2/web", "main"),
+      /already connected/,
+    );
+    // owner1's entry survived untouched.
+    assert.equal(listWorkspaceRepos().length, 1);
+  });
+
+  test("removeRepo cleans registry, watch, parked jobs, and clone", async () => {
+    watchRepo("owner1/web", "main");
+
+    const running = await enqueueJob({
+      type: "index_repo",
+      input: { repo: "web", branch: "main", url: "https://github.com/owner1/web", simulate_delay_ms: 300 },
+    });
+    await waitFor(() => getJob(running.id)?.status === "running");
+    const parked = await enqueueJob({
+      type: "index_repo",
+      input: { repo: "web", branch: "main", url: "https://github.com/owner1/web" },
+    });
+    await waitFor(() => getJob(parked.id)?.status === "queued");
+
+    const summary = await removeRepo("web");
+
+    assert.equal(getJob(parked.id)?.status, "failed");
+    assert.equal((JSON.parse(getJob(parked.id)!.result_json!) as { error: string }).error, "repo_removed");
+    assert.equal(existsSync(join(workspace, "repos", "web")), false);
+    assert.equal(listWorkspaceRepos().length, 0);
+    assert.equal(registeredRepos.has("owner1/web"), false);
+    assert.equal(summary.registry, "removed");
+    assert.equal(summary.checkout, "clone removed");
+
+    // The running job finishes without resurrecting anything.
+    await waitFor(() => getJob(running.id)?.status === "done");
+    assert.equal(listWorkspaceRepos().length, 0);
+  });
+});


### PR DESCRIPTION
## Why

Repo lifecycle operations — adding/removing repos, changing the default branch, pushes landing mid-index, orchestrator restarts, project deletion — could each leave the indexer in a silently wrong state: dropped reindexes, orphaned clones and pollers, stale model-written graph metadata, half-dead indexer children writing to deleted graphs. This PR makes every lifecycle transition explicit, observable, and recoverable. (Born from the main→dev default-branch switch surfacing stale `repo:flow` graph props.)

## What

### Sequential cross-repo index queue (correctness, not just throughput)
Index jobs across repos run **one at a time by default**: each graph-builder sees the complete, stable subgraphs of previously indexed repos, so cross-repo usage contracts attach to existing entities instead of find-before-create racing into duplicates. `FLOW_MAX_CONCURRENT_INDEXES=N` opts into parallelism as an explicit tradeoff. Per-repo coalescing on top: a request arriving while its repo is busy parks (newest wins, superseded row failed as `superseded:<id>`) and runs on release — **pushes during a long index are indexed, never dropped** (previously failed with `mutex: repo already indexing` while the poller cursor advanced past them).

### Lifecycle operations that actually complete
- **change_branch**: single-branch clones get the new branch added to the fetch refspec (previously every reindex after a branch change failed until the clone was hand-deleted); the push poller re-watches the new branch immediately instead of after a restart.
- **repo_removed**: now a deterministic handler — previously the event fell through to the LLM classifier and nothing was cleaned. Cleans registry, poller watch, waiting/queued jobs, the running CLI child, the clone/symlink, and the `repo:<name>` graph node via a new **admin-only gateway endpoint** (deliberately not an MCP verb).
- **Name collisions refused**: connecting `owner2/web` while `owner1/web` holds the name errors instead of silently overwriting the registry entry.

### Process + graph hygiene
- Indexer CLIs spawn as tracked, detached **process groups**; killed on SIGTERM/SIGINT (signal handlers added — `onClose` never ran before), on repo removal, and on timeout. No more orphaned indexers surviving a restart while boot recovery queues a duplicate.
- `flow rm` **tombstones** the deleted graph (`flow:graph-deleted:<graph>`) and deletes the embed-stamp key; gateway write verbs refuse tombstoned graphs (FalkorDB auto-creates on first query, so a surviving writer used to resurrect deleted graphs as orphans); `flow up` clears the tombstone.

### State you can trust
- `GET /v1/repos/status`: per-repo state machine (`never_indexed | queued | indexing | indexed | failed`) derived from registry + jobs table. Dashboard polls it instead of guessing from `!lastIndexedCommit`.
- After every successful index the **orchestrator** stamps `default_branch` / `head_commit` / `indexed_at` onto the graph Repository node; graph-builder instructions now forbid the model from writing these (the stale-props bug that started all this).
- **Durable index_log** (migration 10): every transition — enqueued, parked (with reason), superseded, started, done (commit, duration, full/incremental), failed (error), recovered, watch changes, removal — at `GET /v1/index-log?repo=` and a per-repo history panel in the dashboard (≡ on each source row). Console mirror with `[indexer]` prefix for self-deployers.

### Tasteful reindexing
- Push-triggered runs use **incremental diff-only prompts** when the last indexed commit is an ancestor of HEAD on the same branch (≤200 changed files) — the logic existed in `index-workspace/scripts/update.mjs` but was never wired into the event pipeline. Manual reindexes stay full-pass on purpose.
- Daily **default-branch drift check** (strict resolver, null on API error — no false positives): surfaces `default → <branch>` in status + dashboard, never auto-switches.

### Misc
- Dashboard smoke script resolves the `next` binary from the hoisted root `node_modules` (worktree checkouts).

## Tests
- 5 new orchestrator test files: queue serialization default + `FLOW_MAX_CONCURRENT_INDEXES=2` parallel opt-in + same-repo coalescing with full event-trail assertion; change-branch refspec fix against a real single-branch clone; repo-removed cleanup + collision guard; incremental full-vs-diff decision matrix.
- **231 orchestrator + 23 gateway tests pass; simulators scenario verify passes.**

## Known pre-existing issues (not addressed here)
- Dashboard smoke test has been broken since the PR #25 routing refactor — it asserts bare `/api/*` paths return 200, but the proxy 404s everything un-project-scoped, and its `/`-redirect check requires a `data/projects` entry to exist. Needs a rewrite for project-scoped routing (separate task).