### PR TITLE
fix(memory): idle sweep never fired — ms vs seconds cutoff mismatch

### DIFF
--- a/orchestrator/src/memory/trigger.ts
+++ b/orchestrator/src/memory/trigger.ts
@@ -91,7 +91,11 @@ export function onSessionClosed(id: string, branch: string | null = null): void 
 // transcript content gets distilled. Runs on an interval; also callable directly.
 export async function idleSweep(now = Date.now()): Promise<number> {
   if (!distillerEnabled()) return 0;
-  const cutoff = Math.floor((now - IDLE_MS) / 1000);
+  // agent_sessions.updated_at is MILLISECONDS (runtime.ts writes Date.now()).
+  // The cutoff must be too — a /1000 here once made the comparison always
+  // false, so the sweep silently matched zero sessions and the distiller
+  // never fired on live deployments.
+  const cutoff = now - IDLE_MS;
   const rows = db
     .prepare(
       `SELECT id FROM agent_sessions

--- a/orchestrator/test/memory.test.ts
+++ b/orchestrator/test/memory.test.ts
@@ -629,6 +629,57 @@ describe("remember (active capture)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Distiller triggers — the idle sweep. Regression: agent_sessions.updated_at
+// is written in MILLISECONDS (runtime.ts uses Date.now()); the sweep's cutoff
+// once divided by 1000, so the ms-vs-seconds comparison was always false and
+// the sweep matched ZERO sessions — the distiller never fired on live
+// deployments. These tests insert rows exactly as the runtime does (ms).
+describe("distiller trigger: idle sweep", () => {
+  let trigger: typeof import("../src/memory/trigger.js");
+
+  before(async () => {
+    trigger = await import("../src/memory/trigger.js");
+    store.setEmbedder(stubEmbedder);
+    // memory.test.ts never imports runtime.ts (which owns this table), so
+    // create the columns the trigger touches, shaped like the real thing.
+    db.exec(`CREATE TABLE IF NOT EXISTS agent_sessions (
+      id TEXT PRIMARY KEY, backend TEXT, repo TEXT, cwd TEXT, title TEXT,
+      status TEXT, updated_at INTEGER, created_at INTEGER, last_distilled_seq INTEGER
+    )`);
+    trigger.setTranscriptReader(() => [
+      { seq: 1, kind: "user_prompt", data: { text: "Switch the auth flow to JWT stored in httpOnly cookies, not localStorage." } },
+      { seq: 2, kind: "update", data: { sessionUpdate: "agent_message_chunk", content: { text: "Done — JWT now lives in an httpOnly cookie." } } },
+    ]);
+  });
+
+  beforeEach(() => db.exec("DELETE FROM agent_sessions"));
+
+  test("sweeps an idle session whose updated_at (ms) is older than IDLE_MS", async () => {
+    llm.setLlmTransport(async () =>
+      JSON.stringify([
+        { claim: "Auth uses JWT in httpOnly cookies", kind: "decision", context: {}, source: "user_stated", retrieval_keys: ["jwt", "cookie"] },
+      ]),
+    );
+    const staleMs = Date.now() - trigger.IDLE_MS - 60_000; // ms, as runtime writes
+    db.prepare("INSERT INTO agent_sessions (id, backend, repo, cwd, title, status, created_at, updated_at) VALUES (?, 'claude', ?, '/tmp', 'test', ?, ?, ?)")
+      .run("sweep-1", "acme", "idle", staleMs, staleMs);
+    const ran = await trigger.idleSweep();
+    assert.equal(ran, 1, "the stale idle session must be swept (ms cutoff regression)");
+    const obs = db.prepare("SELECT * FROM observations WHERE session_id = 'sweep-1'").get() as any;
+    assert.ok(obs, "distilled observation should exist");
+    const meta = db.prepare("SELECT last_distilled_seq FROM agent_sessions WHERE id = 'sweep-1'").get() as any;
+    assert.equal(meta.last_distilled_seq, 2, "high-water mark advances to the max transcript seq");
+  });
+
+  test("leaves recently-active sessions alone", async () => {
+    db.prepare("INSERT INTO agent_sessions (id, backend, repo, cwd, title, status, created_at, updated_at) VALUES (?, 'claude', ?, '/tmp', 'test', ?, ?, ?)")
+      .run("sweep-2", "acme", "idle", Date.now(), Date.now());
+    const ran = await trigger.idleSweep();
+    assert.equal(ran, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Section A — anchor resolution. Deterministic file matching against a STUBBED
 // NodeAnchorProvider (no graph, no gateway). Covers: file match, most-specific
 // preference (endpoint over service), cap 3, idempotent re-resolve after a node


### PR DESCRIPTION
Found while investigating why the live store is empty (0 observations, 0 memories, zero distiller rows in llm_log, every session's last_distilled_seq NULL) despite the distiller shipping in #32.

**Root cause:** `agent_sessions.updated_at` is milliseconds (`Date.now()` in runtime.ts), but `idleSweep`'s cutoff was `(now - IDLE_MS) / 1000` — seconds. The comparison was false for every row, so the sweep matched zero sessions since ship. Dashboard sessions end at `idle` (the `closed` trigger never fires for them), so the sweep was the only path — passive capture has been silently dead on every live deployment.

**Fix:** cutoff stays in ms, with a comment anchoring the unit. Adds the first tests for the trigger: a regression inserting sessions with ms timestamps exactly as the runtime writes them (verified to FAIL on the old code) and a recent-session no-op check.

After merge + orchestrator restart, the 45-min sweep will start distilling the backlog of idle sessions.

Suite: memory 75/75; full orchestrator 259/260 (the one failure is the known-flaky poller cursor test — passes standalone).