### PR TITLE
test(settings): EMBEDDING_API_KEY belongs in the secret-keys allowlist

### DIFF
--- a/orchestrator/test/settings.test.ts
+++ b/orchestrator/test/settings.test.ts
@@ -100,6 +100,7 @@ describe("settings registry", () => {
     const secretKeys = new Set([
       "OPENROUTER_API_KEY",
       "LLM_API_KEY",
+      "EMBEDDING_API_KEY",
       "LINEAR_API_KEY",
       "FIREFLIES_API_KEY",
       "GITHUB_TOKEN",


### PR DESCRIPTION
One-line test fix: the embeddings settings work registered EMBEDDING_API_KEY as secret:true (correct — it's an API key) but the settings-registry test's allowlist wasn't updated, so the dev suite has been red since 00626f4. Test-only change; suite 21/21 after.