### PR TITLE
feat(memory): orient docs — the ambient tier, an auto-authored AGENTS.md

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,6 +3,45 @@
 What's shipped, what's next. See `CHANGELOG.md` for dated change history and
 `docs/ARCHITECTURE.md` for the design.
 
+## Design record — memory v2 final form: distiller-only + orient docs (2026-07-18/19, Samyak — SUPERSEDES the 2026-07-10 three-lane consent model)
+
+The 07-10 record priced consent by blast radius across three lanes (procedures
+command / corrections mutate truth / notes color judgment). Dogfooding killed
+the first lane: agents classifying "is this a procedure?" produced junk
+proposals ("LLM gets confused about what is a procedure and creates random
+procedures"). Final form — ONE writer, the distiller; agents never classify:
+
+- **Branch notes: REMOVED** (PR #41). Observations carry {repo, branch,
+  session} mechanically, so a separate agent-authored note lane was redundant.
+- **`remember`: the one active-capture door** (PR #41). User says "remember
+  this" → the model sends text, nothing else. Instant ack, async distillation,
+  source_weight floors to user_stated, verbatim fallback so an explicit
+  remember is never lost. It feeds the pipeline, not the store.
+- **No repo gating inside a project** (PR #43). The project is the trust
+  boundary (one flow.db per project, physically separate). Within it, repo
+  affinity is RANK (+0.08 same repo, +0.04 family sibling), never eligibility;
+  consolidation candidates are project-wide so cross-repo repetition merges
+  and strengthens. Retrieval-eval re-run still owed to confirm precision.
+- **Orient docs: the ambient tier** (validated 2026-07-19 by rendering the doc
+  from the 47 real bench-store memories BEFORE building — Samyak approved the
+  page). One doc per scope ('global' + 'repo:<name>'), returned verbatim and
+  UNCAPPED by orient() — the auto-authored AGENTS.md (~10k tokens is fine;
+  supersedes the old ~1.5k orient cap). Mechanics: the distiller NOMINATES
+  (`ambient` flag per observation — cheap, recall-oriented); INCLUSION is
+  earned (user_stated fast-tracks; agent/error claims wait for evidence ≥ 2;
+  contradiction_count = 0 required — one contradiction evicts the line; kind
+  'plan' never enters). Membership is a DERIVED VIEW recomputed from the
+  memories table each rebuild — connect/disconnect happens by evidence, no
+  doc-editing machinery, memories stay primary. Render v1 is deterministic
+  (claims grouped by kind, each line carrying [mem:id] for drill-down); an
+  LLM prose-polish can replace the renderer later without touching membership.
+- **Procedures: to be REMOVED once orient docs are live** — the blessed
+  procedure migrates into the flow repo's orient doc, then the proposal verbs,
+  Procedure node type, inbox/retirement lanes, GOVERNS ambush, and insert-mode
+  injection all go. Until then agents must not use propose_procedure.
+- Unchanged: corrections lane (machine-verified, different problem), pull-only
+  retrieval, search_knowledge, anchoring, strength/decay.
+
 ## Notes & cautions — decided-for-now, revisit deliberately
 
 Concerns a human flagged as "keep this in mind" — not rules (procedures), not

--- a/graph-gateway/src/verbs.ts
+++ b/graph-gateway/src/verbs.ts
@@ -1057,6 +1057,27 @@ interface MemoryStats {
   bySource: Record<string, number>;
 }
 
+// The ambient tier: rendered orient docs (repo + global), served verbatim and
+// IN FULL — this is the auto-authored AGENTS.md, deliberately uncapped (the
+// curation happened at write time; nothing here is ranked at read time).
+async function fetchOrientDocs(repo: string): Promise<{ global: string | null; repo: string | null } | null> {
+  const url =
+    process.env.FLOW_MEMORY_URL?.replace(/\/search$/, "/orient-doc") ||
+    (process.env.ORCHESTRATOR_URL ? `${process.env.ORCHESTRATOR_URL.replace(/\/$/, "")}/v1/memory/orient-doc` : "");
+  if (!url) return null;
+  const token = process.env.FLOW_ACTIVITY_TOKEN || process.env.FLOW_ADMIN_TOKEN || "";
+  try {
+    const res = await fetch(`${url}?repo=${encodeURIComponent(repo)}`, {
+      headers: token ? { authorization: `Bearer ${token}` } : {},
+      signal: AbortSignal.timeout(4000),
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as { global: string | null; repo: string | null };
+  } catch {
+    return null;
+  }
+}
+
 async function fetchMemoryStats(): Promise<MemoryStats | null> {
   const url =
     process.env.FLOW_MEMORY_URL?.replace(/\/search$/, "/stats") ||
@@ -1085,7 +1106,7 @@ async function orient(input: z.infer<z.ZodObject<typeof orientInput>>) {
   const repo = input.repo || process.env.FLOW_REPO || "";
   const branch = input.branch || process.env.FLOW_BRANCH || "";
 
-  const [repoRows, counts, procRows, memStats] = await Promise.all([
+  const [repoRows, counts, procRows, memStats, orientDocs] = await Promise.all([
     run(input.graph, `MATCH (r:Repository) RETURN r.id AS id, r.name AS name, r.description AS description`),
     run(input.graph, `MATCH (n) RETURN labels(n)[0] AS type, count(*) AS count ORDER BY count DESC`),
     run(
@@ -1096,6 +1117,7 @@ async function orient(input: z.infer<z.ZodObject<typeof orientInput>>) {
        ORDER BY p.created_at DESC`,
     ) as Promise<unknown> as Promise<OrientProc[]>,
     fetchMemoryStats(),
+    fetchOrientDocs(repo),
   ]);
 
   // Repo identity: match by name when the caller told us which repo; otherwise
@@ -1147,6 +1169,16 @@ async function orient(input: z.infer<z.ZodObject<typeof orientInput>>) {
     out.push(`WHAT THIS IS: (repo "${repo}" not indexed in the graph yet)`);
   }
   out.push("");
+  // Orient docs — the ambient tier, verbatim and uncapped. Curation happened
+  // at write time (distiller nomination + earned inclusion); serving is dumb.
+  if (orientDocs?.repo) {
+    out.push(orientDocs.repo);
+    out.push("");
+  }
+  if (orientDocs?.global) {
+    out.push(orientDocs.global);
+    out.push("");
+  }
   out.push(
     `MAP: ${total} nodes indexed${mapBits.length ? ` — ${mapBits.join(", ")}` : ""}.` +
       ((serviceIds as Array<{ id: string }>).length

--- a/orchestrator/src/db.ts
+++ b/orchestrator/src/db.ts
@@ -5,7 +5,7 @@ import Database from "better-sqlite3";
 import { mkdirSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { migrate, MEMORY_SCHEMA, MEMORY_TRIGGERS, ANCHORS_SCHEMA, INDEX_LOG_SCHEMA, WORK_FOLDERS_SCHEMA } from "./migrations.js";
+import { migrate, MEMORY_SCHEMA, MEMORY_TRIGGERS, ANCHORS_SCHEMA, INDEX_LOG_SCHEMA, WORK_FOLDERS_SCHEMA, ORIENT_DOCS_SCHEMA } from "./migrations.js";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
@@ -246,6 +246,9 @@ db.exec(MEMORY_TRIGGERS);
 // a rebuildable projection. Kept byte-identical to the migration via the shared
 // ANCHORS_SCHEMA string.
 db.exec(ANCHORS_SCHEMA);
+// orient_docs: rendered ambient-tier docs (migration 14). Kept byte-identical
+// to the migration via the shared ORIENT_DOCS_SCHEMA string.
+db.exec(ORIENT_DOCS_SCHEMA);
 // index_log: indexer lifecycle trail (migration 11). Kept byte-identical to
 // the migration via the shared INDEX_LOG_SCHEMA string.
 db.exec(INDEX_LOG_SCHEMA);

--- a/orchestrator/src/memory/distiller.ts
+++ b/orchestrator/src/memory/distiller.ts
@@ -17,6 +17,7 @@ import { insertObservation, rawToNewObservation } from "./store.js";
 import { consolidateObservation, type Judge } from "./consolidate.js";
 import { haikuJudge } from "./judge.js";
 import { sweepMemories } from "./maintenance.js";
+import { rebuildOrientDocsFor } from "./orient-doc.js";
 
 export interface DistillContext {
   sessionId: string;
@@ -62,8 +63,10 @@ export async function distillSession(ctx: DistillContext): Promise<DistillOutcom
     actions[res.action] = (actions[res.action] ?? 0) + 1;
   }
 
-  // Cheap maintenance sweep on completion (recency decay → sink under floor).
+  // Cheap maintenance sweep on completion (recency decay → sink under floor),
+  // then refresh the ambient tier — membership may have changed either way.
   sweepMemories();
+  rebuildOrientDocsFor(ctx.repo);
 
   return { ran: true, observations: raws.length, actions };
 }
@@ -98,7 +101,7 @@ export async function rememberText(ctx: RememberContext): Promise<DistillOutcome
   }
   const verbatim = raws.length === 0;
   if (verbatim) {
-    raws = [{ claim: ctx.text, kind: "decision", context: {}, source: "user_stated", retrieval_keys: [] }];
+    raws = [{ claim: ctx.text, kind: "decision", context: {}, source: "user_stated", retrieval_keys: [], ambient: false }];
   }
 
   const judge = ctx.judge ?? haikuJudge;
@@ -114,6 +117,7 @@ export async function rememberText(ctx: RememberContext): Promise<DistillOutcome
     actions[res.action] = (actions[res.action] ?? 0) + 1;
   }
   sweepMemories();
+  rebuildOrientDocsFor(ctx.repo);
 
   return { ran: true, observations: raws.length, actions, ...(verbatim ? { reason: "verbatim-fallback" } : {}) };
 }

--- a/orchestrator/src/memory/orient-doc.ts
+++ b/orchestrator/src/memory/orient-doc.ts
@@ -1,0 +1,126 @@
+// orient-doc.ts — the AMBIENT memory tier: one curated document per scope,
+// returned verbatim and in full by orient(). This is the auto-authored
+// AGENTS.md — nothing here is hand-written or synced to agent machines.
+//
+// The doc is a DERIVED VIEW over memories (memories stay primary, the doc is
+// rebuildable at any time):
+//
+//   membership(scope) = active memories in scope
+//     WHERE kind != 'plan'                     -- plans go stale; they decay as memories
+//       AND ambient-nominated                  -- some attached observation said "every
+//                                              -- session here should see this"
+//       AND contradiction_count = 0            -- contested claims are never doctrine
+//       AND (user_stated OR evidence >= 2)     -- the human dictated it, or the claim
+//                                              -- EARNED corroboration across sessions
+//                                              -- (a fresh single agent claim already
+//                                              -- clears the 'strong' strength tier, so
+//                                              -- tier is NOT the bar — repetition is)
+//
+// Scope 'repo:<name>' matches memories with that repo; 'global' matches
+// repo-less memories (project-wide facts with no single home). Exit is
+// automatic: a memory that sinks (decay), picks up a contradiction, or loses
+// its corroboration simply stops matching on the next rebuild — connect and
+// disconnect, no doc-editing machinery.
+//
+// Render v1 is DETERMINISTIC (no LLM in the write path): claims are already
+// crisp 1-2 sentence statements, so the doc is claims grouped into sections by
+// kind, each line carrying its [mem:id] for drill-down. An LLM prose-polish
+// pass can replace renderOrientDoc later without touching membership.
+
+import db from "../db.js";
+import type { MemoryRow } from "./store.js";
+
+// Section order + headings, keyed by memory kind. 'plan' is deliberately absent.
+const SECTIONS: Array<[kind: string, heading: string]> = [
+  ["preference", "Working preferences"],
+  ["decision", "Decisions"],
+  ["constraint", "Constraints"],
+  ["gotcha", "Gotchas"],
+  ["how_to", "How-to"],
+];
+
+export function orientScopeForRepo(repo: string): string {
+  return `repo:${repo}`;
+}
+
+// The current member set for a scope, recomputed from primary data. Ordered:
+// user_stated before earned-in, then by strength — the doc reads
+// human-dictated principles first.
+export function orientMembers(scope: string): MemoryRow[] {
+  const repoClause = scope === "global" ? "m.repo IS NULL" : "m.repo = ?";
+  const params: string[] = scope === "global" ? [] : [scope.replace(/^repo:/, "")];
+  return db
+    .prepare(
+      `SELECT m.* FROM memories m
+       WHERE m.status = 'active' AND m.kind != 'plan' AND ${repoClause}
+         AND m.contradiction_count = 0
+         AND EXISTS (SELECT 1 FROM observations o WHERE o.memory_id = m.id AND o.ambient = 1)
+         AND (m.max_source_weight = 'user_stated' OR m.evidence_count >= 2)
+       ORDER BY (m.max_source_weight = 'user_stated') DESC, m.strength DESC`,
+    )
+    .all(...params) as MemoryRow[];
+}
+
+// Deterministic render: sections by kind, one claim per line with its [mem:id].
+// Returns "" when there are no members (no doc row is kept for empty scopes).
+export function renderOrientDoc(scope: string, members: MemoryRow[]): string {
+  if (members.length === 0) return "";
+  const title =
+    scope === "global"
+      ? "HOW THIS PROJECT WORKS (distilled from sessions — drill any [mem:id] with get_entity):"
+      : `HOW THIS REPO WORKS (distilled from sessions — drill any [mem:id] with get_entity):`;
+  const out: string[] = [title];
+  for (const [kind, heading] of SECTIONS) {
+    const section = members.filter((m) => m.kind === kind);
+    if (section.length === 0) continue;
+    out.push(`${heading}:`);
+    for (const m of section) out.push(`- ${m.claim} [mem:${m.id}]`);
+  }
+  return out.join("\n");
+}
+
+// Recompute membership + render for one scope; persist only when something
+// changed (member set or any member's claim text). Returns whether it did.
+export function rebuildOrientDoc(scope: string): boolean {
+  const members = orientMembers(scope);
+  const content = renderOrientDoc(scope, members);
+  const memberIds = JSON.stringify(members.map((m) => m.id));
+  const existing = db.prepare(`SELECT content, member_ids, revision FROM orient_docs WHERE scope = ?`).get(scope) as
+    | { content: string; member_ids: string; revision: number }
+    | undefined;
+
+  if (content === "") {
+    if (!existing) return false;
+    db.prepare(`DELETE FROM orient_docs WHERE scope = ?`).run(scope);
+    return true;
+  }
+  if (existing && existing.content === content && existing.member_ids === memberIds) return false;
+  db.prepare(
+    `INSERT INTO orient_docs (scope, content, member_ids, revision, updated_at)
+     VALUES (@scope, @content, @member_ids, 1, unixepoch())
+     ON CONFLICT(scope) DO UPDATE SET
+       content = excluded.content, member_ids = excluded.member_ids,
+       revision = orient_docs.revision + 1, updated_at = unixepoch()`,
+  ).run({ scope, content, member_ids: memberIds });
+  return true;
+}
+
+// Post-distillation hook: rebuild the scopes a session's observations can have
+// touched (its repo + global). Non-throwing — the docs are a cache; a failed
+// rebuild self-heals on the next distill.
+export function rebuildOrientDocsFor(repo: string | null): void {
+  try {
+    rebuildOrientDoc("global");
+    if (repo) rebuildOrientDoc(orientScopeForRepo(repo));
+  } catch (err) {
+    console.warn(`[memory] orient-doc rebuild failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+// Read side, served by GET /v1/memory/orient-doc and spliced into orient().
+export function getOrientDocs(repo: string | null): { global: string | null; repo: string | null } {
+  const get = (scope: string): string | null =>
+    (db.prepare(`SELECT content FROM orient_docs WHERE scope = ?`).get(scope) as { content: string } | undefined)
+      ?.content ?? null;
+  return { global: get("global"), repo: repo ? get(orientScopeForRepo(repo)) : null };
+}

--- a/orchestrator/src/memory/parse.ts
+++ b/orchestrator/src/memory/parse.ts
@@ -15,6 +15,11 @@ export interface RawObservation {
   context: { repo?: string; branch?: string; files?: string[] };
   source: ObservationSource;
   retrieval_keys: string[];
+  // Orient-doc nomination: "every future session on this repo should see this
+  // before starting." Absent/false = situational (search-only). The nomination
+  // is cheap and recall-oriented; INCLUSION in the doc is earned separately
+  // (user_stated fast-tracks, agent claims wait for strong tier).
+  ambient: boolean;
 }
 
 const KINDS: ReadonlySet<string> = new Set(["decision", "constraint", "gotcha", "how_to", "preference", "plan"]);
@@ -89,6 +94,7 @@ export function validateObservation(raw: unknown): RawObservation | null {
       files: toStringArray(ctx.files),
     },
     retrieval_keys: toStringArray(o.retrieval_keys),
+    ambient: o.ambient === true,
   };
 }
 

--- a/orchestrator/src/memory/prompt.ts
+++ b/orchestrator/src/memory/prompt.ts
@@ -22,8 +22,11 @@ Each observation is an object:
   "kind": "decision | constraint | gotcha | how_to | preference | plan",
   "context": { "repo": "<repo name>", "branch": "<branch if known, else omit>", "files": ["<paths central to the claim>"] },
   "source": "user_stated | agent_inferred | error_proven",
-  "retrieval_keys": ["5-10 short strings: file paths, error symptoms (INCLUDE VERBATIM ERROR SNIPPETS when present), command names, and ALTERNATE PHRASINGS a future agent might search for"]
+  "retrieval_keys": ["5-10 short strings: file paths, error symptoms (INCLUDE VERBATIM ERROR SNIPPETS when present), command names, and ALTERNATE PHRASINGS a future agent might search for"],
+  "ambient": false
 }
+
+ambient guide: set true ONLY when EVERY future session on this repo should see this before starting any work — how the system works overall, standing conventions, durable design principles, deployment-wide constraints (the AGENTS.md tier). Set false for anything situational: specific bugs, API shapes, one-off findings, anything only relevant when touching a particular area (those are found via search instead). MOST observations are false.
 
 kind guide:
 - decision: a chosen approach / architecture / tradeoff that was settled ("we use X not Y because Z").

--- a/orchestrator/src/memory/routes.ts
+++ b/orchestrator/src/memory/routes.ts
@@ -13,6 +13,9 @@
 //   POST /v1/memory/remember {text, repo?, branch?, session?} → {status:"queued"}
 //                                                     active capture: instant
 //                                                     ack, async distillation.
+//   GET  /v1/memory/orient-doc?repo=<name>           → {global, repo} rendered
+//                                                     ambient-tier docs (null
+//                                                     when a scope has none).
 
 import type { FastifyInstance } from "fastify";
 import db from "../db.js";
@@ -27,6 +30,7 @@ import { getNodeHeadline } from "./headline.js";
 import { getCard } from "./cards.js";
 import { memoryHitsForQueries, MEMORY_HIT_QUOTA } from "./find-hits.js";
 import { rememberText } from "./distiller.js";
+import { getOrientDocs } from "./orient-doc.js";
 
 export interface MemoryStats {
   memories: number;
@@ -154,4 +158,10 @@ export function registerMemoryRoutes(app: FastifyInstance): void {
       return reply.code(202).send({ status: "queued" });
     },
   );
+
+  // The ambient tier — rendered orient docs, served verbatim into the
+  // gateway's orient(). A scope with no members returns null, never "".
+  app.get<{ Querystring: { repo?: string } }>("/v1/memory/orient-doc", async (req) => {
+    return getOrientDocs(req.query.repo?.trim() || null);
+  });
 }

--- a/orchestrator/src/memory/store.ts
+++ b/orchestrator/src/memory/store.ts
@@ -34,6 +34,7 @@ export interface ObservationRow {
   source_weight: string;
   context_files: string | null;
   retrieval_keys: string | null;
+  ambient: number; // 0 | 1 — orient-doc nomination
   embedding: Buffer | null;
   memory_id: string | null;
   created_at: number;
@@ -61,10 +62,10 @@ export interface MemoryRow {
 const insertObservationStmt = db.prepare(`
   INSERT INTO observations
     (id, source, repo, repo_family, branch, session_id, source_id, source_url, claim, kind, source_weight,
-     context_files, retrieval_keys, embedding, memory_id)
+     context_files, retrieval_keys, ambient, embedding, memory_id)
   VALUES
     (@id, @source, @repo, @repo_family, @branch, @session_id, @source_id, @source_url, @claim, @kind, @source_weight,
-     @context_files, @retrieval_keys, @embedding, @memory_id)
+     @context_files, @retrieval_keys, @ambient, @embedding, @memory_id)
 `);
 
 export interface NewObservation {
@@ -79,6 +80,7 @@ export interface NewObservation {
   source_weight?: string;
   context_files?: string[];
   retrieval_keys?: string[];
+  ambient?: boolean;
   memory_id?: string | null;
 }
 
@@ -107,6 +109,7 @@ export async function insertObservation(o: NewObservation): Promise<ObservationR
     source_weight: o.source_weight ?? "agent_inferred",
     context_files: o.context_files && o.context_files.length ? JSON.stringify(o.context_files) : null,
     retrieval_keys: keys.length ? JSON.stringify(keys) : null,
+    ambient: o.ambient ? 1 : 0,
     embedding: vec ? vecToBlob(vec) : null,
     memory_id: o.memory_id ?? null,
   };
@@ -154,6 +157,7 @@ export function rawToNewObservation(
     source_weight: raw.source,
     context_files: raw.context.files ?? [],
     retrieval_keys: raw.retrieval_keys ?? [],
+    ambient: raw.ambient,
   };
 }
 

--- a/orchestrator/src/migrations.ts
+++ b/orchestrator/src/migrations.ts
@@ -206,7 +206,38 @@ export const MIGRATIONS: Migration[] = [
       `);
     },
   },
+  {
+    id: 14,
+    name: "orient docs: ambient nomination column + rendered doc cache",
+    up: (db) => {
+      // A DB below version 8 walks migration 8 first, which executes the
+      // SHARED MEMORY_SCHEMA string — already containing `ambient` — so a bare
+      // ALTER here would crash on "duplicate column". Same guard as migration 10.
+      const cols = db.prepare(`SELECT name FROM pragma_table_info('observations')`).all() as Array<{ name: string }>;
+      if (!new Set(cols.map((c) => c.name)).has("ambient")) {
+        db.exec("ALTER TABLE observations ADD COLUMN ambient INTEGER NOT NULL DEFAULT 0");
+      }
+      db.exec(ORIENT_DOCS_SCHEMA);
+    },
+  },
 ];
+
+// Orient docs — the AMBIENT memory tier. One rendered document per scope
+// ('global' or 'repo:<name>'), returned verbatim and in full by orient() —
+// the auto-authored AGENTS.md. The doc is a DERIVED VIEW over memories:
+// membership is recomputed from the memories table on every rebuild
+// (ambient-nominated AND (user_stated OR strong tier); kind 'plan' never
+// qualifies), member_ids records the set for provenance, content is the
+// deterministic render. Rebuildable at any time — memories stay primary.
+export const ORIENT_DOCS_SCHEMA = `
+  CREATE TABLE IF NOT EXISTS orient_docs (
+    scope      TEXT PRIMARY KEY,   -- 'global' | 'repo:<name>'
+    content    TEXT NOT NULL,
+    member_ids TEXT NOT NULL,      -- JSON array of member memory ids (render provenance)
+    revision   INTEGER NOT NULL DEFAULT 1,
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+  );
+`;
 
 // Per-user WORK surfaces (where agent sessions run) — deliberately separate
 // from repos.json so one user's local paths never leak into a teammate's
@@ -285,6 +316,7 @@ export const MEMORY_SCHEMA = `
     source_weight  TEXT NOT NULL DEFAULT 'agent_inferred', -- user_stated|agent_inferred|error_proven
     context_files  TEXT,            -- JSON array
     retrieval_keys TEXT,            -- JSON array
+    ambient        INTEGER NOT NULL DEFAULT 0, -- distiller nomination: orient-doc tier ("every session here should see this")
     embedding      BLOB,
     memory_id      TEXT,            -- FK -> memories.id, nullable until consolidated
     created_at     INTEGER NOT NULL DEFAULT (unixepoch())

--- a/orchestrator/test/memory.test.ts
+++ b/orchestrator/test/memory.test.ts
@@ -58,7 +58,7 @@ function stubVec(text: string): Float32Array {
 const stubEmbedder = async (t: string) => stubVec(t);
 
 function clearMemory(): void {
-  db.exec("DELETE FROM observations; DELETE FROM memories; DELETE FROM anchors; DELETE FROM slack_messages; DELETE FROM linear_tickets;");
+  db.exec("DELETE FROM observations; DELETE FROM memories; DELETE FROM anchors; DELETE FROM orient_docs; DELETE FROM slack_messages; DELETE FROM linear_tickets;");
   store.invalidateVectorCache();
   headline?.invalidateHeadlineCache();
 }
@@ -676,6 +676,101 @@ describe("distiller trigger: idle sweep", () => {
       .run("sweep-2", "acme", "idle", Date.now(), Date.now());
     const ran = await trigger.idleSweep();
     assert.equal(ran, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Orient docs — the ambient tier. Membership is a derived view (nominated +
+// user_stated-or-corroborated + uncontested), the render is deterministic, and
+// docs rebuild from the distiller hook. These tests drive the real
+// consolidation path, never the doc table directly.
+describe("orient docs (ambient tier)", () => {
+  let orientDoc: typeof import("../src/memory/orient-doc.js");
+
+  before(async () => {
+    orientDoc = await import("../src/memory/orient-doc.js");
+    store.setEmbedder(stubEmbedder);
+  });
+
+  type SeedOpts = { repo?: string | null; kind?: string; weight?: string; ambient?: boolean };
+  async function seed(claim: string, { repo = "acme", kind = "decision", weight = "user_stated", ambient = true }: SeedOpts = {}) {
+    const o = await store.insertObservation({
+      source: "session", repo, claim, kind, source_weight: weight, retrieval_keys: [], ambient, session_id: "s1",
+    });
+    return consolidate.consolidateObservation(o, async () => ({ verdict: "new" as const }));
+  }
+
+  test("user_stated + ambient fast-tracks into the repo doc; sections + [mem:id] render", async () => {
+    await seed("agents never run in the managed clone; work folders only", { kind: "constraint" });
+    orientDoc.rebuildOrientDocsFor("acme");
+    const docs = orientDoc.getOrientDocs("acme");
+    assert.ok(docs.repo, "repo doc should exist");
+    assert.match(docs.repo!, /HOW THIS REPO WORKS/);
+    assert.match(docs.repo!, /Constraints:/);
+    assert.match(docs.repo!, /managed clone.*\[mem:[0-9a-f-]+\]/);
+    assert.equal(docs.global, null, "repo-scoped memory must not leak into the global doc");
+  });
+
+  test("agent_inferred waits for corroboration (evidence >= 2), then earns in", async () => {
+    await seed("the graph indexes at capability level, not per-function", { weight: "agent_inferred" });
+    orientDoc.rebuildOrientDocsFor("acme");
+    assert.equal(orientDoc.getOrientDocs("acme").repo, null, "single agent claim must NOT be doctrine yet");
+
+    // A second session observes the same thing → judge says same → evidence 2.
+    const o2 = await store.insertObservation({
+      source: "session", repo: "acme", claim: "the graph indexes at capability level, not per-function",
+      kind: "decision", source_weight: "agent_inferred", retrieval_keys: [], ambient: true, session_id: "s2",
+    });
+    await consolidate.consolidateObservation(o2, async () => ({ verdict: "same" as const }));
+    orientDoc.rebuildOrientDocsFor("acme");
+    assert.match(orientDoc.getOrientDocs("acme").repo ?? "", /capability level/, "corroborated claim earns in");
+  });
+
+  test("plans and non-nominated memories never enter; contradiction evicts", async () => {
+    await seed("next week we migrate the queue", { kind: "plan" });
+    await seed("tabs not spaces in this repo", { ambient: false });
+    const inDoc = await seed("deploys go through staging first", { kind: "constraint" });
+    orientDoc.rebuildOrientDocsFor("acme");
+    let doc = orientDoc.getOrientDocs("acme").repo ?? "";
+    assert.doesNotMatch(doc, /migrate the queue/);
+    assert.doesNotMatch(doc, /tabs not spaces/);
+    assert.match(doc, /staging first/);
+
+    // A contradicting observation lands → the line leaves the doc immediately.
+    const contra = await store.insertObservation({
+      source: "session", repo: "acme", claim: "deploys now go straight to prod",
+      kind: "constraint", source_weight: "user_stated", retrieval_keys: [], ambient: true, session_id: "s3",
+      memory_id: null,
+    });
+    await consolidate.consolidateObservation(contra, async () => ({ verdict: "contradicts" as const }));
+    orientDoc.rebuildOrientDocsFor("acme");
+    doc = orientDoc.getOrientDocs("acme").repo ?? "";
+    assert.doesNotMatch(doc, new RegExp(`mem:${inDoc.memoryId}`), "contested memory must leave the doc");
+  });
+
+  test("repo-less memories land in the global doc; revision bumps only on change", async () => {
+    await seed("the team ships behind PRs, never direct pushes", { repo: null });
+    orientDoc.rebuildOrientDocsFor(null);
+    const docs = orientDoc.getOrientDocs(null);
+    assert.match(docs.global ?? "", /HOW THIS PROJECT WORKS/);
+    const rev = () => (db.prepare("SELECT revision FROM orient_docs WHERE scope = 'global'").get() as any).revision;
+    const r1 = rev();
+    orientDoc.rebuildOrientDocsFor(null); // nothing changed
+    assert.equal(rev(), r1, "no-op rebuild must not bump the revision");
+  });
+
+  test("distiller e2e: an ambient extraction reaches the doc through the hook", async () => {
+    llm.setLlmTransport(async () =>
+      JSON.stringify([
+        { claim: "All background jobs are idempotent by convention", kind: "decision", context: {}, source: "user_stated", retrieval_keys: ["idempotent", "jobs"], ambient: true },
+      ]),
+    );
+    const events = [
+      { kind: "user_prompt", data: { text: "Remember that all our background jobs must stay idempotent." } },
+      { kind: "update", data: { sessionUpdate: "agent_message_chunk", content: { text: "Noted and applied." } } },
+    ];
+    await distiller.distillSession({ sessionId: "sess-doc", repo: "acme", branch: "main", events, judge: async () => ({ verdict: "new" as const }) });
+    assert.match(orientDoc.getOrientDocs("acme").repo ?? "", /idempotent by convention/);
   });
 });
 


### PR DESCRIPTION
The ambient half of the two-tier memory design you approved via the offline render: one curated document per scope (`global` + `repo:<name>`), returned **verbatim and uncapped** by `orient()` — the auto-authored AGENTS.md. Situational memories stay pull-only, exactly as shipped.

## How it works — one writer, agents never classify

- **Distiller nominates**: new `ambient` field in the extraction contract ("every future session on this repo should see this before starting — most observations are false"), stored on observations (migration 14).
- **Inclusion is earned**, not granted: membership is a *derived view* over memories — ambient-nominated **AND** uncontested (`contradiction_count = 0`) **AND** (`user_stated` **OR** `evidence_count >= 2`). One deliberate deviation from the render discussion: the earned bar is **corroboration, not strength tier** — a fresh single agent claim already scores "strong" (0.88 ≥ 0.6), so tier would admit everything immediately; repetition across sessions is the honest bar.
- **Exit is automatic**: decay (status sunk), a single contradiction, or lost corroboration drops the line at the next rebuild. Connect/disconnect with zero doc-editing machinery; `plan`-kind never enters.
- **Render v1 is deterministic** — claims grouped by kind into sections, each line carrying `[mem:id]` for `get_entity` drill-down. No LLM in the write path; an LLM prose-polish can replace `renderOrientDoc` later without touching membership.
- **Rebuild** runs after every `distillSession`/`rememberText` (cheap SQL + string building, non-throwing). `orient_docs` stores content + `member_ids` + revision — a cache; memories stay primary.
- **Serving**: `GET /v1/memory/orient-doc?repo=` → gateway splices repo + global docs into `orient()` right after WHAT THIS IS. Missing docs are silently omitted — the section appears only once the store has earned content.

ROADMAP gains the superseding design record (memory v2 final form: distiller-only, remember, no repo gating, orient docs; procedures removal is the named follow-up).

## Testing
- Orchestrator **265/265** (5 new: fast-track + render shape; corroboration earn-in; plan/non-nominated exclusion + contradiction eviction; global scope + revision stability; distiller-hook e2e).
- Gateway 24/24. Migration 14 follows the guarded-ALTER pattern (shared-schema safe).

Left open for your review rather than self-merged — this is the flagship design. After merge + restart, docs start forming as the distiller sweeps real sessions (which it now does, post-#45).