### PR TITLE
fix(indexer): record indexed commit for symlinked local-tier repos

### DIFF
--- a/dashboard/src/app/api/agents/route.ts
+++ b/dashboard/src/app/api/agents/route.ts
@@ -1,13 +1,16 @@
 import { NextResponse } from "next/server";
-import { getSessionToken } from "@/lib/auth";
+import { currentUser, getSessionToken } from "@/lib/auth";
 import { orcFetch } from "@/lib/orchestrator";
 
-// GET /api/agents — installed agents + connected repos (proxied to orchestrator)
+// GET /api/agents — installed agents + connected repos + the CURRENT USER's
+// work folders (owner resolved server-side; folders are never shared).
 export async function GET(): Promise<NextResponse> {
   const token = await getSessionToken();
   if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   try {
-    const res = await orcFetch("/v1/agents", token);
+    const user = await currentUser();
+    const owner = user?.email ?? "local";
+    const res = await orcFetch(`/v1/agents?owner=${encodeURIComponent(owner)}`, token);
     return NextResponse.json(await res.json(), { status: res.status });
   } catch (err) {
     return NextResponse.json({ error: (err as Error).message }, { status: 502 });

--- a/dashboard/src/app/api/agents/sessions/route.ts
+++ b/dashboard/src/app/api/agents/sessions/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getSessionToken } from "@/lib/auth";
+import { currentUser, getSessionToken } from "@/lib/auth";
 import { orcFetch } from "@/lib/orchestrator";
 
 // GET /api/agents/sessions — list; POST — create {backend, repo, prompt}
@@ -18,10 +18,13 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   const token = await getSessionToken();
   if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   try {
-    const body = await req.json();
+    const body = (await req.json()) as Record<string, unknown>;
+    // Owner is resolved server-side so workFolder ownership checks can't be
+    // spoofed from the client.
+    const user = await currentUser();
     const res = await orcFetch("/v1/agents/sessions", token, {
       method: "POST",
-      body: JSON.stringify(body),
+      body: JSON.stringify({ ...body, owner: user?.email ?? "local" }),
     });
     return NextResponse.json(await res.json(), { status: res.status });
   } catch (err) {

--- a/dashboard/src/app/api/work-folders/route.ts
+++ b/dashboard/src/app/api/work-folders/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { currentUser, getSessionToken } from "@/lib/auth";
+import { orcFetch } from "@/lib/orchestrator";
+
+// Per-user work folders — where THIS user's agent sessions run. The owner is
+// resolved server-side from the session (never trusted from the client), so
+// one user's local paths can never appear in a teammate's dashboard.
+async function owner(): Promise<string> {
+  const user = await currentUser();
+  return user?.email ?? "local";
+}
+
+export async function GET(): Promise<NextResponse> {
+  const token = await getSessionToken();
+  if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  try {
+    const res = await orcFetch(`/v1/work-folders?owner=${encodeURIComponent(await owner())}`, token);
+    return NextResponse.json(await res.json(), { status: res.status });
+  } catch (err) {
+    return NextResponse.json({ error: (err as Error).message }, { status: 502 });
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const token = await getSessionToken();
+  if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  try {
+    const body = (await req.json()) as { path?: string; repo?: string };
+    const res = await orcFetch(`/v1/work-folders`, token, {
+      method: "POST",
+      body: JSON.stringify({ owner: await owner(), path: body.path, repo: body.repo }),
+    });
+    return NextResponse.json(await res.json(), { status: res.status });
+  } catch (err) {
+    return NextResponse.json({ error: (err as Error).message }, { status: 502 });
+  }
+}
+
+export async function DELETE(req: NextRequest): Promise<NextResponse> {
+  const token = await getSessionToken();
+  if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  try {
+    const body = (await req.json()) as { path?: string };
+    const res = await orcFetch(`/v1/work-folders`, token, {
+      method: "DELETE",
+      body: JSON.stringify({ owner: await owner(), path: body.path }),
+    });
+    return NextResponse.json(await res.json(), { status: res.status });
+  } catch (err) {
+    return NextResponse.json({ error: (err as Error).message }, { status: 502 });
+  }
+}

--- a/dashboard/src/components/AddFolder.tsx
+++ b/dashboard/src/components/AddFolder.tsx
@@ -51,8 +51,6 @@ function SourceConfigModal({
   setBranch,
   childRepos,
   setChildRepos,
-  docsChecked,
-  setDocsChecked,
   showSkipped,
   setShowSkipped,
   adding,
@@ -66,8 +64,6 @@ function SourceConfigModal({
   setBranch: (v: string) => void;
   childRepos: Record<number, { checked: boolean; branch: string }>;
   setChildRepos: React.Dispatch<React.SetStateAction<Record<number, { checked: boolean; branch: string }>>>;
-  docsChecked: boolean;
-  setDocsChecked: React.Dispatch<React.SetStateAction<boolean>>;
   showSkipped: boolean;
   setShowSkipped: React.Dispatch<React.SetStateAction<boolean>>;
   adding: boolean;
@@ -109,7 +105,7 @@ function SourceConfigModal({
   function renderGitRepo(repo: RepoInfo) {
     return (
       <>
-        <Kicker>Code · GitHub-synced, using your folder</Kicker>
+        <Kicker>Code · remote-synced, using your folder</Kicker>
         <div style={{ ...mono, fontSize: 14, color: "var(--ink)", margin: "6px 0 4px" }}>{repo.name}</div>
         <div style={{ ...mono, fontSize: 11, color: "var(--text-muted)", marginBottom: 4 }}>{repo.path}</div>
         {repo.remoteUrl && (
@@ -168,7 +164,7 @@ function SourceConfigModal({
         ) : (
           <>
             <div style={{ display: "inline-block", fontSize: 12, color: "var(--text)", background: "var(--sand)", border: "1px solid var(--line)", borderRadius: 6, padding: "6px 10px", lineHeight: 1.5 }}>
-              Local-only — the brain rescans on demand; push it to GitHub anytime to upgrade to auto-sync.
+              No remote — the brain clones from the folder itself and follows your commits. Add a remote anytime; nothing changes for Flow.
             </div>
             <div style={{ fontSize: 13, color: "var(--text)", marginTop: 10 }}>
               Base branch: <span style={{ ...mono, color: "var(--ink)" }}>{repo.currentBranch}</span>
@@ -191,31 +187,26 @@ function SourceConfigModal({
   function renderFolder(docs: DocsInfo) {
     return (
       <>
-        <Kicker>Docs &amp; files — becomes searchable knowledge</Kicker>
+        <Kicker>No git repositories here</Kicker>
         <div style={{ ...mono, fontSize: 14, color: "var(--ink)", margin: "6px 0 4px" }}>{docs.name}</div>
         <div style={{ ...mono, fontSize: 11, color: "var(--text-muted)", marginBottom: 8 }}>{docs.path}</div>
-        <div style={{ fontSize: 13, color: "var(--text)" }}>
-          {docs.fileCount} file{docs.fileCount === 1 ? "" : "s"} · {money(docs.totalBytes)}
+        <div style={{ fontSize: 13, color: "var(--text)", lineHeight: 1.6 }}>
+          Flow indexes git repositories — commits are how it tracks what changed and when.
+          This folder has no repository, so there is nothing Flow can follow.
         </div>
-        {renderSkipped(docs.skipped)}
-        <div style={{ marginTop: 14 }}>
-          <ConfirmBtn
-            loading={adding}
-            label="Add source"
-            onClick={() => onAdd([{ type: "docs", path: docs.path, name: docs.name }])}
-          />
+        <div style={{ fontSize: 12.5, color: "var(--text-muted)", marginTop: 8, lineHeight: 1.6 }}>
+          Run <span style={{ ...mono, color: "var(--ink)" }}>git init</span> inside it, or pick a folder
+          that contains repositories.
         </div>
       </>
     );
   }
 
   function renderContainer(children: Children) {
-    const withGithub = children.repos.filter((r) => r.remoteUrl).length;
     const own = children.repos.map((r, i) => ({ r, i })).filter(({ r }) => !r.thirdParty);
     const third = children.repos.map((r, i) => ({ r, i })).filter(({ r }) => r.thirdParty);
 
-    const checkedCount =
-      Object.values(childRepos).filter((c) => c.checked).length + (docsChecked ? 1 : 0);
+    const checkedCount = Object.values(childRepos).filter((c) => c.checked).length;
 
     const repoRow = ({ r, i }: { r: ChildRepo; i: number }) => {
       const st = childRepos[i] ?? { checked: false, branch: r.remoteUrl ? r.defaultBranch : r.currentBranch };
@@ -266,12 +257,10 @@ function SourceConfigModal({
     return (
       <>
         <Kicker>
-          {withGithub > 0
-            ? `Found ${withGithub} GitHub repo${withGithub === 1 ? "" : "s"} in this folder`
-            : "A folder with several things inside"}
+          Found {children.repos.length} git repositor{children.repos.length === 1 ? "y" : "ies"} in this folder
         </Kicker>
-        <div style={{ fontSize: 12.5, color: "var(--text-muted)", margin: "6px 0 4px" }}>
-          Pick what Flow should take on.
+        <div style={{ fontSize: 12.5, color: "var(--ink)", margin: "6px 0 4px", fontWeight: 500 }}>
+          These repositories will be indexed — nothing else in this folder.
         </div>
 
         {own.length > 0 && (
@@ -289,23 +278,6 @@ function SourceConfigModal({
             <div style={{ marginTop: 6 }}>{third.map(repoRow)}</div>
           </details>
         )}
-
-        {/* Everything else → docs */}
-        <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "10px 0", borderTop: "1px solid var(--line)", marginTop: 14 }}>
-          <input
-            type="checkbox"
-            checked={docsChecked}
-            onChange={() => setDocsChecked((c) => !c)}
-            style={{ width: 14, height: 14, accentColor: "var(--ink)", flexShrink: 0 }}
-          />
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <div style={{ fontSize: 13, color: "var(--ink)", fontWeight: 500 }}>Everything else</div>
-            <div style={{ fontSize: 11.5, color: "var(--text-muted)" }}>
-              everything except the repos above · {children.docs.fileCount} file
-              {children.docs.fileCount === 1 ? "" : "s"} · {money(children.docs.totalBytes)}
-            </div>
-          </div>
-        </div>
 
         <div style={{ marginTop: 16 }}>
           <ConfirmBtn
@@ -326,9 +298,6 @@ function SourceConfigModal({
                   });
                 }
               });
-              if (docsChecked) {
-                sources.push({ type: "docs", path: children.docs.path, name: children.docs.name });
-              }
               onAdd(sources);
             }}
           />
@@ -420,7 +389,6 @@ export function AddFolder({
 
   const [branch, setBranch] = useState("");
   const [childRepos, setChildRepos] = useState<Record<number, { checked: boolean; branch: string }>>({});
-  const [docsChecked, setDocsChecked] = useState(true);
   const [showSkipped, setShowSkipped] = useState(false);
 
   function seedForm(data: Inspect) {
@@ -434,10 +402,8 @@ export function AddFolder({
         init[i] = { checked: r.checkedDefault && !r.alreadyConnected, branch: seedBranch };
       });
       setChildRepos(init);
-      setDocsChecked(!isProd);
     } else {
       setChildRepos({});
-      setDocsChecked(true);
     }
   }
 
@@ -538,8 +504,6 @@ export function AddFolder({
           setBranch={setBranch}
           childRepos={childRepos}
           setChildRepos={setChildRepos}
-          docsChecked={docsChecked}
-          setDocsChecked={setDocsChecked}
           showSkipped={showSkipped}
           setShowSkipped={setShowSkipped}
           adding={adding}

--- a/dashboard/src/components/AgentsView.tsx
+++ b/dashboard/src/components/AgentsView.tsx
@@ -84,6 +84,13 @@ export function AgentsView() {
 
   const [backend, setBackend] = useState("");
   const [repo, setRepo] = useState("");
+  // Work folder: "" = the repo's default surface (Flow's managed clone or the
+  // registered checkout). A picked folder means "use this repo's knowledge,
+  // but make the changes over THERE" — folders are per-user, never shared.
+  const [workFolders, setWorkFolders] = useState<{ path: string; repo: string | null }[]>([]);
+  const [workFolder, setWorkFolder] = useState("");
+  const [newFolderPath, setNewFolderPath] = useState("");
+  const [addingFolder, setAddingFolder] = useState(false);
   const [prompt, setPrompt] = useState("");
   const [starting, setStarting] = useState(false);
   const [error, setError] = useState("");
@@ -100,6 +107,7 @@ export function AgentsView() {
       ]);
       setAgents(a.agents ?? []);
       setRepos((a.repos ?? []).filter((r: RepoOption) => r.cloned));
+      setWorkFolders(a.workFolders ?? []);
       setSessions(s.sessions ?? []);
       setBackend((prev) => prev || (a.agents ?? []).find((x: DetectedAgent) => x.installed)?.id || "");
       setRepo((prev) => prev || (a.repos ?? [])[0]?.name || "");
@@ -135,7 +143,13 @@ export function AgentsView() {
       const res = await fetch(prefix("/api/agents/sessions"), {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ backend, repo, prompt, ...(placement ? { placement } : {}) }),
+        body: JSON.stringify({
+          backend,
+          repo,
+          prompt,
+          ...(placement ? { placement } : {}),
+          ...(workFolder ? { workFolder } : {}),
+        }),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error ?? `status ${res.status}`);
@@ -222,6 +236,62 @@ export function AgentsView() {
               </option>
             ))}
           </select>
+          {/* Work folder — YOUR checkouts (per-user, never a teammate's paths).
+              Default = the repo's own surface; picking a folder means "use this
+              repo's knowledge, but make the changes over there". */}
+          <select
+            value={workFolder}
+            onChange={(e) => setWorkFolder(e.target.value)}
+            className="rounded-lg border border-line bg-cream px-3 py-2 text-[13px] text-ink"
+            style={{ fontFamily: "var(--font-mono)" }}
+            data-testid="work-folder-select"
+            title="Where the agent makes its changes — your folders, on your machine"
+          >
+            <option value="">work in: {repo || "repo"} (default)</option>
+            {workFolders.map((f) => (
+              <option key={f.path} value={f.path}>
+                work in: {f.path}
+              </option>
+            ))}
+          </select>
+          <span className="flex items-center gap-1">
+            <input
+              value={newFolderPath}
+              onChange={(e) => setNewFolderPath(e.target.value)}
+              placeholder="/path/to/another/checkout"
+              className="rounded-lg border border-line bg-cream px-3 py-2 text-[12px] text-ink w-56"
+              style={{ fontFamily: "var(--font-mono)" }}
+              data-testid="work-folder-input"
+            />
+            <button
+              onClick={async () => {
+                const path = newFolderPath.trim();
+                if (!path) return;
+                setAddingFolder(true);
+                try {
+                  const res = await fetch(prefix("/api/work-folders"), {
+                    method: "POST",
+                    headers: { "content-type": "application/json" },
+                    body: JSON.stringify({ path, repo: repo || undefined }),
+                  });
+                  const d = (await res.json()) as { folders?: { path: string; repo: string | null }[] };
+                  if (res.ok && d.folders) {
+                    setWorkFolders(d.folders);
+                    setWorkFolder(path);
+                    setNewFolderPath("");
+                  }
+                } finally {
+                  setAddingFolder(false);
+                }
+              }}
+              disabled={addingFolder || !newFolderPath.trim()}
+              className="rounded-lg border border-line bg-cream px-3 py-2 text-[12px] text-text-muted hover:text-ink"
+              style={{ fontFamily: "var(--font-mono)" }}
+              title="Remember this folder as a place agents can work"
+            >
+              + folder
+            </button>
+          </span>
         </div>
         <MentionTextarea
           value={prompt}

--- a/dashboard/src/components/SourcesFrontDoor.tsx
+++ b/dashboard/src/components/SourcesFrontDoor.tsx
@@ -225,9 +225,10 @@ function SourceRow({ s, st, onChanged }: { s: SourceEntry; st?: RepoStatusEntry;
   const { prefix } = useProject();
   const chip = sourceChip(s);
   // Prefer the orchestrator's state machine; fall back to the legacy guess
-  // when the status endpoint hasn't answered yet.
+  // when the status endpoint hasn't answered yet. Local-tier repos may have
+  // lastIndexedAt without a commit — either one means "indexed".
   const status: RepoStatusEntry["status"] | undefined =
-    s.kind === "docs" ? undefined : st?.status ?? (!s.lastIndexedCommit ? "indexing" : "indexed");
+    s.kind === "docs" ? undefined : st?.status ?? (!s.lastIndexedCommit && !s.lastIndexedAt ? "indexing" : "indexed");
   const indexing = status === "indexing";
   const [showLog, setShowLog] = useState(false);
 

--- a/dashboard/src/components/SourcesFrontDoor.tsx
+++ b/dashboard/src/components/SourcesFrontDoor.tsx
@@ -55,7 +55,7 @@ interface IndexLogRow {
 function sourceChip(s: SourceEntry): string {
   if (s.kind === "docs") return "docs · ingestion pending";
   if (s.localPath) return "your folder";
-  return "GitHub-synced";
+  return "remote-synced";
 }
 
 function timeAgo(iso?: string): string | null {

--- a/orchestrator/package.json
+++ b/orchestrator/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts",
-    "test": "node --import tsx/esm --test test/fake-opencode.ts test/orchestrator.test.ts test/adapters.test.ts test/outbox-approve.test.ts test/llmlog.test.ts test/smoke.ts test/notify.test.ts test/pollers.test.ts test/poller.test.ts test/settings.test.ts test/sources.test.ts test/agent-diff.test.ts test/worktrees.test.ts test/memory.test.ts test/llm.test.ts test/indexer-runtime.test.ts test/index-queue.test.ts test/change-branch.test.ts test/repo-removed.test.ts test/index-incremental.test.ts",
+    "test": "node --import tsx/esm --test test/fake-opencode.ts test/orchestrator.test.ts test/adapters.test.ts test/outbox-approve.test.ts test/llmlog.test.ts test/smoke.ts test/notify.test.ts test/pollers.test.ts test/poller.test.ts test/settings.test.ts test/sources.test.ts test/agent-diff.test.ts test/worktrees.test.ts test/memory.test.ts test/llm.test.ts test/indexer-runtime.test.ts test/index-queue.test.ts test/change-branch.test.ts test/repo-removed.test.ts test/index-incremental.test.ts test/work-folders.test.ts",
     "verify": "npm test",
     "verify:real": "tsx test/real-integrations.ts",
     "verify:session": "tsx test/real-session.ts"

--- a/orchestrator/src/actions/index.ts
+++ b/orchestrator/src/actions/index.ts
@@ -235,9 +235,9 @@ async function handleGithubAuto(event: NormalizedEvent, cls: ClassificationResul
   // ensureRepoClone throws "no checkout and no url" and the job dies.
   const p = event.payload as Record<string, string | undefined>;
   const { listWorkspaceRepos } = await import("../opencode.js");
-  const { ownerRepoFromUrl } = await import("../adapters/github.js");
+  const { watchKeyForUrl } = await import("../adapters/github.js");
   const entry = listWorkspaceRepos().find(
-    (r) => r.url && ownerRepoFromUrl(r.url) === p.repo
+    (r) => r.url && watchKeyForUrl(r.url) === p.repo
   );
   const repoName = entry?.name ?? p.repo ?? "";
   const job = await enqueueJob({

--- a/orchestrator/src/adapters/github.ts
+++ b/orchestrator/src/adapters/github.ts
@@ -91,8 +91,9 @@ export function ghAuthOk(): boolean {
 export async function seedWatchedRepos(): Promise<void> {
   const { listWorkspaceRepos } = await import("../opencode.js");
   for (const r of listWorkspaceRepos()) {
-    const ownerRepo = r.url ? ownerRepoFromUrl(r.url) : null;
-    if (ownerRepo) registeredRepos.set(ownerRepo, r.branch || "main");
+    if (r.kind === "docs") continue;
+    const key = watchKeyForUrl(r.url);
+    if (key) registeredRepos.set(key, r.branch || "main");
   }
 }
 
@@ -260,8 +261,19 @@ function verifyGithubSignature(secret: string, rawBody: Buffer, sigHeader: strin
 // Subsequent polls: emit push event only when SHA differs from cursor.
 // ------------------------------------------------------------------
 
+// Watch keys are "owner/repo" for GitHub, or a full clone source (any remote
+// URL, or a local filesystem path — git treats a path as a remote) for
+// everything else. ls-remote works identically against all three.
 function repoUrl(repo: string): string {
+  if (repo.includes("://") || repo.startsWith("/") || repo.startsWith("git@")) return repo;
   return `https://github.com/${repo}.git`;
+}
+
+// The watch key for a registry url: GitHub shorthand when parseable, else the
+// url/path itself. Null only for empty urls (nothing to poll).
+export function watchKeyForUrl(url: string | undefined): string | null {
+  if (!url) return null;
+  return ownerRepoFromUrl(url) ?? url;
 }
 
 export async function githubFetchSince(cursor: string): Promise<FetchResult> {

--- a/orchestrator/src/agents/routes.ts
+++ b/orchestrator/src/agents/routes.ts
@@ -54,9 +54,36 @@ import {
 } from "./runtime.js";
 
 export function registerAgentRoutes(app: FastifyInstance): void {
-  app.get("/v1/agents", async () => {
+  app.get<{ Querystring: { owner?: string } }>("/v1/agents", async (req) => {
     const agents = await detectAgents();
-    return { agents, repos: listRepoOptions() };
+    const owner = req.query.owner || "local";
+    const { listWorkFolders } = await import("../work-folders.js");
+    return { agents, repos: listRepoOptions(), workFolders: listWorkFolders(owner) };
+  });
+
+  // Per-user work folders — where THIS user's agent sessions run. Owner is
+  // supplied by the dashboard from its session identity ("local" in local
+  // mode); folders are never shared across owners.
+  app.get<{ Querystring: { owner?: string } }>("/v1/work-folders", async (req) => {
+    const { listWorkFolders } = await import("../work-folders.js");
+    return { folders: listWorkFolders(req.query.owner || "local") };
+  });
+
+  app.post("/v1/work-folders", async (req, reply) => {
+    const body = req.body as { owner?: string; path?: string; repo?: string };
+    const path = body.path?.trim();
+    if (!path) return reply.code(400).send({ error: "path is required" });
+    const { addWorkFolder, listWorkFolders } = await import("../work-folders.js");
+    addWorkFolder(body.owner?.trim() || "local", path, body.repo?.trim() || undefined);
+    return { folders: listWorkFolders(body.owner?.trim() || "local") };
+  });
+
+  app.delete("/v1/work-folders", async (req, reply) => {
+    const body = req.body as { owner?: string; path?: string };
+    if (!body.path) return reply.code(400).send({ error: "path is required" });
+    const { removeWorkFolder, listWorkFolders } = await import("../work-folders.js");
+    removeWorkFolder(body.owner?.trim() || "local", body.path);
+    return { folders: listWorkFolders(body.owner?.trim() || "local") };
   });
 
   app.get("/v1/agents/sessions", async () => ({ sessions: listSessions() }));
@@ -73,7 +100,14 @@ export function registerAgentRoutes(app: FastifyInstance): void {
   // `placement` (optional): "in_place" starts anyway in the same folder;
   // "separate_copy" branches the checkout into a worktree and runs there.
   app.post("/v1/agents/sessions", async (req, reply) => {
-    const body = req.body as { backend?: string; repo?: string; prompt?: string; placement?: string };
+    const body = req.body as {
+      backend?: string;
+      repo?: string;
+      prompt?: string;
+      placement?: string;
+      workFolder?: string;
+      owner?: string;
+    };
     const backend = body.backend as AgentBackend;
     if (!backend || !(backend in BACKENDS)) {
       return reply.code(400).send({ error: `backend must be one of ${Object.keys(BACKENDS).join(", ")}` });
@@ -85,7 +119,16 @@ export function registerAgentRoutes(app: FastifyInstance): void {
     if (placement !== undefined && placement !== "in_place" && placement !== "separate_copy") {
       return reply.code(400).send({ error: "placement must be 'in_place' or 'separate_copy'" });
     }
-    const result = await createSession({ backend, repo: body.repo, prompt: body.prompt.trim(), placement });
+    // A work folder must be one the requesting owner registered — sessions
+    // never run in a path some other user (or nobody) vouched for.
+    let workFolder: string | undefined;
+    if (body.workFolder?.trim()) {
+      const { listWorkFolders } = await import("../work-folders.js");
+      const owned = listWorkFolders(body.owner?.trim() || "local").some((f) => f.path === body.workFolder);
+      if (!owned) return reply.code(400).send({ error: "workFolder is not registered for this user" });
+      workFolder = body.workFolder.trim();
+    }
+    const result = await createSession({ backend, repo: body.repo, prompt: body.prompt.trim(), placement, workFolder });
     if ("error" in result) return reply.code(400).send(result);
     return result;
   });

--- a/orchestrator/src/agents/runtime.ts
+++ b/orchestrator/src/agents/runtime.ts
@@ -1154,10 +1154,21 @@ export async function createSession(opts: {
   repo: string;
   prompt: string;
   placement?: SessionPlacement;
+  // Explicit per-user WORK surface (a registered work folder): "use this
+  // repo's knowledge, but make the changes in THIS checkout." Overrides the
+  // repo's default surface.
+  workFolder?: string;
 }): Promise<CreateSessionResult> {
-  const repoOpt = listRepoOptions().find((r) => r.name === opts.repo);
-  if (!repoOpt) return { error: `Unknown repo "${opts.repo}" — connect it first` };
-  if (!repoOpt.cloned) return { error: `Repo "${opts.repo}" is not cloned yet` };
+  const found = listRepoOptions().find((r) => r.name === opts.repo);
+  if (!found) return { error: `Unknown repo "${opts.repo}" — connect it first` };
+  if (!found.cloned && !opts.workFolder) return { error: `Repo "${opts.repo}" is not cloned yet` };
+  let repoOpt = found;
+  if (opts.workFolder) {
+    if (!existsSync(opts.workFolder)) {
+      return { error: `Work folder "${opts.workFolder}" doesn't exist on this machine` };
+    }
+    repoOpt = { ...found, path: opts.workFolder, cloned: true };
+  }
 
   const title = opts.prompt.length > 80 ? opts.prompt.slice(0, 77) + "…" : opts.prompt;
 

--- a/orchestrator/src/db.ts
+++ b/orchestrator/src/db.ts
@@ -5,7 +5,7 @@ import Database from "better-sqlite3";
 import { mkdirSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { migrate, MEMORY_SCHEMA, MEMORY_TRIGGERS, ANCHORS_SCHEMA, INDEX_LOG_SCHEMA } from "./migrations.js";
+import { migrate, MEMORY_SCHEMA, MEMORY_TRIGGERS, ANCHORS_SCHEMA, INDEX_LOG_SCHEMA, WORK_FOLDERS_SCHEMA } from "./migrations.js";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
@@ -274,6 +274,9 @@ db.exec(ANCHORS_SCHEMA);
 // index_log: indexer lifecycle trail (migration 11). Kept byte-identical to
 // the migration via the shared INDEX_LOG_SCHEMA string.
 db.exec(INDEX_LOG_SCHEMA);
+// work_folders: per-user agent work surfaces (migration 12). Kept
+// byte-identical to the migration via the shared WORK_FOLDERS_SCHEMA string.
+db.exec(WORK_FOLDERS_SCHEMA);
 
 // FTS triggers to keep virtual tables in sync with base tables
 db.exec(`

--- a/orchestrator/src/events.ts
+++ b/orchestrator/src/events.ts
@@ -142,9 +142,9 @@ export async function processEvent(event: NormalizedEvent): Promise<void> {
           indexLog(p.repo, "watch", undefined, { branch: p.branch, previous: entry.branch });
         }
         if (entry.url) {
-          const { watchRepo, ownerRepoFromUrl } = await import("./adapters/github.js");
-          const ownerRepo = ownerRepoFromUrl(entry.url);
-          if (ownerRepo) watchRepo(ownerRepo, p.branch);
+          const { watchRepo, watchKeyForUrl } = await import("./adapters/github.js");
+          const watchKey = watchKeyForUrl(entry.url);
+          if (watchKey) watchRepo(watchKey, p.branch);
         }
       }
     }

--- a/orchestrator/src/index.ts
+++ b/orchestrator/src/index.ts
@@ -272,6 +272,9 @@ const start = async (): Promise<void> => {
 
     // Register all pollers with the engine (enabled() checks gating at tick time)
     await seedWatchedRepos();
+    // Legacy localPath entries become the "local" owner's work folders.
+    const { seedWorkFoldersFromRegistry } = await import("./work-folders.js");
+    seedWorkFoldersFromRegistry();
     registerGithubPoller();
     registerLinearPoller();
     registerFirefliesPoller();

--- a/orchestrator/src/migrations.ts
+++ b/orchestrator/src/migrations.ts
@@ -184,7 +184,31 @@ export const MIGRATIONS: Migration[] = [
       db.exec(INDEX_LOG_SCHEMA);
     },
   },
+  {
+    id: 12,
+    name: "work_folders: per-user agent work surfaces",
+    up: (db) => {
+      // Keep byte-identical to WORK_FOLDERS_SCHEMA in db.ts (see migration 8 note).
+      db.exec(WORK_FOLDERS_SCHEMA);
+    },
+  },
 ];
+
+// Per-user WORK surfaces (where agent sessions run) — deliberately separate
+// from repos.json so one user's local paths never leak into a teammate's
+// dashboard on a shared deployment. owner = dashboard session user in prod,
+// "local" in local mode. UNIQUE keeps re-registration idempotent.
+export const WORK_FOLDERS_SCHEMA = `
+  CREATE TABLE IF NOT EXISTS work_folders (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner      TEXT NOT NULL,
+    path       TEXT NOT NULL,
+    repo       TEXT,
+    added_at   INTEGER NOT NULL DEFAULT (unixepoch()),
+    UNIQUE(owner, path)
+  );
+  CREATE INDEX IF NOT EXISTS idx_work_folders_owner ON work_folders(owner);
+`;
 
 // Indexer lifecycle trail — one row per transition (enqueued, parked,
 // superseded, started, done, failed, recovered, watch, removed) so

--- a/orchestrator/src/opencode.ts
+++ b/orchestrator/src/opencode.ts
@@ -11,7 +11,7 @@
 
 import { spawn, spawnSync } from "node:child_process";
 import { createHmac, randomUUID } from "node:crypto";
-import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, lstatSync, mkdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
@@ -520,9 +520,9 @@ export async function connectGithubRepo(
   const entry = registerRepo(url, resolvedBranch);
   if (localPath) registerSource({ name: entry.name, localPath });
   // registeredRepos is otherwise only seeded at boot — watch this branch now.
-  const { watchRepo, ownerRepoFromUrl } = await import("./adapters/github.js");
-  const ownerRepo = ownerRepoFromUrl(url);
-  if (ownerRepo) watchRepo(ownerRepo, entry.branch);
+  const { watchRepo, watchKeyForUrl } = await import("./adapters/github.js");
+  const watchKey = watchKeyForUrl(url);
+  if (watchKey) watchRepo(watchKey, entry.branch);
   const job = await enqueueJob({
     type: "index_repo",
     input: { repo: entry.name, url: entry.url, branch: entry.branch },
@@ -535,36 +535,43 @@ export async function connectGithubRepo(
 // multi-minute clone must never block the event loop. Private repos: the
 // GITHUB_TOKEN (settings or env) is injected into the clone URL only; it is
 // never written to disk, the registry, or error messages.
-async function ensureRepoClone(entry: { name: string; url?: string; branch?: string }): Promise<string> {
-  // Local tier: an entry with no url but a localPath is the user's own checkout
-  // — index in place from that folder (there is nothing to clone). Materialize
-  // repos/<name> as a symlink to it, because downstream consumers (the index
-  // prompt, the corrections verifier) address checkouts as repos/<name>
-  // relative paths and must not care which tier a repo is.
-  if (!entry.url) {
-    const reg = readRepoRegistry().repos.find((r) => r.name === entry.name);
+export async function ensureRepoClone(entry: { name: string; url?: string; branch?: string }): Promise<string> {
+  // One tier, one mechanism: every indexable source is a git repo we CLONE
+  // from — a remote URL or a local filesystem path (git treats a path as a
+  // remote). The old local tier symlinked repos/<name> to the user's checkout,
+  // which broke commit bookkeeping and read uncommitted state; a clone from
+  // the path gives local repos the exact same fetch/reset/poll machinery.
+  const dest = resolve(WORKSPACE_DIR, "repos", entry.name);
+
+  // Legacy migration: a symlinked checkout from the old local tier is
+  // replaced by a real clone on the next index.
+  let isLink = false;
+  try {
+    isLink = lstatSync(dest).isSymbolicLink();
+  } catch {
+    /* nothing at dest */
+  }
+  if (isLink) unlinkSync(dest);
+  else if (existsSync(dest)) return dest;
+
+  // Clone source: the entry's url (remote or path). Legacy local-only entries
+  // registered url:"" with only a localPath — use the path and self-heal the
+  // registry so pollers and future jobs see it as the clone source.
+  let cloneSrc = entry.url ?? "";
+  if (!cloneSrc) {
+    const registry = readRepoRegistry();
+    const reg = registry.repos.find((r) => r.name === entry.name);
     if (reg?.localPath && existsSync(reg.localPath)) {
-      const dest = resolve(WORKSPACE_DIR, "repos", entry.name);
-      if (!existsSync(dest)) {
-        mkdirSync(resolve(WORKSPACE_DIR, "repos"), { recursive: true });
-        try {
-          symlinkSync(reg.localPath, dest);
-        } catch (err) {
-          // A dangling symlink at dest fails existsSync yet blocks creation —
-          // anything other than "already there" is a real error.
-          if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
-        }
-      }
-      return dest;
+      cloneSrc = reg.localPath;
+      reg.url = reg.localPath;
+      writeFileSync(reposJsonPath(), JSON.stringify(registry, null, 2));
     }
   }
-  const dest = resolve(WORKSPACE_DIR, "repos", entry.name);
-  if (existsSync(dest)) return dest;
-  if (!entry.url) throw new Error(`repo '${entry.name}' has no checkout and no url to clone from`);
+  if (!cloneSrc) throw new Error(`repo '${entry.name}' has no checkout and no url to clone from`);
   mkdirSync(resolve(WORKSPACE_DIR, "repos"), { recursive: true });
 
   const token = getSetting("GITHUB_TOKEN");
-  let cloneUrl = entry.url;
+  let cloneUrl = cloneSrc;
   if (token && /^https:\/\/github\.com\//.test(cloneUrl)) {
     cloneUrl = cloneUrl.replace("https://github.com/", `https://x-access-token:${token}@github.com/`);
   }

--- a/orchestrator/src/opencode.ts
+++ b/orchestrator/src/opencode.ts
@@ -231,12 +231,14 @@ export function registerSource(entry: SourceRegistration): RepoEntry {
 }
 
 // Record the commit we just indexed so update.mjs and the orchestrator agree
-// on state. Called after a successful index_repo job.
-export function updateRepoIndexCommit(name: string, commit: string): void {
+// on state. Called after every successful index_repo job — lastIndexedAt is
+// stamped even when no commit resolves (a non-git docs folder), so a
+// successful index is never invisible to the status machine.
+export function updateRepoIndexCommit(name: string, commit: string | null): void {
   const registry = readRepoRegistry();
   const existing = registry.repos.find((r) => r.name === name);
   if (existing) {
-    existing.lastIndexedCommit = commit;
+    if (commit) existing.lastIndexedCommit = commit;
     existing.lastIndexedAt = new Date().toISOString();
     writeFileSync(reposJsonPath(), JSON.stringify(registry, null, 2));
   }
@@ -349,7 +351,9 @@ export function repoStatuses(): RepoStatus[] {
   return readRepoRegistry().repos.map((entry) => {
     const running = (runningJob.get(entry.name) as { id: string } | undefined)?.id ?? null;
     const parked = indexWaitQueue.find((e) => e.repo === entry.name)?.id ?? null;
-    const indexed = Boolean(entry.lastIndexedCommit);
+    // Either field proves a successful index — local-tier repos may lack a
+    // commit (see updateRepoIndexCommit) but always get lastIndexedAt.
+    const indexed = Boolean(entry.lastIndexedCommit || entry.lastIndexedAt);
     let lastError: string | null = null;
     let status: RepoStatus["status"];
     if (running) status = "indexing";
@@ -471,10 +475,15 @@ export function incrementalContext(repo: string, branch: string): { from: string
   }
 }
 
-// Resolve the current HEAD of a managed checkout; null if missing/local.
+// Resolve the commit that was just indexed. Managed clones and the local
+// tier both live at repos/<name>; for a symlink (the user's own checkout,
+// indexed in place) HEAD is read through the link — the target is still a
+// git repo, and it is exactly what the indexer read. Skipping symlinks here
+// left local-only repos showing "never indexed" forever after successful
+// runs. Null only when the folder is missing or not a git repo.
 function repoHeadCommit(name: string): string | null {
   const dest = resolve(WORKSPACE_DIR, "repos", name);
-  if (!existsSync(dest) || lstatSync(dest).isSymbolicLink()) return null;
+  if (!existsSync(dest)) return null;
   try {
     const res = spawnSync("git", ["-C", dest, "rev-parse", "HEAD"], { encoding: "utf8", timeout: 5000 });
     return res.status === 0 ? res.stdout.trim() : null;
@@ -808,7 +817,7 @@ async function runJob(id: string, opts: JobInput): Promise<void> {
     // Record the commit we just indexed so update.mjs and the orchestrator agree.
     if (opts.type === "index_repo" && repo) {
       const head = repoHeadCommit(repo);
-      if (head) updateRepoIndexCommit(repo, head);
+      updateRepoIndexCommit(repo, head);
       const inc = (opts.input as { incremental?: { from: string } }).incremental;
       indexLog(repo, "done", id, {
         ...(head ? { commit: head } : {}),

--- a/orchestrator/src/sources.ts
+++ b/orchestrator/src/sources.ts
@@ -325,7 +325,6 @@ async function inspectGitRepo(repoPath: string): Promise<GitRepoResult> {
   const name = basename(repoPath);
   const remoteRes = await git(repoPath, ["remote", "get-url", "origin"]);
   const remoteRaw = remoteRes.ok ? remoteRes.out : "";
-  const isGithub = remoteRaw ? /github\.com[/:]/i.test(remoteRaw) : false;
   const remoteUrl = remoteRaw ? normalizeRemote(remoteRaw) : null;
 
   // Default branch: origin/HEAD's target, else the current branch, else main.
@@ -345,9 +344,11 @@ async function inspectGitRepo(repoPath: string): Promise<GitRepoResult> {
     dirty,
     alreadyConnected: !!findRegistered({ name, url: remoteUrl, path: repoPath }),
   };
-  // A GitHub remote → git_repo (has a BRAIN via the managed clone). No remote,
-  // or a non-GitHub remote → local_only tier (we keep remoteUrl for display).
-  return { kind: isGithub ? "git_repo" : "git_repo_local_only", repo };
+  // Any remote → git_repo (the BRAIN clones from it; ls-remote polling is
+  // provider-agnostic, GitHub gets no special treatment here). No remote →
+  // local_only tier: still fully indexable — git treats a filesystem path as
+  // a remote, so the BRAIN clones from the path itself.
+  return { kind: remoteUrl ? "git_repo" : "git_repo_local_only", repo };
 }
 
 async function inspectContainer(containerPath: string, repoPaths: string[]): Promise<ContainerResult> {
@@ -489,14 +490,13 @@ export async function addSources(sources: AddSource[]): Promise<AddResult> {
     const name = (src as { name?: string }).name ?? "(unnamed)";
     try {
       if (src.type === "docs") {
-        // Docs always live on the local filesystem.
-        if (prod) throw new Error("local paths aren't available on a remote Flow — connect GitHub repos or upload files");
-        if (!src.path || !src.name) throw new Error("docs source needs a name and a path");
-        assertNameFree({ name: src.name, path: src.path });
-        registerSource({ kind: "docs", name: src.name, path: src.path, status: "pending_ingestion" });
-        auditSource("docs_registered", src.name, { path: src.path });
-        out.added.push({ name: src.name, kind: "docs" });
-        continue;
+        // Folders without git are not indexable: no commits means no stable
+        // identity, no diffs, and no change signal to hang knowledge off.
+        // The old "pending_ingestion" registration was a door to nowhere —
+        // nothing ever consumed it. Refuse honestly instead.
+        throw new Error(
+          "folders without a git repository can't be indexed — no commits means no change tracking. Initialize a git repo in it, or connect the repositories inside it.",
+        );
       }
 
       if (src.type === "repo") {
@@ -518,14 +518,16 @@ export async function addSources(sources: AddSource[]): Promise<AddResult> {
         }
 
         if (localPath) {
-          // Local-only (no remote) repo — index in place from the user's
-          // folder (the local tier). runJob's ensureRepoClone resolves the
-          // localPath from the registry.
+          // No-remote local repo — the path IS the remote: the BRAIN clones
+          // from it and the poller ls-remotes it, exactly like a hosted repo.
+          // localPath doubles as the WORK surface for agent sessions.
           assertNameFree({ name: src.name, path: localPath });
-          registerSource({ kind: "code", name: src.name, url: "", localPath, branch: src.branch });
+          registerSource({ kind: "code", name: src.name, url: localPath, localPath, branch: src.branch });
+          const { watchRepo } = await import("./adapters/github.js");
+          watchRepo(localPath, src.branch);
           const job = await enqueueJob({
             type: "index_repo",
-            input: { repo: src.name, branch: src.branch },
+            input: { repo: src.name, url: localPath, branch: src.branch },
             repo: src.name,
           });
           auditSource("index_job", src.name, { job: job.id, branch: src.branch, localPath: true });

--- a/orchestrator/src/work-folders.ts
+++ b/orchestrator/src/work-folders.ts
@@ -1,0 +1,50 @@
+// work-folders.ts — per-user WORK surfaces: the local checkouts where agent
+// sessions run. Deliberately SEPARATE from repos.json (the project-global
+// list of indexable sources): on a shared deployment (Flow on EC2, agents on
+// each user's machine) one user's local paths must never appear in another
+// user's dashboard. Keyed by owner — the dashboard session user in prod,
+// "local" in local mode.
+
+import { db } from "./db.js";
+import { listWorkspaceRepos } from "./opencode.js";
+
+export interface WorkFolder {
+  owner: string;
+  path: string;
+  repo: string | null; // optional hint: which source this folder is a checkout of
+  added_at: number;
+}
+
+const insertFolder = db.prepare(`
+  INSERT INTO work_folders (owner, path, repo)
+  VALUES (@owner, @path, @repo)
+  ON CONFLICT(owner, path) DO UPDATE SET repo = COALESCE(excluded.repo, work_folders.repo)
+`);
+
+export function addWorkFolder(owner: string, path: string, repo?: string): void {
+  insertFolder.run({ owner, path, repo: repo ?? null });
+}
+
+export function listWorkFolders(owner: string): WorkFolder[] {
+  return db
+    .prepare(`SELECT owner, path, repo, added_at FROM work_folders WHERE owner = ? ORDER BY added_at DESC`)
+    .all(owner) as WorkFolder[];
+}
+
+export function removeWorkFolder(owner: string, path: string): void {
+  db.prepare(`DELETE FROM work_folders WHERE owner = ? AND path = ?`).run(owner, path);
+}
+
+// One-time seed: registry entries that carried a localPath (the old
+// project-global WORK surface) become the "local" owner's folders, so
+// existing local-mode setups keep their in-place sessions. Idempotent.
+export function seedWorkFoldersFromRegistry(): void {
+  for (const r of listWorkspaceRepos()) {
+    if (r.kind === "docs" || !r.localPath) continue;
+    try {
+      addWorkFolder("local", r.localPath, r.name);
+    } catch {
+      /* seed is best-effort */
+    }
+  }
+}

--- a/orchestrator/test/change-branch.test.ts
+++ b/orchestrator/test/change-branch.test.ts
@@ -5,7 +5,7 @@
 // creates the remote-tracking ref and every reindex after a branch change
 // fails until the clone dir is deleted by hand.
 
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
@@ -62,5 +62,53 @@ describe("change_branch survives single-branch clones", () => {
 
     // The checkout now sits on origin/dev's tip (the "two" commit).
     assert.equal(sh(`git log -1 --format=%s`, clone), "two");
+  });
+});
+
+describe("path-as-remote: local repos ride the clone machinery", () => {
+  let ensureRepoClone: (entry: { name: string; url?: string; branch?: string }) => Promise<string>;
+  let refreshRepoCheckout: (name: string, branch: string) => Promise<void>;
+  let src: string;
+
+  before(async () => {
+    ({ ensureRepoClone, refreshRepoCheckout } = await import("../src/opencode.js"));
+    // A no-remote local repo — the user's own project folder.
+    src = join(workspace, "local-src");
+    execSync(`git init -q -b main ${src}`, { env: { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null" } });
+    sh(`git config user.email t@t && git config user.name t`, src);
+    writeFileSync(join(src, "code.txt"), "v1\n");
+    sh(`git add . && git commit -qm v1`, src);
+  });
+
+  test("clones from a filesystem path exactly like a remote, then tracks new commits", async () => {
+    const dest = await ensureRepoClone({ name: "local-src", url: src, branch: "main" });
+    // A real clone, not a symlink — committed state only.
+    assert.equal(sh(`git rev-parse --is-inside-work-tree`, dest), "true");
+    assert.throws(() => execSync(`test -L ${dest}`));
+    assert.equal(sh(`git log -1 --format=%s`, dest), "v1");
+
+    // New commit in the user's folder → refresh picks it up via fetch/reset.
+    writeFileSync(join(src, "code.txt"), "v2\n");
+    sh(`git add . && git commit -qm v2`, src);
+    await refreshRepoCheckout("local-src", "main");
+    assert.equal(sh(`git log -1 --format=%s`, dest), "v2");
+  });
+
+  test("legacy symlinked checkout migrates to a clone and self-heals the registry url", async () => {
+    const { symlinkSync } = await import("node:fs");
+    symlinkSync(src, join(workspace, "repos", "legacy"));
+    writeFileSync(
+      join(workspace, "repos.json"),
+      JSON.stringify({ repos: [{ name: "legacy", url: "", localPath: src, branch: "main" }] }),
+    );
+
+    const dest = await ensureRepoClone({ name: "legacy", branch: "main" });
+
+    assert.throws(() => execSync(`test -L ${dest}`), "symlink replaced by a real clone");
+    assert.equal(sh(`git log -1 --format=%s`, dest), "v2");
+    const registry = JSON.parse(readFileSync(join(workspace, "repos.json"), "utf8")) as {
+      repos: { url: string }[];
+    };
+    assert.equal(registry.repos[0].url, src);
   });
 });

--- a/orchestrator/test/index-incremental.test.ts
+++ b/orchestrator/test/index-incremental.test.ts
@@ -4,7 +4,7 @@
 // surprising (first index, branch change, up-to-date) falls back to null =
 // full pass.
 
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
@@ -77,5 +77,35 @@ describe("incremental index decision", () => {
     const registry = { repos: [{ name: "inc-repo", url: "x", branch: "main", lastIndexedCommit: "0".repeat(40) }] };
     writeFileSync(join(workspace, "repos.json"), JSON.stringify(registry));
     assert.equal(incrementalContext("inc-repo", "main"), null);
+  });
+
+  test("symlinked local repo records commit + timestamp after a successful index", async () => {
+    // The local tier materializes repos/<name> as a symlink to the user's own
+    // checkout. HEAD must resolve THROUGH the link, or the repo shows "never
+    // indexed" forever despite successful runs (the orbit-package bug).
+    const target = join(workspace, "user-checkout");
+    execSync(`git init -q -b main ${target}`, { env: gitEnv });
+    sh(`git config user.email t@t && git config user.name t`, target);
+    writeFileSync(join(target, "pkg.txt"), "local\n");
+    sh(`git add . && git commit -qm local`, target);
+    const targetHead = sh(`git rev-parse HEAD`, target);
+    symlinkSync(target, join(workspace, "repos", "linked-pkg"));
+
+    const registry = {
+      repos: [{ name: "linked-pkg", url: "", branch: "main", localPath: target, lastIndexedCommit: null }],
+    };
+    writeFileSync(join(workspace, "repos.json"), JSON.stringify(registry));
+
+    const { enqueueJob, getJob, listWorkspaceRepos } = await import("../src/opencode.js");
+    const job = await enqueueJob({ type: "index_repo", input: { repo: "linked-pkg", branch: "main" } });
+    const deadline = Date.now() + 5000;
+    while (getJob(job.id)?.status !== "done") {
+      if (Date.now() > deadline) throw new Error("index job did not finish");
+      await new Promise((r) => setTimeout(r, 10));
+    }
+
+    const entry = listWorkspaceRepos().find((r) => r.name === "linked-pkg");
+    assert.equal(entry?.lastIndexedCommit, targetHead);
+    assert.ok(entry?.lastIndexedAt);
   });
 });

--- a/orchestrator/test/sources.test.ts
+++ b/orchestrator/test/sources.test.ts
@@ -117,12 +117,20 @@ describe("inspectSource", () => {
     assert.equal(r.repo.remoteUrl, null);
   });
 
-  test("git_repo_local_only — non-GitHub remote keeps url for display", async () => {
+  test("git_repo — any remote counts, not just GitHub (ls-remote is provider-agnostic)", async () => {
     const dir = join(TMP, "gitlab-repo");
     gitInit(dir, "https://gitlab.com/acme/tool.git");
     const r = await inspectSource(dir);
-    assert.equal(r.kind, "git_repo_local_only");
+    assert.equal(r.kind, "git_repo");
     assert.equal(r.repo.remoteUrl, "https://gitlab.com/acme/tool");
+  });
+
+  test("git_repo_local_only — no remote at all (the path becomes the clone source)", async () => {
+    const dir = join(TMP, "noremote-repo");
+    gitInit(dir);
+    const r = await inspectSource(dir);
+    assert.equal(r.kind, "git_repo_local_only");
+    assert.equal(r.repo.remoteUrl, null);
   });
 
   test("folder — junk-defended docs counts", async () => {
@@ -277,20 +285,28 @@ describe("already-connected identity + name collisions", () => {
   });
 
   test("add refuses a name collision with a different source", async () => {
-    const docsDir = join(TMP, "col-docs");
-    mkdirSync(docsDir, { recursive: true });
-    const r = await addSources([{ type: "docs", path: docsDir, name: "colwidgets" }]);
+    const repoDir = join(TMP, "col-repo");
+    gitInit(repoDir);
+    const r = await addSources([{ type: "repo", localPath: repoDir, name: "colwidgets", branch: "main" }]);
     assert.equal(r.added.length, 0);
     assert.equal(r.errors.length, 1);
     assert.match(r.errors[0].error, /already connected/);
   });
 
   test("re-adding the same identity is a harmless update, not an error", async () => {
-    const docsDir = join(TMP, "col-notes");
-    mkdirSync(docsDir, { recursive: true });
-    registerSource({ kind: "docs", name: "col-notes", path: docsDir, status: "pending_ingestion" });
-    const r = await addSources([{ type: "docs", path: docsDir, name: "col-notes" }]);
+    const repoDir = join(TMP, "col-notes");
+    gitInit(repoDir);
+    registerSource({ kind: "code", name: "col-notes", url: repoDir, localPath: repoDir, branch: "main" });
+    const r = await addSources([{ type: "repo", localPath: repoDir, name: "col-notes", branch: "main" }]);
     assert.equal(r.errors.length, 0);
     assert.equal(r.added.length, 1);
+  });
+
+  test("non-git folders are refused — no commits, no change tracking", async () => {
+    const docsDir = join(TMP, "plain-folder");
+    mkdirSync(docsDir, { recursive: true });
+    const r = await addSources([{ type: "docs", path: docsDir, name: "plain-folder" }]);
+    assert.equal(r.added.length, 0);
+    assert.match(r.errors[0].error, /can't be indexed/);
   });
 });

--- a/orchestrator/test/work-folders.test.ts
+++ b/orchestrator/test/work-folders.test.ts
@@ -1,0 +1,83 @@
+// work-folders.test.ts — per-user WORK surfaces: folders are scoped to their
+// owner (no cross-user leakage on shared deployments), re-registration is
+// idempotent, and the registry seed maps legacy localPath entries to the
+// "local" owner.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Setup: workspace + in-memory DB before any imports that touch db
+const workspace = mkdtempSync(join(tmpdir(), "flow-work-folders-"));
+process.env.OPENCODE_WORKSPACE_DIR = workspace;
+process.env.DB_PATH = ":memory:";
+process.env.FLOW_ADMIN_TOKEN = "test-token-work-folders";
+process.env.FLOW_FAKE_OPENCODE = "1";
+process.env.FLOW_DRAIN_DISABLE = "1";
+
+import { test, describe, before, after } from "node:test";
+import assert from "node:assert/strict";
+
+let addWorkFolder: (owner: string, path: string, repo?: string) => void;
+let listWorkFolders: (owner: string) => { owner: string; path: string; repo: string | null }[];
+let removeWorkFolder: (owner: string, path: string) => void;
+let seedWorkFoldersFromRegistry: () => void;
+
+before(async () => {
+  ({ addWorkFolder, listWorkFolders, removeWorkFolder, seedWorkFoldersFromRegistry } = await import(
+    "../src/work-folders.js"
+  ));
+});
+
+after(() => rmSync(workspace, { recursive: true, force: true }));
+
+describe("per-user work folders", () => {
+  test("folders are scoped to their owner — no cross-user leakage", () => {
+    addWorkFolder("samyak@pixelapps.io", "/Users/samyak/code/orbit-api", "orbit-api");
+    addWorkFolder("teammate@pixelapps.io", "/home/teammate/orbit-api", "orbit-api");
+
+    const mine = listWorkFolders("samyak@pixelapps.io");
+    assert.equal(mine.length, 1);
+    assert.equal(mine[0].path, "/Users/samyak/code/orbit-api");
+    // The teammate's dashboard never sees my paths, and vice versa.
+    const theirs = listWorkFolders("teammate@pixelapps.io");
+    assert.equal(theirs.length, 1);
+    assert.equal(theirs[0].path, "/home/teammate/orbit-api");
+  });
+
+  test("re-registration is idempotent and fills the repo hint", () => {
+    addWorkFolder("u1", "/tmp/checkout");
+    addWorkFolder("u1", "/tmp/checkout", "web");
+    const folders = listWorkFolders("u1");
+    assert.equal(folders.length, 1);
+    assert.equal(folders[0].repo, "web");
+  });
+
+  test("remove deletes only the owner's entry", () => {
+    addWorkFolder("u2", "/tmp/shared-path");
+    addWorkFolder("u3", "/tmp/shared-path");
+    removeWorkFolder("u2", "/tmp/shared-path");
+    assert.equal(listWorkFolders("u2").length, 0);
+    assert.equal(listWorkFolders("u3").length, 1);
+  });
+
+  test("seed maps legacy registry localPath entries to the 'local' owner", () => {
+    writeFileSync(
+      join(workspace, "repos.json"),
+      JSON.stringify({
+        repos: [
+          { name: "app", url: "https://github.com/acme/app", localPath: "/Users/x/app", branch: "main" },
+          { name: "no-checkout", url: "https://github.com/acme/no-checkout", branch: "main" },
+        ],
+      }),
+    );
+    seedWorkFoldersFromRegistry();
+    const local = listWorkFolders("local");
+    assert.equal(local.length, 1);
+    assert.equal(local[0].path, "/Users/x/app");
+    assert.equal(local[0].repo, "app");
+    // Idempotent on re-seed.
+    seedWorkFoldersFromRegistry();
+    assert.equal(listWorkFolders("local").length, 1);
+  });
+});


### PR DESCRIPTION
repoHeadCommit skipped symlinks, so a local-only repo (repos/<name> is a symlink to the user's checkout) never got lastIndexedCommit/lastIndexedAt after a successful index — the dashboard showed no 'indexed X ago' and the status machine reported never_indexed forever. HEAD now resolves through the link (the target is exactly what the indexer read), and lastIndexedAt is stamped even when no commit resolves (non-git docs folders), so a successful index is never invisible. Status derivation and the dashboard fallback accept either field as proof.