### PR TITLE
memory: parallelize find_entity blend + distant fallback under the cosine floor

### DIFF
--- a/orchestrator/src/memory/find-hits.ts
+++ b/orchestrator/src/memory/find-hits.ts
@@ -14,7 +14,7 @@
 // Output is terse typed lines the gateway splices into find_entity's match list:
 //   [Memory:gotcha] <headline> (strong) [mem:<id>]
 
-import { searchMemory, type SearchTypeFilter } from "./search.js";
+import { searchMemory, BATCH_CONCURRENCY, type SearchTypeFilter } from "./search.js";
 
 // Max memory hits blended into a single find_entity query's results, unless the
 // query carries a type filter. Small on purpose: find_entity is graph-first; a
@@ -56,13 +56,14 @@ export async function memoryHitsForQuery(
   const res = await searchMemory({ query, repo, type: opts.type ?? null, limit: Math.max(cap, MEMORY_HIT_QUOTA) });
   return res.memories.slice(0, cap).map((m) => {
     const headline = trunc(m.claim, HEADLINE_TRUNC);
+    const tag = m.distant ? `${m.strengthTier}, distant` : m.strengthTier;
     return {
       type: "memory" as const,
       kind: m.kind,
       headline,
       tier: m.strengthTier,
       id: `mem:${m.id}`,
-      line: `[Memory:${m.kind}] ${headline} (${m.strengthTier}) [mem:${m.id}]`,
+      line: `[Memory:${m.kind}] ${headline} (${tag}) [mem:${m.id}]`,
     };
   });
 }
@@ -73,14 +74,24 @@ export interface QueryHits {
 }
 
 // Batch form: several queries, grouped in request order (mirrors search batch).
+// Queries run through the same bounded pool as searchMemoryBatch: each one is
+// a full searchMemory — a query-embed round trip plus FTS — so running them
+// serially multiplies embed latency by the batch size, which is what blew the
+// gateway's blend timeout and silently dropped memory_hits from find_entity.
 export async function memoryHitsForQueries(
   queries: string[],
   repo: string | null,
   opts: { type?: SearchTypeFilter | null; limit?: number } = {},
 ): Promise<QueryHits[]> {
-  const out: QueryHits[] = [];
-  for (const q of queries) {
-    out.push({ query: q, hits: await memoryHitsForQuery(q, repo, opts) });
-  }
+  const out: QueryHits[] = new Array(queries.length);
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(BATCH_CONCURRENCY, queries.length) }, async () => {
+    for (;;) {
+      const i = cursor++;
+      if (i >= queries.length) return;
+      out[i] = { query: queries[i], hits: await memoryHitsForQuery(queries[i], repo, opts) };
+    }
+  });
+  await Promise.all(workers);
   return out;
 }

--- a/orchestrator/src/memory/search.ts
+++ b/orchestrator/src/memory/search.ts
@@ -11,9 +11,12 @@
 //         + 0.10 * file_mention_overlap
 //         + 0.08 * same_repo_exact
 //         + 0.04 * same_family (sibling repo, e.g. acme-backend from acme-frontend)
-//   SILENCE GATE: drop results under ~0.55 cosine UNLESS they are an FTS5 exact
-//     hit. FTS candidates are ALWAYS eligible (identifiers/error strings are the
-//     reliable path); vector-only candidates must clear the cosine floor.
+//   SILENCE GATE: vector-only candidates under ~0.55 cosine don't count as
+//     confident hits — FTS5 exact hits always do (identifiers/error strings are
+//     the reliable path). The gate marks rather than mutes (Samyak, 2026-07-27):
+//     when fewer than FLOOR_FALLBACK_HITS confident hits survive, the top
+//     below-floor candidates surface anyway, flagged `distant`, so retrieval
+//     degrades to best-effort instead of silence.
 //   Merge FTS5 + vector candidates before ranking.
 //
 // Returns terse lines. Also searches the corpus (slack/linear/meeting FTS) and
@@ -28,6 +31,11 @@ import { searchCorpus } from "../corpus.js";
 import { itemsAnchoredToNode } from "./anchors.js";
 
 export const COSINE_FLOOR = 0.55;
