### PR TITLE
feat(memory): project-wide eligibility — repo affinity ranks, never gates

### DIFF
--- a/graph-gateway/src/verbs.ts
+++ b/graph-gateway/src/verbs.ts
@@ -957,7 +957,7 @@ const searchMemoryInput = {
   // call. At least one form is required; `query` wins when both are given.
   query: z.string().min(1).optional().describe("What to look up (single form). Works best with symptoms (verbatim error snippets), identifiers, command names, or file paths — like grep."),
   queries: z.array(z.string().min(1)).min(1).max(SEARCH_MEMORY_MAX_BATCH).optional().describe(`Several things to look up in one call (batch form, ≤${SEARCH_MEMORY_MAX_BATCH}) — prefer one batched call over sequential single searches. Results come back grouped per query.`),
-  repo: z.string().optional().describe("Repository name to scope to (defaults from the session's env). Cross-repo memories in the same product family are still eligible; unrelated repos are hard-filtered out."),
+  repo: z.string().optional().describe("Repository name for ranking (defaults from the session's env). Same-repo memories rank first, same-family next — but every memory in the project stays eligible; nothing is filtered out by repo."),
   limit: z.number().int().min(1).max(50).optional().describe("Max memories to return per query (default 8)."),
 };
 

--- a/orchestrator/src/memory/consolidate.ts
+++ b/orchestrator/src/memory/consolidate.ts
@@ -23,7 +23,7 @@ import {
   type ObservationRow,
   type MemoryRow,
   createMemory,
-  memoriesInFamily,
+  activeMemoryRows,
   updateMemory,
   attachObservation,
   recomputePeopleCount,
@@ -85,8 +85,12 @@ export function recomputeStrength(memoryId: string): MemoryRow {
 }
 
 export async function consolidateObservation(obs: ObservationRow, judge: Judge): Promise<ConsolidateResult> {
-  const candidates = memoriesInFamily(obs.repo_family);
-  const match = bestMatch(obs, candidates);
+  // Candidates are PROJECT-WIDE, not family-scoped: all repos in a project
+  // share memories (Samyak, 2026-07-19), so the same fact learned from two
+  // repos merges and strengthens instead of duplicating per family. The T_LO
+  // band + judge already own the same/new decision; widening candidates only
+  // adds cheap in-process cosine comparisons.
+  const match = bestMatch(obs, activeMemoryRows());
 
   // No candidate at all, or below T_LO → brand-new memory.
   if (!match || match.sim < T_LO) {

--- a/orchestrator/src/memory/find-hits.ts
+++ b/orchestrator/src/memory/find-hits.ts
@@ -6,7 +6,7 @@
 // MERGES memory hits into find_entity results by asking the orchestrator here.
 //
 // This REUSES search.ts's ranking/gating verbatim (meaningful-token FTS + the
-// 0.55 silence gate + family gate) — no forked logic. On top of it we apply the
+// 0.55 silence gate; repo affinity ranks, never gates) — no forked logic. On top of it we apply the
 // TYPE QUOTA: at most MEMORY_HIT_QUOTA memory hits per query UNLESS the caller
 // passed a type filter (a typed query is deliberately memory-first, so the quota
 // lifts). Batching (qs[]) works because it's just several single calls.

--- a/orchestrator/src/memory/repo-family.ts
+++ b/orchestrator/src/memory/repo-family.ts
@@ -1,12 +1,13 @@
 // repo-family.ts — normalize a repo name into its "family".
 //
-// Memory retrieval hard-gates on repo_family: a memory from `acme-backend` is
-// eligible for a query on `acme-frontend` (same product) but NOT for `other`.
-// We strip common component suffixes so the family is the product, not the tier.
-// Also strips owner prefix (owner/repo -> repo) and a trailing .git.
-//
-// A NULL/empty family means "match-all" (corpus rows we couldn't attribute to a
-// repo) — the gate treats null as matching every query's family.
+// repo_family is a RANKING affinity, not a gate: a memory from `acme-backend`
+// ranks above rest-of-project memories for a query from `acme-frontend` (same
+// product), but nothing in the project is ever filtered out — the project is
+// the trust boundary (one flow.db per project), so all repos share memories.
+// We strip common component suffixes so the family is the product, not the
+// tier. Also strips owner prefix (owner/repo -> repo) and a trailing .git.
+// A NULL/empty family (corpus rows we couldn't attribute to a repo) simply
+// earns no affinity boost.
 
 const SUFFIXES = [
   "backend",
@@ -45,12 +46,4 @@ export function repoFamily(repo: string | null | undefined): string | null {
     }
   }
   return name || null;
-}
-
-// Family gate: does a memory/observation with family `memFamily` match a query
-// scoped to `queryFamily`? Null on EITHER side means match-all (unattributed
-// corpus, or a query with no repo). Otherwise exact family equality.
-export function familyMatches(queryFamily: string | null, memFamily: string | null): boolean {
-  if (!queryFamily || !memFamily) return true;
-  return queryFamily === memFamily;
 }

--- a/orchestrator/src/memory/search.ts
+++ b/orchestrator/src/memory/search.ts
@@ -1,11 +1,16 @@
 // search.ts — retrieval for search_knowledge. Eval-calibrated ranking:
 //
-//   HARD GATE on repo_family mismatch — drop, never downweight. (null family on
-//     either side = match-all.)
+//   REPO AFFINITY IS RANK, NEVER A GATE (Samyak, 2026-07-19). The project is
+//     the trust boundary — one flow.db per project — and every memory in it is
+//     eligible from any repo's session. Same repo ranks first, same family
+//     next; nothing is invisible. (Supersedes the eval-era repo_family hard
+//     gate, which predates the meaningful-tokens FTS fix that closed the
+//     actual noise hole.)
 //   score = cosine
 //         + 0.15 * retrieval_keys_overlap
 //         + 0.10 * file_mention_overlap
 //         + 0.08 * same_repo_exact
+//         + 0.04 * same_family (sibling repo, e.g. acme-backend from acme-frontend)
 //   SILENCE GATE: drop results under ~0.55 cosine UNLESS they are an FTS5 exact
 //     hit. FTS candidates are ALWAYS eligible (identifiers/error strings are the
 //     reliable path); vector-only candidates must clear the cosine floor.
@@ -17,7 +22,7 @@
 import db from "../db.js";
 import { cosine, blobToVec } from "../embed.js";
 import { getEmbedder, memoryVectors, type MemoryRow } from "./store.js";
-import { repoFamily, familyMatches } from "./repo-family.js";
+import { repoFamily } from "./repo-family.js";
 import { strengthTier } from "./strength.js";
 import { searchCorpus } from "../corpus.js";
 import { itemsAnchoredToNode } from "./anchors.js";
@@ -263,9 +268,6 @@ export async function searchMemory(input: SearchInput): Promise<SearchResult> {
     // Node scope: drop memories not anchored to the node.
     if (nodeMemoryIds && !nodeMemoryIds.has(m.id)) continue;
 
-    // HARD family gate — drop, don't downweight.
-    if (!familyMatches(queryFamily, m.repo_family)) continue;
-
     const cos = cosById.get(m.id) ?? 0;
     const isFts = ftsIds.has(m.id);
     // Silence gate: vector-only candidates must clear the cosine floor; FTS
@@ -277,9 +279,12 @@ export async function searchMemory(input: SearchInput): Promise<SearchResult> {
     const keyOverlap = overlap(queryTokens, keys);
     const files = keys.filter((k) => k.includes("/") || k.includes("."));
     const fileOverlap = overlap(queryTokens, files);
+    // Repo affinity: rank, never gate — same repo first, family sibling next,
+    // rest of the project after. All eligible.
     const sameRepoExact = input.repo && m.repo && input.repo.toLowerCase() === m.repo.toLowerCase() ? 1 : 0;
+    const sameFamily = !sameRepoExact && queryFamily && m.repo_family && queryFamily === m.repo_family ? 1 : 0;
 
-    const score = cos + 0.15 * keyOverlap + 0.1 * fileOverlap + 0.08 * sameRepoExact;
+    const score = cos + 0.15 * keyOverlap + 0.1 * fileOverlap + 0.08 * sameRepoExact + 0.04 * sameFamily;
     hits.push({
       id: m.id,
       claim: m.claim,

--- a/orchestrator/src/memory/store.ts
+++ b/orchestrator/src/memory/store.ts
@@ -164,16 +164,6 @@ export function getMemory(id: string): MemoryRow | undefined {
   return db.prepare(`SELECT * FROM memories WHERE id = ?`).get(id) as MemoryRow | undefined;
 }
 
-export function memoriesInFamily(family: string | null): MemoryRow[] {
-  // family null (unattributed observation) → compare against all active memories.
-  if (family === null) {
-    return db.prepare(`SELECT * FROM memories WHERE status = 'active'`).all() as MemoryRow[];
-  }
-  return db
-    .prepare(`SELECT * FROM memories WHERE status = 'active' AND (repo_family = ? OR repo_family IS NULL)`)
-    .all(family) as MemoryRow[];
-}
-
 export function createMemory(o: ObservationRow): MemoryRow {
   const id = randomUUID();
   const now = Math.floor(Date.now() / 1000);

--- a/orchestrator/test/memory.test.ts
+++ b/orchestrator/test/memory.test.ts
@@ -182,12 +182,6 @@ describe("repo family", () => {
     assert.equal(repoFamily.repoFamily(null), null);
   });
 
-  test("family gate: null matches all; mismatch drops", () => {
-    assert.equal(repoFamily.familyMatches("acme", "acme"), true);
-    assert.equal(repoFamily.familyMatches("acme", "other"), false);
-    assert.equal(repoFamily.familyMatches(null, "acme"), true);
-    assert.equal(repoFamily.familyMatches("acme", null), true);
-  });
 });
 
 // ---------------------------------------------------------------------------
@@ -316,18 +310,19 @@ describe("search ranking", () => {
     return consolidate.consolidateObservation(o, judge);
   }
 
-  test("family hard gate drops cross-family memories", async () => {
+  test("repo affinity ranks — cross-repo memories stay eligible, same-family first", async () => {
+    // Two repos in one project learn about the same area. The project is the
+    // trust boundary: NOTHING is filtered by repo; family affinity only orders.
     await seed("payment webhooks are verified with an hmac signature", "acme-backend", ["hmac", "webhook"]);
-    await seed("payment webhooks are verified with an hmac signature", "other-repo", ["hmac", "webhook"]);
+    await seed("payment webhooks retry with exponential backoff", "other-repo", ["hmac", "webhook", "retry"]);
     store.setEmbedder(stubEmbedder);
     const res = await search.searchMemory({ query: "payment webhooks hmac signature verified", repo: "acme-frontend", limit: 10 });
-    // acme-frontend shares family "acme" with acme-backend, NOT with other-repo.
-    assert.ok(res.memories.length >= 1);
-    assert.ok(res.memories.every((m) => m.claim.includes("hmac")));
-    // Ensure the other-repo memory is absent: only acme-family survives the gate.
-    const ids = new Set(res.memories.map((m) => m.id));
-    const otherFamily = db.prepare("SELECT id FROM memories WHERE repo_family = 'other'").all() as Array<{ id: string }>;
-    for (const m of otherFamily) assert.ok(!ids.has(m.id), "other-family memory must be gated out");
+    const ids = res.memories.map((m) => m.id);
+    const acme = db.prepare("SELECT id FROM memories WHERE repo_family = 'acme' AND claim LIKE '%hmac%'").get() as { id: string };
+    const other = db.prepare("SELECT id FROM memories WHERE repo_family = 'other-repo'").get() as { id: string };
+    assert.ok(ids.includes(acme.id), "same-family memory surfaces");
+    assert.ok(ids.includes(other.id), "cross-repo memory must NOT be gated out — all repos in a project share memories");
+    assert.ok(ids.indexOf(acme.id) < ids.indexOf(other.id), "same-family ranks above rest-of-project");
   });
 
   test("silence gate drops weak vector-only hits", async () => {


### PR DESCRIPTION
All repos in a project share memories. The project is the trust boundary — one `flow.db` per project, physically separate stores — so gating retrieval *inside* a project walls the team's knowledge off from itself.

## Changes

- **Search**: the `repo_family` hard gate is gone. Repo affinity is now pure rank order: `+0.08` same repo, `+0.04` family sibling (`acme-backend` ↔ `acme-frontend`), rest-of-project at parity. Nothing is ever invisible; identifier/FTS matches cross repos at full strength (grep doesn't stop at repo boundaries).
- **Consolidation**: candidates widen from family-scoped to project-wide, so the same fact learned from two repos merges into one memory and *strengthens*, instead of duplicating per family. The T_LO band + LLM judge already own the same/new decision — widening only adds cheap in-process cosine comparisons.
- `familyMatches()` / `memoriesInFamily()` deleted; `repoFamily()` survives as the ranking-affinity key. `search_knowledge`'s `repo` description updated so the model knows scope means priority, not filtering.

## Why the eval-era gate is safe to drop

The hard gate ("drop, never downweight") was eval-backed, but it predates the meaningful-tokens FTS fix — the actual source of cross-repo noise was stopword FTS hits bypassing the silence gate, which is closed. Weak cross-repo cosine-only matches still die at the 0.55 silence floor. Worth a retrieval-eval re-run to confirm precision holds (the harness lives in flow-benchmarks/memory-evals/retrieval).

## Related

- `search_knowledge` being dead in Flow-run sessions ("FLOW_MEMORY_URL unset") is fixed by #41 (the env swap in `flowGraphMcp()`), not here — needs #41 merged + services restarted.
- Vector-search dimension mismatch (1536 stored vs 768 query) is being fixed separately by Samyak.

## Testing

Orchestrator 255/255 (gate test rewritten: cross-repo memory must surface AND rank below same-family), gateway 24/24.