### PR TITLE
feat(agents): BRAIN/WORK separation — managed clones are never work surfaces

### DIFF
--- a/dashboard/src/app/api/agents/repos/files/route.ts
+++ b/dashboard/src/app/api/agents/repos/files/route.ts
@@ -1,18 +1,24 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getSessionToken } from "@/lib/auth";
+import { currentUser, getSessionToken } from "@/lib/auth";
 import { orcFetch } from "@/lib/orchestrator";
 
-// GET /api/agents/repos/files?repo=&q= — @mention autocomplete before a
-// session exists (the "start a new session" composer).
+// GET /api/agents/repos/files?repo=&q=&folder= — @mention autocomplete before
+// a session exists (the "start a new session" composer). `folder` scopes the
+// listing to one of the CURRENT USER's work folders (owner resolved
+// server-side, same as /api/agents).
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const token = await getSessionToken();
   if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const repo = req.nextUrl.searchParams.get("repo") ?? "";
   const q = req.nextUrl.searchParams.get("q") ?? "";
+  const folder = req.nextUrl.searchParams.get("folder") ?? "";
   if (!repo) return NextResponse.json({ error: "repo required" }, { status: 400 });
   try {
+    const user = await currentUser();
+    const owner = user?.email ?? "local";
     const res = await orcFetch(
-      `/v1/agents/repos/files?repo=${encodeURIComponent(repo)}&q=${encodeURIComponent(q)}`,
+      `/v1/agents/repos/files?repo=${encodeURIComponent(repo)}&q=${encodeURIComponent(q)}` +
+        (folder ? `&folder=${encodeURIComponent(folder)}&owner=${encodeURIComponent(owner)}` : ""),
       token
     );
     return NextResponse.json(await res.json(), { status: res.status });

--- a/dashboard/src/components/AgentsView.tsx
+++ b/dashboard/src/components/AgentsView.tsx
@@ -21,6 +21,10 @@ interface DetectedAgent {
 interface RepoOption {
   name: string;
   cloned: boolean;
+  // "folder" = the user connected their own checkout (it's the automatic work
+  // surface). "managed" = GitHub-added, index-only: sessions need one of the
+  // user's own folders.
+  surface?: "folder" | "managed";
 }
 interface SessionRow {
   id: string;
@@ -84,9 +88,10 @@ export function AgentsView() {
 
   const [backend, setBackend] = useState("");
   const [repo, setRepo] = useState("");
-  // Work folder: "" = the repo's default surface (Flow's managed clone or the
-  // registered checkout). A picked folder means "use this repo's knowledge,
-  // but make the changes over THERE" — folders are per-user, never shared.
+  // Work folder: "" = the folder the user connected as the source (only valid
+  // for folder-connected repos). GitHub-added repos are index-only — Flow's
+  // internal clone is never a work surface, so those require picking one of
+  // YOUR folders here. Folders are per-user, never shared.
   const [workFolders, setWorkFolders] = useState<{ path: string; repo: string | null }[]>([]);
   const [workFolder, setWorkFolder] = useState("");
   const [newFolderPath, setNewFolderPath] = useState("");
@@ -122,14 +127,30 @@ export function AgentsView() {
     return () => clearInterval(iv);
   }, [refresh]);
 
+  // GitHub-added repos are index-only: no default surface, a work folder is
+  // required. Folder-connected repos carry their own surface (the folder the
+  // user picked as the source).
+  const needsFolder = repos.find((r) => r.name === repo)?.surface === "managed";
+
+  // Switching to a GitHub-added repo: auto-pick the user's folder that was
+  // registered against it, if there is one — never leave "" meaning nothing.
+  useEffect(() => {
+    if (needsFolder && !workFolder) {
+      const match = workFolders.find((f) => f.repo === repo);
+      if (match) setWorkFolder(match.path);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [repo, needsFolder, workFolders]);
+
   const fetchFiles = useCallback(
     (q: string) => {
       if (!repo) return Promise.resolve([]);
-      return fetch(prefix(`/api/agents/repos/files?repo=${encodeURIComponent(repo)}&q=${encodeURIComponent(q)}`))
+      const folder = workFolder ? `&folder=${encodeURIComponent(workFolder)}` : "";
+      return fetch(prefix(`/api/agents/repos/files?repo=${encodeURIComponent(repo)}&q=${encodeURIComponent(q)}${folder}`))
         .then((r) => (r.ok ? r.json() : { entries: [] }))
         .then((d: { entries?: FileEntry[] }) => d.entries ?? []);
     },
-    [repo, prefix]
+    [repo, workFolder, prefix]
   );
 
   // `placement` is passed only after the user answers a collision prompt:
@@ -237,8 +258,9 @@ export function AgentsView() {
             ))}
           </select>
           {/* Work folder — YOUR checkouts (per-user, never a teammate's paths).
-              Default = the repo's own surface; picking a folder means "use this
-              repo's knowledge, but make the changes over there". */}
+              Folder-connected repos default to the folder the user picked as
+              the source. GitHub-added repos have no default — Flow only
+              indexes them, so one of your folders must be chosen. */}
           <select
             value={workFolder}
             onChange={(e) => setWorkFolder(e.target.value)}
@@ -247,7 +269,13 @@ export function AgentsView() {
             data-testid="work-folder-select"
             title="Where the agent makes its changes — your folders, on your machine"
           >
-            <option value="">work in: {repo || "repo"} (default)</option>
+            {needsFolder ? (
+              <option value="" disabled>
+                pick a folder to work in…
+              </option>
+            ) : (
+              <option value="">work in: {repo || "repo"} (your connected folder)</option>
+            )}
             {workFolders.map((f) => (
               <option key={f.path} value={f.path}>
                 work in: {f.path}
@@ -301,6 +329,12 @@ export function AgentsView() {
           rows={3}
           className="w-full rounded-lg border border-line bg-cream px-3.5 py-3 text-[14px] text-ink placeholder:text-text-muted/60 focus:outline-none focus:border-black/20 resize-y mb-3"
         />
+        {needsFolder && !workFolder && (
+          <p className="text-[12px] text-text-muted mb-3">
+            {repo} came from GitHub, so Flow only indexes it. Pick one of your folders above (or add
+            one) — that&apos;s where the agent will work.
+          </p>
+        )}
         {error && <p className="text-[12px] mb-3" style={{ color: "#b3261e" }}>{error}</p>}
 
         {/* Collision prompt — another live session is already working in this
@@ -333,7 +367,11 @@ export function AgentsView() {
             </div>
           </div>
         ) : (
-          <Button onClick={() => start()} disabled={starting || !prompt.trim() || !backend || !repo} arrow>
+          <Button
+            onClick={() => start()}
+            disabled={starting || !prompt.trim() || !backend || !repo || (needsFolder && !workFolder)}
+            arrow
+          >
             {starting ? "Starting…" : "Start agent"}
           </Button>
         )}

--- a/orchestrator/src/agents/routes.ts
+++ b/orchestrator/src/agents/routes.ts
@@ -290,10 +290,21 @@ export function registerAgentRoutes(app: FastifyInstance): void {
   });
 
   // Same, for the "start a new session" composer (no session id yet).
+  // `folder` narrows the listing to a work folder the requesting owner
+  // registered — same vouching rule as session creation.
   app.get("/v1/agents/repos/files", async (req, reply) => {
-    const { repo, q } = req.query as { repo?: string; q?: string };
+    const { repo, q, folder, owner } = req.query as { repo?: string; q?: string; folder?: string; owner?: string };
     if (!repo) return reply.code(400).send({ error: "repo required" });
-    const r = await listRepoFiles(repo, q ?? "");
+    let dir: string | undefined;
+    if (folder?.trim()) {
+      const { listWorkFolders } = await import("../work-folders.js");
+      const wanted = folder.trim();
+      if (!listWorkFolders(owner?.trim() || "local").some((f) => f.path === wanted)) {
+        return reply.code(400).send({ error: "folder is not registered for this user" });
+      }
+      dir = wanted;
+    }
+    const r = await listRepoFiles(repo, q ?? "", 40, dir);
     if ("error" in r) return reply.code(404).send(r);
     return r;
   });

--- a/orchestrator/src/agents/runtime.ts
+++ b/orchestrator/src/agents/runtime.ts
@@ -348,6 +348,12 @@ export interface RepoOption {
   // The repo's registered base branch (repos.json `branch`) — the BASE-scope
   // diff resolves against this. Undefined for entries that never recorded one.
   branch?: string;
+  // Whether sessions may run at `path`. "folder" = the user connected their
+  // own checkout, so it doubles as the WORK surface. "managed" = GitHub-added:
+  // `path` is Flow's BRAIN clone, kept for indexing and git metadata (branch
+  // lists) only — sessions never run there and never browse its files; they
+  // need an explicit per-user work folder.
+  surface: "folder" | "managed";
 }
 
 export function listRepoOptions(): RepoOption[] {
@@ -367,11 +373,11 @@ export function listRepoOptions(): RepoOption[] {
         // run in-place there (the in-place default) rather than in Flow's
         // managed clone.
         if (r.localPath && existsSync(r.localPath)) {
-          out.push({ name: r.name, path: r.localPath, cloned: true, branch });
+          out.push({ name: r.name, path: r.localPath, cloned: true, branch, surface: "folder" });
           continue;
         }
         const p = path.join(reposDir, r.name);
-        out.push({ name: r.name, path: p, cloned: existsSync(p), branch });
+        out.push({ name: r.name, path: p, cloned: existsSync(p), branch, surface: "managed" });
       }
     } catch {
       /* empty list */
@@ -1162,6 +1168,14 @@ export async function createSession(opts: {
   const found = listRepoOptions().find((r) => r.name === opts.repo);
   if (!found) return { error: `Unknown repo "${opts.repo}" — connect it first` };
   if (!found.cloned && !opts.workFolder) return { error: `Repo "${opts.repo}" is not cloned yet` };
+  // BRAIN/WORK separation: a GitHub-added repo's only checkout is Flow's
+  // managed clone, which the indexer force-resets at will — never a place to
+  // run agents. Sessions over these repos require an explicit work folder.
+  if (found.surface === "managed" && !opts.workFolder) {
+    return {
+      error: `"${opts.repo}" was connected from GitHub, so Flow only indexes it. Pick one of your folders to run the agent in.`,
+    };
+  }
   let repoOpt = found;
   if (opts.workFolder) {
     if (!existsSync(opts.workFolder)) {
@@ -1766,11 +1780,18 @@ export async function listSessionFiles(
 export async function listRepoFiles(
   repo: string,
   query: string,
-  limit = 40
+  limit = 40,
+  dir?: string
 ): Promise<{ entries: FileEntry[] } | { error: string }> {
   const repoOpt = listRepoOptions().find((r) => r.name === repo);
   if (!repoOpt || !repoOpt.cloned) return { error: `Unknown repo "${repo}"` };
-  return { entries: await filesUnder(repoOpt.path, query, limit) };
+  // Autocomplete from where the session will actually run: the caller's work
+  // folder when one is chosen, else the user's connected folder. A managed
+  // (GitHub-only) repo has no browsable surface — the BRAIN clone is for
+  // indexing, not for peeking.
+  const root = dir ?? (repoOpt.surface === "folder" ? repoOpt.path : null);
+  if (!root) return { error: `"${repo}" is index-only — pick a work folder to browse its files` };
+  return { entries: await filesUnder(root, query, limit) };
 }
 
 // Open the session's repo folder in the OS file manager or VS Code. Local-mode


### PR DESCRIPTION
## What

Hard role separation between a source's BRAIN (what Flow indexes) and WORK (where agents run):

- **GitHub-added repos are index-only.** Flow's managed clone under `workspace/repos/` exists solely for the indexer — which force-resets it (`refreshRepoCheckout` → `git reset --hard`) on every run. Sessions can no longer run there, and the composer's @mention autocomplete no longer browses it.
- **Folder-connected sources are unchanged**: the folder the user picked *is* the work surface, auto-chosen. Flow may still keep an internal clone for indexing, but that stays invisible.
- To run agents over a GitHub-added repo, you pick (or add) one of your own folders — the door that already exists in the composer.

## Changes

- `runtime.ts`: `RepoOption.surface: "folder" | "managed"`. `createSession` refuses a managed repo without a work folder, with a clear message. `listRepoFiles` takes an optional dir and refuses to list a managed clone.
- `routes.ts`: `/v1/agents/repos/files` accepts `folder` (+`owner`), validated against the owner's registered work folders — same vouching rule as session creation.
- Dashboard: files proxy resolves owner server-side and forwards `folder`; the composer shows no "default surface" option for GitHub repos, auto-picks a folder registered against the repo, disables Start until one is chosen, and explains why.

## Why

Uncommitted agent work in a managed clone gets destroyed the moment the watched branch moves (fetch + hard reset before every index run — observed live today). Beyond data loss, the managed clone has no worktrees or env files, and users shouldn't be peeking into the index checkout at all: it's Flow's, not theirs.

## Testing

- Full orchestrator suite: 256/256 pass.
- Dashboard `tsc --noEmit` clean.