+
+// When the gate leaves fewer confident hits than this, the best below-floor
+// candidates fill the gap (marked distant) — the caller always sees the top
+// few closest memories when any exist at all.
+export const FLOOR_FALLBACK_HITS = 3;
 
 // Node-scoped + type filters parsed out of the query string (Section E). A
 // caller can write `node:svc:users type:memory hmac` and get memories anchored
@@ -94,6 +102,9 @@ export interface MemoryHit {
   score: number;
   cosine: number;
   ftsHit: boolean;
+  // True when this hit is a below-floor fallback: no FTS match and cosine under
+  // COSINE_FLOOR. Rendered as a "distant" tag so the agent can weigh it.
+  distant: boolean;
 }
 
 export interface CorpusHit {
@@ -264,16 +275,20 @@ export async function searchMemory(input: SearchInput): Promise<SearchResult> {
   const emptyNodeScope = nodeMemoryIds !== null && effectiveQuery === "";
 
   const hits: MemoryHit[] = [];
+  // Below-floor candidates kept aside instead of dropped: if the gate leaves
+  // fewer than FLOOR_FALLBACK_HITS confident hits, the best of these surface
+  // anyway, marked distant — best-effort beats silent emptiness.
+  const distantPool: MemoryHit[] = [];
   for (const m of memRows) {
     // Node scope: drop memories not anchored to the node.
     if (nodeMemoryIds && !nodeMemoryIds.has(m.id)) continue;
 
     const cos = cosById.get(m.id) ?? 0;
     const isFts = ftsIds.has(m.id);
-    // Silence gate: vector-only candidates must clear the cosine floor; FTS
-    // exact hits bypass it. An empty node-scoped query bypasses (the anchor IS
-    // the selection).
-    if (!emptyNodeScope && !isFts && cos < COSINE_FLOOR) continue;
+    // Silence gate: vector-only candidates under the cosine floor are marked
+    // distant; FTS exact hits pass. An empty node-scoped query passes (the
+    // anchor IS the selection).
+    const distant = !emptyNodeScope && !isFts && cos < COSINE_FLOOR;
 
     const keys = parseJsonArray(m.retrieval_keys);
     const keyOverlap = overlap(queryTokens, keys);
@@ -285,7 +300,7 @@ export async function searchMemory(input: SearchInput): Promise<SearchResult> {
     const sameFamily = !sameRepoExact && queryFamily && m.repo_family && queryFamily === m.repo_family ? 1 : 0;
 
     const score = cos + 0.15 * keyOverlap + 0.1 * fileOverlap + 0.08 * sameRepoExact + 0.04 * sameFamily;
-    hits.push({
+    (distant ? distantPool : hits).push({
       id: m.id,
       claim: m.claim,
       kind: m.kind,
@@ -294,9 +309,14 @@ export async function searchMemory(input: SearchInput): Promise<SearchResult> {
       score,
       cosine: cos,
       ftsHit: isFts,
+      distant,
     });
   }
 
+  if (hits.length < FLOOR_FALLBACK_HITS && distantPool.length > 0) {
+    distantPool.sort((a, b) => b.score - a.score);
+    hits.push(...distantPool.slice(0, FLOOR_FALLBACK_HITS - hits.length));
+  }
   hits.sort((a, b) => b.score - a.score);
   return {
     memories: hits.slice(0, limit),
@@ -325,7 +345,7 @@ function nodeScopeIds(nodeId: string): NodeScope {
 // kept in REQUEST ORDER. Concurrency is bounded — each query is a full FTS +
 // vector pass, so a small pool keeps a batch from monopolizing the event loop.
 export const SEARCH_MEMORY_MAX_BATCH = 10;
-const BATCH_CONCURRENCY = 4;
+export const BATCH_CONCURRENCY = 4;
 
 export interface BatchSearchInput {
   queries: string[];
@@ -415,7 +435,7 @@ export function renderSearchResult(res: SearchResult): string {
   if (res.memories.length) {
     lines.push("MEMORY:");
     for (const m of res.memories) {
-      lines.push(`- ${m.claim} [${m.kind}/${m.strengthTier}] (memory ${m.id})`);
+      lines.push(`- ${m.claim} [${m.kind}/${m.strengthTier}${m.distant ? ", distant" : ""}] (memory ${m.id})`);
     }
   }
   if (res.corpus.length) {

--- a/orchestrator/test/memory.test.ts
+++ b/orchestrator/test/memory.test.ts
@@ -325,20 +325,24 @@ describe("search ranking", () => {
     assert.ok(ids.indexOf(acme.id) < ids.indexOf(other.id), "same-family ranks above rest-of-project");
   });
 
-  test("silence gate drops weak vector-only hits", async () => {
+  test("weak vector-only hits surface as distant fallback, never confident", async () => {
     await seed("we chose tailwind css for styling the dashboard", "acme", ["tailwind", "css"]);
-    // Query with no token overlap → cosine ~0 → below floor, no FTS hit → dropped.
+    // Query with no token overlap → cosine ~0 → below floor, no FTS hit. The
+    // gate marks rather than mutes: the memory still surfaces, tagged distant.
     const res = await search.searchMemory({ query: "database migration rollback strategy", repo: "acme", limit: 10 });
-    assert.equal(res.memories.length, 0, "weak vector-only hit must be silenced");
+    assert.ok(res.memories.length >= 1, "below-floor candidates fill in as fallback");
+    assert.ok(res.memories.every((m) => m.distant), "every fallback hit is marked distant");
+    assert.match(search.renderSearchResult(res), /, distant\]/, "render carries the distant tag");
   });
 
-  test("FTS exact-match bypasses the silence gate", async () => {
+  test("FTS exact-match is a confident hit (never marked distant)", async () => {
     // Seed a memory whose retrieval keys carry a rare identifier. A query for
     // that identifier is an FTS exact hit even if the dense cosine is weak.
     await seed("the flaky test is caused by a race in the WorktreePruner", "acme", ["WorktreePruner", "race"]);
     const res = await search.searchMemory({ query: "WorktreePruner", repo: "acme", limit: 10 });
     assert.ok(res.memories.length >= 1, "FTS exact hit must survive even under the cosine floor");
     assert.ok(res.memories[0].ftsHit);
+    assert.equal(res.memories[0].distant, false, "an FTS hit is confident, not distant");
   });
 });
 
@@ -369,12 +373,14 @@ describe("keyword matching + multi-memory retrieval", () => {
     assert.deepEqual(search.meaningfulTokens("how is it that we do this with the"), []);
   });
 
-  test("stopword-only overlap does NOT surface a memory (the live bug)", async () => {
+  test("stopword-only overlap is never a CONFIDENT hit (the live bug)", async () => {
     clearMemory();
     // The memory shares ONLY filler words with the query below ("on", "with").
+    // It may surface as a distant fallback, but must never read as a real
+    // keyword/vector match — the live bug was an unmarked confident hit.
     await seed("the ci pipeline runs on github-actions with layer caching", "acme", ["ci", "github-actions", "caching"]);
     const res = await search.searchMemory({ query: "avatar images on profile cards with rounded corners", repo: "acme", limit: 10 });
-    assert.equal(res.memories.length, 0, "shared stopwords must not surface an unrelated memory");
+    assert.ok(res.memories.every((m) => m.distant && !m.ftsHit), "shared stopwords never make a confident (non-distant) hit");
     // positive control: a real content token from that memory DOES surface it
     const hit = await search.searchMemory({ query: "github-actions caching", repo: "acme", limit: 10 });
     assert.ok(hit.memories.length >= 1 && hit.memories[0].ftsHit, "real keyword must still hit");
@@ -439,13 +445,16 @@ describe("batched memory search", () => {
     );
   });
 
-  test("a query with no hits still gets an (empty) group in order", async () => {
+  test("a query with no confident hits keeps its group in order (distant fallback)", async () => {
     clearMemory();
     await seed("dashboard uses tailwind for styling", "acme", ["tailwind", "css"]);
     const res = await search.searchMemoryBatch({ queries: ["tailwind", "zzznonexistentzzz"], repo: "acme", limit: 10 });
     assert.equal(res.groups.length, 2);
     assert.ok(res.groups[0].result.memories.length >= 1);
-    assert.equal(res.groups[1].result.memories.length, 0, "empty group is kept, not dropped");
+    assert.ok(
+      res.groups[1].result.memories.every((m) => m.distant),
+      "an off-topic query gets at most distant fallback hits, never confident ones",
+    );
   });
 
   test("batch render labels each query section in order", async () => {
@@ -1220,10 +1229,40 @@ describe("find_entity memory hits + quota (Section D)", () => {
     assert.ok(hits.length > findHits.MEMORY_HIT_QUOTA, "a typed query lifts the quota");
   });
 
-  test("the 0.55 silence gate still applies to hits (no keyword → no noise)", async () => {
+  test("a weak vector-only match blends in as a distant-tagged hit, not silence", async () => {
     clearMemory();
     await seed("we chose tailwind css for styling", "acme", ["tailwind"]);
     const hits = await findHits.memoryHitsForQuery("database migration rollback", "acme");
-    assert.equal(hits.length, 0, "a weak vector-only match is silenced, so no memory hit blends in");
+    assert.ok(hits.length >= 1, "below-floor fallback keeps find_entity's blend non-empty");
+    assert.match(hits[0].line, /\(\w+, distant\) \[mem:/, "the terse line carries the distant tag");
+  });
+
+  test("batch runs queries concurrently but returns groups in request order", async () => {
+    clearMemory();
+    await seed("payments verified with hmac signature", "acme", ["hmac"]);
+    await seed("s3 uploads use presigned urls", "acme", ["presigned"]);
+    // Embedder that resolves out of order: first call (hmac) waits until the
+    // second (presigned) has resolved — a sequential loop would deadlock-free
+    // pass too, but out-of-order results would land in the wrong group if the
+    // pool wrote by completion order instead of request index.
+    let firstRelease!: () => void;
+    const firstDone = new Promise<void>((r) => (firstRelease = r));
+    let calls = 0;
+    store.setEmbedder(async (text) => {
+      const call = ++calls;
+      if (call === 1) await firstDone;
+      else if (call === 2) firstRelease();
+      return stubEmbedder(text);
+    });
+    try {
+      const groups = await findHits.memoryHitsForQueries(["hmac", "presigned"], "acme");
+      assert.equal(groups.length, 2);
+      assert.equal(groups[0].query, "hmac");
+      assert.equal(groups[1].query, "presigned");
+      assert.ok(groups[0].hits[0]?.line.includes("hmac"), "first group holds the first query's hits");
+      assert.ok(groups[1].hits[0]?.line.includes("presigned"), "second group holds the second query's hits");
+    } finally {
+      store.setEmbedder(stubEmbedder);
+    }
   });
 });


### PR DESCRIPTION
## Context

Investigating why a directly-relevant memory never surfaced in a landinghero agent session (`find_entity` returned no `memory_hits` at all) turned up two retrieval failures:

- The orchestrator's `/v1/memory/hits` ran batch queries **sequentially** (`find-hits.ts`), each one a full `searchMemory` = one query-embed round trip (+FTS). With API-served embeddings (~0.4–1.9 s RTT), a 3-query blend measured **8.3 s** against the gateway's **4 s** `fetchMemoryHits` timeout → fail-open `[]` → the `memory_hits` key silently omitted. The agent saw nothing and couldn't tell "no memories" from "blend timed out".
- When nothing clears the 0.55 cosine silence gate, retrieval returns empty even when close-but-below-floor candidates exist.

## Changes

**1. Parallelize the blend** — `memoryHitsForQueries` now runs queries through the same bounded pool as `searchMemoryBatch` (shared, now-exported `BATCH_CONCURRENCY = 4`), writing results by request index so groups stay in request order. A 3-query blend costs ~1 embed RTT of wall-clock instead of 3.

**2. Distant fallback under the floor** — the silence gate marks instead of mutes. When fewer than `FLOOR_FALLBACK_HITS` (3) confident hits survive, the best below-floor candidates surface anyway with a new `distant: true` field on `MemoryHit`, rendered as `(tier, distant)` in the terse lines (`search_knowledge` + `find_entity` blend). Confident semantics unchanged: FTS exact hits are never distant, and the stopword-noise protection holds — filler-only overlap can never produce an unmarked confident hit.

## Tests

- New test proves real concurrency: the first query's embed blocks until the second query's embed runs — deadlocks under the old sequential loop, passes with the pool — and asserts hits land in the correct groups despite out-of-order completion.
- Silence-gate tests updated from "returns empty" to "returns distant-tagged fallback, never an unmarked confident hit".
- `orchestrator` memory suite: **81/81 pass**.

## Notes

- Not included (follow-ups discussed separately): embedding backfill for the 108 NULL-embedding landinghero memories, switch to local Gemma embeds (settings-side, `EMBEDDING_MODEL`), retrieval-key tokenization in `overlap()`.