### PR TITLE
remove(sources): drop default-branch drift warning

### DIFF
--- a/dashboard/src/components/SourcesFrontDoor.tsx
+++ b/dashboard/src/components/SourcesFrontDoor.tsx
@@ -39,7 +39,6 @@ export interface RepoStatusEntry {
   lastIndexedCommit: string | null;
   lastIndexedAt: string | null;
   lastError: string | null;
-  upstreamDefaultBranch?: string;
 }
 
 // One row of the durable indexer trail (GET /api/index-log).
@@ -348,15 +347,6 @@ function SourceRow({ s, st, onChanged }: { s: SourceEntry; st?: RepoStatusEntry;
               indexed {timeAgo(s.lastIndexedAt)}
             </span>
           ) : null}
-          {st?.upstreamDefaultBranch && (
-            <span
-              style={{ fontFamily: "var(--font-mono)" }}
-              className="text-[10px] text-text-muted flex-shrink-0"
-              title={`GitHub's default branch is now ${st.upstreamDefaultBranch}; Flow still indexes ${st.branch}. Change the branch if you want to follow it.`}
-            >
-              ⚠ default → {st.upstreamDefaultBranch}
-            </span>
-          )}
         </div>
         <div className="flex items-center gap-2 flex-shrink-0">
           <span

--- a/orchestrator/src/index.ts
+++ b/orchestrator/src/index.ts
@@ -8,7 +8,7 @@ import { registerOutboxRoutes } from "./outbox-routes.js";
 import { registerPolicyRoutes } from "./policy.js";
 import { registerCorpusRoutes } from "./corpus.js";
 import db from "./db.js";
-import { getJob, enqueueJob, recoverStalledJobs, killRunningJobChildren, repoStatuses, checkDefaultBranchDrift } from "./opencode.js";
+import { getJob, enqueueJob, recoverStalledJobs, killRunningJobChildren, repoStatuses } from "./opencode.js";
 import { activityForRepo } from "./job-activity.js";
 import { readIndexLog } from "./index-log.js";
 import { registerLinearWebhook, registerLinearPoller } from "./adapters/linear.js";
@@ -281,14 +281,6 @@ const start = async (): Promise<void> => {
 
     // Start all registered pollers (no-ops if FLOW_POLL_DISABLE=1)
     startAllPollers();
-
-    // Default-branch drift check: shortly after boot, then daily. Records
-    // drift on the registry entry (never auto-switches); the dashboard shows
-    // "default → <branch>" so a human can decide. Skipped in tests.
-    if (!process.env.FLOW_FAKE_OPENCODE && process.env.FLOW_POLL_DISABLE !== "1") {
-      setTimeout(() => void checkDefaultBranchDrift(), 30_000);
-      setInterval(() => void checkDefaultBranchDrift(), 24 * 60 * 60 * 1000);
-    }
 
     // Boot Slack Socket Mode adapter (no-op if tokens absent)
     bootSlackAdapter().catch((err) =>

--- a/orchestrator/src/opencode.ts
+++ b/orchestrator/src/opencode.ts
@@ -134,9 +134,6 @@ export interface RepoEntry {
   lastIndexedCommit?: string | null;
   lastIndexedAt?: string;
   addedAt?: string;
-  // Set by the drift check when GitHub's default branch no longer matches
-  // `branch` — surfaced in /v1/repos/status so a human can decide to switch.
-  upstreamDefaultBranch?: string;
   // Sources front door. A source plays up to two roles: BRAIN (indexed) and
   // WORK (where coding-agent sessions run). `kind` distinguishes an indexed
   // CODE repo from a DOCS folder; absent = code (back-compat with old rows).
@@ -336,7 +333,6 @@ export interface RepoStatus {
   lastError: string | null;
   runningJobId: string | null;
   queuedJobId: string | null;
-  upstreamDefaultBranch?: string;
 }
 
 export function repoStatuses(): RepoStatus[] {
@@ -377,7 +373,6 @@ export function repoStatuses(): RepoStatus[] {
       lastError,
       runningJobId: running,
       queuedJobId: parked,
-      ...(entry.upstreamDefaultBranch ? { upstreamDefaultBranch: entry.upstreamDefaultBranch } : {}),
     };
   });
 }
@@ -415,35 +410,6 @@ async function stampRepoNode(name: string, branch: string, head: string | null):
   }
 }
 
-// Default-branch drift: GitHub's default branch can change (main → dev) after
-// a repo is connected, and nothing else would ever notice — the poller keeps
-// watching the registered branch and the graph quietly goes stale against the
-// real default. This check (boot + daily) records the drift on the registry
-// entry so /v1/repos/status and the dashboard can surface "default → dev".
-// It NEVER auto-switches: changing the indexed branch is a human decision.
-export async function checkDefaultBranchDrift(): Promise<void> {
-  const { githubDefaultBranch } = await import("./repo-branch.js");
-  for (const entry of listWorkspaceRepos()) {
-    if (!entry.url || entry.kind === "docs") continue;
-    const upstream = await githubDefaultBranch(entry.url);
-    if (!upstream) continue; // API unreachable — keep whatever we knew
-    const registry = readRepoRegistry();
-    const current = registry.repos.find((r) => r.name === entry.name);
-    if (!current) continue;
-    if (upstream !== current.branch && current.upstreamDefaultBranch !== upstream) {
-      current.upstreamDefaultBranch = upstream;
-      writeFileSync(reposJsonPath(), JSON.stringify(registry, null, 2));
-      indexLog(entry.name, "watch", undefined, {
-        upstream_default: upstream,
-        indexing: current.branch,
-        note: "default branch drift — switch via change_branch if intended",
-      });
-    } else if (upstream === current.branch && current.upstreamDefaultBranch) {
-      delete current.upstreamDefaultBranch;
-      writeFileSync(reposJsonPath(), JSON.stringify(registry, null, 2));
-    }
-  }
-}
 
 // Full-pass vs incremental: after a push, if the last indexed commit is an
 // ancestor of the refreshed HEAD (same branch, no history rewrite) and the


### PR DESCRIPTION
## What

Removes the "⚠ default → <branch>" chip from the source card, along with all the machinery behind it:

- **Dashboard** (`SourcesFrontDoor.tsx`): the chip and the `upstreamDefaultBranch` field on `RepoStatusEntry`.
- **Orchestrator** (`opencode.ts`): `checkDefaultBranchDrift()`, plus `upstreamDefaultBranch` on `RepoEntry`, `RepoStatus`, and the status passthrough.
- **Orchestrator** (`index.ts`): the boot + daily drift-check scheduling.

`githubDefaultBranch()` in `repo-branch.ts` is untouched — it still resolves the default branch when a repo is first connected.

## Why

The chip warned when GitHub's default branch differed from the branch the user chose to index. But the user picked that branch deliberately — flagging the mismatch second-guesses an explicit choice, and the `default → main` phrasing read as cryptic/alarming rather than helpful.

Stale `upstreamDefaultBranch` keys left in existing `repos.json` files are harmless — nothing reads them anymore.