### PR TITLE
agents: split-screen workspaces/sessions with activity sort and copy cleanup

### DIFF
--- a/dashboard/src/components/AgentTaskComposer.tsx
+++ b/dashboard/src/components/AgentTaskComposer.tsx
@@ -42,12 +42,22 @@ interface WorkFolder {
   repo: string | null;
 }
 
+// "+ New session" on a copy card targets the composer at that existing copy —
+// the session runs inside it instead of a work folder.
+export interface CopyTarget {
+  path: string;
+  branch: string | null;
+  repo: string;
+}
+
 interface AgentTaskComposerProps {
   nodeCount?: number;
   selectedNodeTag?: string | null;
   onClearNodeTag?: () => void;
   compact?: boolean;
   className?: string;
+  worktreeTarget?: CopyTarget | null;
+  onClearWorktreeTarget?: () => void;
 }
 
 const AGENT_BRANDS: Record<string, BrandName> = {
@@ -68,6 +78,8 @@ export function AgentTaskComposer({
   onClearNodeTag,
   compact = false,
   className = "",
+  worktreeTarget = null,
+  onClearWorktreeTarget,
 }: AgentTaskComposerProps) {
   const router = useRouter();
   const { prefix } = useProject();
@@ -227,18 +239,21 @@ export function AgentTaskComposer({
     }
   };
 
-  // Autocomplete files from repo/folder
+  // Autocomplete files from repo/folder — inside a copy target, complete
+  // against the copy's own checkout.
   const fetchFiles = useCallback(
     (q: string) => {
-      if (!repo) return Promise.resolve([]);
-      const folderParam = workFolder ? `&folder=${encodeURIComponent(workFolder)}` : "";
+      const effRepo = worktreeTarget?.repo ?? repo;
+      if (!effRepo) return Promise.resolve([]);
+      const folder = worktreeTarget?.path ?? workFolder;
+      const folderParam = folder ? `&folder=${encodeURIComponent(folder)}` : "";
       return fetch(
-        prefix(`/api/agents/repos/files?repo=${encodeURIComponent(repo)}&q=${encodeURIComponent(q)}${folderParam}`)
+        prefix(`/api/agents/repos/files?repo=${encodeURIComponent(effRepo)}&q=${encodeURIComponent(q)}${folderParam}`)
       )
         .then((r) => (r.ok ? r.json() : { entries: [] }))
         .then((d: { entries?: FileEntry[] }) => d.entries ?? []);
     },
-    [repo, workFolder, prefix]
+    [repo, workFolder, worktreeTarget, prefix]
   );
 
   // Handle image / file attachments
@@ -304,7 +319,7 @@ export function AgentTaskComposer({
     e?.preventDefault();
     if (!prompt.trim() || starting) return;
 
-    if (!workFolder) {
+    if (!workFolder && !worktreeTarget) {
       setError("Please choose a local folder to run the agent task in.");
       setIsFolderPickerOpen(true);
       return;
@@ -315,15 +330,18 @@ export function AgentTaskComposer({
     setCollision(null);
 
     try {
+      // A copy target runs the session inside that existing separate copy —
+      // no work folder, no placement, no collision prompt.
+      const target = worktreeTarget
+        ? { repo: worktreeTarget.repo, worktreePath: worktreeTarget.path }
+        : { repo: repo || "local-folder", workFolder, ...(placement ? { placement } : {}) };
       const res = await fetch(prefix("/api/agents/sessions"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           backend,
-          repo: repo || "local-folder",
-          workFolder,
+          ...target,
           prompt: prompt.trim(),
-          ...(placement ? { placement } : {}),
           ...(Object.keys(config).length > 0 ? { config } : {}),
           ...(modeChanged && modeId ? { modeId } : {}),
           attachments: attachments.map((a) => ({ name: a.name, mimeType: a.mimeType, data: a.data })),
@@ -342,6 +360,7 @@ export function AgentTaskComposer({
 
       setPrompt("");
       setAttachments([]);
+      onClearWorktreeTarget?.();
       if (data.id) {
         router.push(prefix(`/agents/${data.id}`));
       }
@@ -363,39 +382,58 @@ export function AgentTaskComposer({
     <div className={`flex flex-col gap-3 ${className}`}>
       {/* Top row: local folder (left) + engine chips (right) */}
       <div className="flex items-center justify-between gap-3 flex-wrap">
-        {/* Local Folder Target — TOP LEFT */}
-        <div className="flex items-center gap-1.5 bg-cream/70 px-2.5 py-1.5 rounded-lg border border-line min-w-0 max-w-[45%]">
-          <span className="text-xs">📁</span>
-          <span className="text-[11px] font-mono text-ink truncate flex-1" title={workFolder}>
-            {workFolder ? workFolder : "Choose local folder..."}
-          </span>
-          {workFolders.length > 0 && (
-            <select
-              value={workFolder}
-              onChange={(e) => {
-                const selected = e.target.value;
-                setWorkFolder(selected);
-                const match = workFolders.find((f) => f.path === selected);
-                if (match?.repo) setRepo(match.repo);
-              }}
-              className="bg-transparent border-none text-[10px] font-mono text-text-muted outline-none cursor-pointer w-4 flex-shrink-0"
-              title="Switch local folder"
+        {/* Target — TOP LEFT: an existing separate copy when one is picked
+            ("+ new session" on a copy card), otherwise the local folder. */}
+        {worktreeTarget ? (
+          <div className="flex items-center gap-1.5 bg-cream/70 px-2.5 py-1.5 rounded-lg border border-line min-w-0 max-w-[45%]">
+            <span className="text-xs">⎇</span>
+            <span className="text-[11px] font-mono text-ink truncate flex-1" title={worktreeTarget.path}>
+              {worktreeTarget.branch ?? worktreeTarget.path.split("/").pop()}
+            </span>
+            <span className="text-[10px] font-mono text-text-muted flex-shrink-0">separate copy</span>
+            <button
+              type="button"
+              onClick={() => onClearWorktreeTarget?.()}
+              className="text-[12px] font-bold text-text-muted hover:text-ink ml-1 cursor-pointer flex-shrink-0"
+              title="Back to picking a local folder"
             >
-              {workFolders.map((f) => (
-                <option key={f.path} value={f.path}>
-                  {f.path}
-                </option>
-              ))}
-            </select>
-          )}
-          <button
-            type="button"
-            onClick={() => setIsFolderPickerOpen(true)}
-            className="text-[10px] font-mono text-text-muted hover:text-ink underline ml-1 cursor-pointer flex-shrink-0"
-          >
-            Change
-          </button>
-        </div>
+              ×
+            </button>
+          </div>
+        ) : (
+          <div className="flex items-center gap-1.5 bg-cream/70 px-2.5 py-1.5 rounded-lg border border-line min-w-0 max-w-[45%]">
+            <span className="text-xs">📁</span>
+            <span className="text-[11px] font-mono text-ink truncate flex-1" title={workFolder}>
+              {workFolder ? workFolder : "Choose local folder..."}
+            </span>
+            {workFolders.length > 0 && (
+              <select
+                value={workFolder}
+                onChange={(e) => {
+                  const selected = e.target.value;
+                  setWorkFolder(selected);
+                  const match = workFolders.find((f) => f.path === selected);
+                  if (match?.repo) setRepo(match.repo);
+                }}
+                className="bg-transparent border-none text-[10px] font-mono text-text-muted outline-none cursor-pointer w-4 flex-shrink-0"
+                title="Switch local folder"
+              >
+                {workFolders.map((f) => (
+                  <option key={f.path} value={f.path}>
+                    {f.path}
+                  </option>
+                ))}
+              </select>
+            )}
+            <button
+              type="button"
+              onClick={() => setIsFolderPickerOpen(true)}
+              className="text-[10px] font-mono text-text-muted hover:text-ink underline ml-1 cursor-pointer flex-shrink-0"
+            >
+              Change
+            </button>
+          </div>
+        )}
 
         {/* Agent Engine Selector Chips — TOP RIGHT (green dot = ready) */}
         <div className="flex items-center gap-1 bg-cream/90 p-1 rounded-lg border border-line">

--- a/dashboard/src/components/AgentsView.tsx
+++ b/dashboard/src/components/AgentsView.tsx
@@ -1,22 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useProject } from "@/lib/useProject";
 import { Kicker, Heading, Card, StatusPill } from "@/components/ui";
 import { BrandIcon, type BrandName } from "@/components/BrandIcon";
 import { DiffView, type DiffFile } from "@/components/DiffView";
 import { BranchSelect } from "@/components/BranchSelect";
-import { AgentTaskComposer } from "@/components/AgentTaskComposer";
-
-interface DetectedAgent {
-  id: string;
-  name: string;
-  installed: boolean;
-  version?: string;
-  source?: "explicit" | "local" | "bundled";
-  installHint: string;
-}
+import { AgentTaskComposer, type CopyTarget } from "@/components/AgentTaskComposer";
 
 interface SessionRow {
   id: string;
@@ -25,8 +16,30 @@ interface SessionRow {
   title: string;
   status: string;
   live: boolean;
+  worktree_id: string | null;
   created_at: number;
   updated_at: number;
+}
+
+interface WorktreeSession {
+  id: string;
+  title: string;
+  status: string;
+  backend: string;
+  updated_at: number;
+}
+
+interface Worktree {
+  repo: string;
+  path: string;
+  branch: string | null;
+  base: string;
+  aheadCount: number;
+  dirty: boolean;
+  merged: boolean;
+  health: "ok" | "broken";
+  sessions: WorktreeSession[];
+  github: boolean;
 }
 
 const AGENT_BRANDS: Record<string, BrandName> = {
@@ -34,6 +47,8 @@ const AGENT_BRANDS: Record<string, BrandName> = {
   codex: "openai",
   opencode: "opencode",
 };
+
+const ACTIVE_STATUSES = new Set(["starting", "running", "waiting"]);
 
 function AgentBrandIcon({ backend, className }: { backend: string; className?: string }) {
   const name = AGENT_BRANDS[backend];
@@ -69,21 +84,39 @@ function timeAgo(ts: number): string {
   return `${Math.floor(s / 86400)}d ago`;
 }
 
+// Last touch on a copy = its most recent session activity. Copies with no
+// sessions sort last.
+function lastActivity(wt: Worktree): number {
+  return wt.sessions.reduce((m, s) => Math.max(m, s.updated_at ?? 0), 0);
+}
+
+function hasActiveSession(wt: Worktree): boolean {
+  return wt.sessions.some((s) => ACTIVE_STATUSES.has(s.status));
+}
+
 export function AgentsView() {
   const router = useRouter();
   const { prefix } = useProject();
-  const [agents, setAgents] = useState<DetectedAgent[]>([]);
   const [sessions, setSessions] = useState<SessionRow[]>([]);
+  const [trees, setTrees] = useState<Worktree[]>([]);
   const [loading, setLoading] = useState(true);
+  const [treesLoaded, setTreesLoaded] = useState(false);
+
+  // "+ New session" on a copy targets the composer at that copy.
+  const [copyTarget, setCopyTarget] = useState<CopyTarget | null>(null);
+  const composerRef = useRef<HTMLDivElement>(null);
 
   const refresh = useCallback(async () => {
     try {
-      const [a, s] = await Promise.all([
-        fetch(prefix("/api/agents")).then((r) => (r.ok ? r.json() : {})) as Promise<{ agents?: DetectedAgent[] }>,
+      const [s, w] = await Promise.all([
         fetch(prefix("/api/agents/sessions")).then((r) => (r.ok ? r.json() : {})) as Promise<{ sessions?: SessionRow[] }>,
+        fetch(prefix("/api/agents/worktrees")).then((r) => (r.ok ? r.json() : {})) as Promise<{ worktrees?: Worktree[] }>,
       ]);
-      setAgents(a.agents ?? []);
       setSessions(s.sessions ?? []);
+      if (Array.isArray(w.worktrees)) {
+        setTrees(w.worktrees);
+        setTreesLoaded(true);
+      }
     } finally {
       setLoading(false);
     }
@@ -95,8 +128,15 @@ export function AgentsView() {
     return () => clearInterval(iv);
   }, [refresh]);
 
+  const navigate = useCallback((sid: string) => router.push(prefix(`/agents/${sid}`)), [router, prefix]);
+
+  const startInCopy = useCallback((wt: Worktree) => {
+    setCopyTarget({ path: wt.path, branch: wt.branch, repo: wt.repo });
+    composerRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, []);
+
   return (
-    <div className="max-w-4xl pb-16">
+    <div className="max-w-6xl pb-16">
       <Kicker>Your coding agents</Kicker>
       <Heading className="mb-2">Give the work to an agent.</Heading>
       <p className="text-text-muted text-[14px] mb-8 max-w-xl">
@@ -105,79 +145,126 @@ export function AgentsView() {
       </p>
 
       {/* New Task Composer Box */}
-      <Card className="p-5 mb-10">
-        <Kicker>New Agent Task</Kicker>
-        <div className="mt-2 mb-4">
-          <h2
-            style={{ fontFamily: "var(--font-display)" }}
-            className="text-base font-semibold text-ink"
-          >
-            Start a new coding task
-          </h2>
-          <p className="text-text-muted text-[12.5px] mt-0.5">
-            Select your engine, model, and target local folder below to launch an agent.
-          </p>
-        </div>
+      <div ref={composerRef} className="scroll-mt-4">
+        <Card className="p-5 mb-10">
+          <Kicker>New Agent Task</Kicker>
+          <div className="mt-2 mb-4">
+            <h2
+              style={{ fontFamily: "var(--font-display)" }}
+              className="text-base font-semibold text-ink"
+            >
+              Start a new coding task
+            </h2>
+            <p className="text-text-muted text-[12.5px] mt-0.5">
+              Select your engine, model, and target local folder below to launch an agent.
+            </p>
+          </div>
 
-        <AgentTaskComposer />
-      </Card>
+          <AgentTaskComposer
+            worktreeTarget={copyTarget}
+            onClearWorktreeTarget={() => setCopyTarget(null)}
+          />
+        </Card>
+      </div>
 
-      {/* Separate copies (worktrees) */}
-      <SeparateCopies onNavigate={(sid) => router.push(prefix(`/agents/${sid}`))} />
-
-      {/* Sessions History */}
-      <Kicker>Sessions</Kicker>
-      <div className="mt-3 flex flex-col gap-2">
-        {sessions.length === 0 && !loading && (
-          <p className="text-text-muted text-[13px]">No sessions yet — start one above.</p>
-        )}
-        {sessions.map((s) => (
-          <button
-            key={s.id}
-            onClick={() => router.push(prefix(`/agents/${s.id}`))}
-            className="text-left rounded-lg border border-line bg-paper px-4 py-3 hover:bg-cream transition flex items-center gap-4 cursor-pointer"
-          >
-            <AgentBrandIcon backend={s.backend} className="text-ink flex-shrink-0" />
-            <div className="min-w-0 flex-1">
-              <p className="text-ink text-[13.5px] truncate font-medium" style={{ fontFamily: "var(--font-display)" }}>
-                {s.title}
-              </p>
-              <p style={{ fontFamily: "var(--font-mono)" }} className="text-[10px] uppercase tracking-wider text-text-muted mt-0.5">
-                {s.backend} · {s.repo} · {timeAgo(s.updated_at)}
-              </p>
-            </div>
-            <StatusPill kind={statusKind(s.status)}>{statusLabel(s.status)}</StatusPill>
-          </button>
-        ))}
+      {/* Split view: workspaces (separate copies) left, session history right */}
+      <div className="grid gap-10 lg:gap-8 lg:grid-cols-[minmax(0,7fr)_minmax(0,5fr)] items-start">
+        <WorkspacesColumn
+          trees={trees}
+          loaded={treesLoaded}
+          onNavigate={navigate}
+          onNewSession={startInCopy}
+          onChanged={refresh}
+        />
+        <SessionsColumn sessions={sessions} loading={loading} onNavigate={navigate} />
       </div>
     </div>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Separate copies — isolated branch checkouts
-interface WorktreeSession {
-  id: string;
-  title: string;
-  status: string;
-}
-interface Worktree {
-  repo: string;
-  path: string;
-  branch: string | null;
-  base: string;
-  aheadCount: number;
-  dirty: boolean;
-  merged: boolean;
-  health: "ok" | "broken";
-  sessions: WorktreeSession[];
-  github: boolean;
+// Sessions — recency-sorted history, capped with "show all". Sessions that ran
+// on a separate copy carry a ⎇ badge so the two columns cross-reference.
+
+const SESSIONS_SHOWN = 12;
+
+function SessionsColumn({
+  sessions,
+  loading,
+  onNavigate,
+}: {
+  sessions: SessionRow[];
+  loading: boolean;
+  onNavigate: (sid: string) => void;
+}) {
+  const [showAll, setShowAll] = useState(false);
+  const shown = showAll ? sessions : sessions.slice(0, SESSIONS_SHOWN);
+
+  return (
+    <div>
+      <Kicker>Sessions</Kicker>
+      <p className="text-text-muted text-[12.5px] mt-1 mb-3">
+        Every agent run, newest first. ⎇ marks runs on a separate copy.
+      </p>
+      <div className="flex flex-col gap-2">
+        {sessions.length === 0 && !loading && (
+          <p className="text-text-muted text-[13px]">No sessions yet — start one above.</p>
+        )}
+        {shown.map((s) => (
+          <button
+            key={s.id}
+            onClick={() => onNavigate(s.id)}
+            className="text-left rounded-lg border border-line bg-paper px-3.5 py-2.5 hover:bg-cream transition flex items-center gap-3 cursor-pointer"
+          >
+            <AgentBrandIcon backend={s.backend} className="text-ink flex-shrink-0" />
+            <div className="min-w-0 flex-1">
+              <p className="text-ink text-[13px] truncate font-medium" style={{ fontFamily: "var(--font-display)" }}>
+                {s.title}
+              </p>
+              <p style={{ fontFamily: "var(--font-mono)" }} className="text-[10px] uppercase tracking-wider text-text-muted mt-0.5 truncate">
+                {s.backend} · {timeAgo(s.updated_at)}
+                {s.worktree_id ? (
+                  <span className="normal-case" title={`Ran on separate copy ${s.worktree_id}`}>
+                    {" "}· ⎇ {s.worktree_id.split("/").pop()}
+                  </span>
+                ) : null}
+              </p>
+            </div>
+            <StatusPill kind={statusKind(s.status)}>{statusLabel(s.status)}</StatusPill>
+          </button>
+        ))}
+      </div>
+      {sessions.length > SESSIONS_SHOWN && (
+        <button
+          onClick={() => setShowAll((v) => !v)}
+          className="mt-2 text-[12px] text-text-muted hover:text-ink transition cursor-pointer"
+        >
+          {showAll ? "Show fewer" : `Show all ${sessions.length}`}
+        </button>
+      )}
+    </div>
+  );
 }
 
-function SeparateCopies({ onNavigate }: { onNavigate: (sessionId: string) => void }) {
+// ---------------------------------------------------------------------------
+// Workspaces — the separate copies. Sorted by activity (working copies first,
+// then most recently touched). Merged, settled copies fold away into a
+// cleanup group with a one-click "Clear all".
+
+function WorkspacesColumn({
+  trees,
+  loaded,
+  onNavigate,
+  onNewSession,
+  onChanged,
+}: {
+  trees: Worktree[];
+  loaded: boolean;
+  onNavigate: (sessionId: string) => void;
+  onNewSession: (wt: Worktree) => void;
+  onChanged: () => Promise<void>;
+}) {
   const { prefix } = useProject();
-  const [trees, setTrees] = useState<Worktree[]>([]);
-  const [loaded, setLoaded] = useState(false);
 
   const [busy, setBusy] = useState<Record<string, boolean>>({});
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -188,24 +275,26 @@ function SeparateCopies({ onNavigate }: { onNavigate: (sessionId: string) => voi
   const [conflicts, setConflicts] = useState<Record<string, { targetBranch: string; files: string[] } | undefined>>({});
   const [openDiff, setOpenDiff] = useState<Record<string, boolean>>({});
   const [diffs, setDiffs] = useState<Record<string, { files: DiffFile[]; diff: string; truncated: boolean } | null>>({});
+  const [mergedOpen, setMergedOpen] = useState(false);
+  const [clearing, setClearing] = useState<{ done: number; total: number } | null>(null);
 
-  const refresh = useCallback(async () => {
-    try {
-      const r = await fetch(prefix("/api/agents/worktrees"));
-      const d = await r.json();
-      if (Array.isArray(d.worktrees)) setTrees(d.worktrees);
-    } catch {
-      /* leave last known */
-    } finally {
-      setLoaded(true);
+  // Settled copies (merged, clean, nothing running) fold away; everything else
+  // stays visible, working copies first, then most recently touched.
+  const { activeTrees, settledTrees } = useMemo(() => {
+    const settled: Worktree[] = [];
+    const active: Worktree[] = [];
+    for (const wt of trees) {
+      if (wt.health === "ok" && wt.merged && !wt.dirty && !hasActiveSession(wt)) settled.push(wt);
+      else active.push(wt);
     }
-  }, [prefix]);
-
-  useEffect(() => {
-    refresh();
-    const iv = setInterval(refresh, 8000);
-    return () => clearInterval(iv);
-  }, [refresh]);
+    const byRecency = (a: Worktree, b: Worktree) =>
+      Number(hasActiveSession(b)) - Number(hasActiveSession(a)) ||
+      lastActivity(b) - lastActivity(a) ||
+      (a.branch ?? "").localeCompare(b.branch ?? "");
+    active.sort(byRecency);
+    settled.sort(byRecency);
+    return { activeTrees: active, settledTrees: settled };
+  }, [trees]);
 
   const setError = (path: string, msg: string) => setErrors((e) => ({ ...e, [path]: msg }));
   const clearError = (path: string) => setErrors((e) => ({ ...e, [path]: "" }));
@@ -228,11 +317,35 @@ function SeparateCopies({ onNavigate }: { onNavigate: (sessionId: string) => voi
         return;
       }
       if (action === "remove") setConfirmRemove((c) => ({ ...c, [path]: false }));
-      await refresh();
+      await onChanged();
     } catch {
       setError(path, "Couldn't reach the server.");
     } finally {
       setBusy((b) => ({ ...b, [path]: false }));
+    }
+  }
+
+  // One click clears every settled copy — sequential removes so partial
+  // failures leave an accurate list behind.
+  async function clearSettled() {
+    const targets = settledTrees;
+    setClearing({ done: 0, total: targets.length });
+    try {
+      for (let i = 0; i < targets.length; i++) {
+        try {
+          await fetch(prefix("/api/agents/worktrees/remove"), {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ path: targets[i].path }),
+          });
+        } catch {
+          /* keep going — the refresh below shows what's left */
+        }
+        setClearing({ done: i + 1, total: targets.length });
+      }
+      await onChanged();
+    } finally {
+      setClearing(null);
     }
   }
 
@@ -266,7 +379,7 @@ function SeparateCopies({ onNavigate }: { onNavigate: (sessionId: string) => voi
         setPrUrls((p) => ({ ...p, [path]: data.compareUrl }));
         window.open(data.compareUrl, "_blank", "noopener,noreferrer");
       }
-      await refresh();
+      await onChanged();
     } catch {
       setError(path, "Couldn't reach the server.");
     } finally {
@@ -339,23 +452,65 @@ function SeparateCopies({ onNavigate }: { onNavigate: (sessionId: string) => voi
     }
   }
 
-  if (!loaded || trees.length === 0) return null;
+  function removeButton(wt: Worktree) {
+    const b = busy[wt.path];
+    if (confirmRemove[wt.path]) {
+      return (
+        <span className="inline-flex items-center gap-2">
+          <span className="text-[11px] text-text-muted">Uncommitted changes — remove anyway?</span>
+          <button
+            onClick={() => act(wt.path, "remove", { force: true })}
+            disabled={b}
+            className="rounded-md border border-line bg-paper px-2 py-0.5 text-[11px] hover:bg-cream transition disabled:opacity-50 cursor-pointer"
+            style={{ color: "var(--danger)" }}
+          >
+            Remove
+          </button>
+          <button
+            onClick={() => setConfirmRemove((c) => ({ ...c, [wt.path]: false }))}
+            className="text-[11px] text-text-muted hover:text-ink transition cursor-pointer"
+          >
+            Cancel
+          </button>
+        </span>
+      );
+    }
+    return (
+      <button
+        onClick={() => (wt.dirty ? setConfirmRemove((c) => ({ ...c, [wt.path]: true })) : act(wt.path, "remove"))}
+        disabled={b}
+        title="Remove this copy"
+        className="rounded-md px-1.5 py-0.5 text-[14px] leading-none text-text-muted hover:text-ink hover:bg-cream transition disabled:opacity-50 cursor-pointer"
+      >
+        ×
+      </button>
+    );
+  }
 
   return (
-    <div className="mb-10">
-      <Kicker>Separate copies</Kicker>
-      <p className="text-text-muted text-[12.5px] mt-1 mb-3 max-w-xl">
-        Isolated copies of a branch, made when two agents would otherwise share one folder. Open a PR
-        from the copy, review conflicts, or clear the copy away.
+    <div>
+      <Kicker>Workspaces · Separate copies</Kicker>
+      <p className="text-text-muted text-[12.5px] mt-1 mb-3">
+        Isolated copies of a branch. Each holds its own sessions — start another
+        agent in a copy, open a PR from it, or clear it away.
       </p>
-      <div className="flex flex-col gap-2">
-        {trees.map((wt) => {
+
+      {loaded && trees.length === 0 && (
+        <p className="text-text-muted text-[13px]">
+          No separate copies yet. Flow makes one when two agents would share a
+          folder — or pick “Separate copy” when starting a task.
+        </p>
+      )}
+
+      <div className="flex flex-col gap-2.5">
+        {activeTrees.map((wt) => {
           const b = busy[wt.path];
           const err = errors[wt.path];
           const notice = notices[wt.path];
           const compareUrl = prUrls[wt.path];
           const targetBranch = targetBranches[wt.path] ?? wt.base;
           const conflict = conflicts[wt.path];
+          const touched = lastActivity(wt);
 
           if (wt.health === "broken") {
             return (
@@ -369,7 +524,7 @@ function SeparateCopies({ onNavigate }: { onNavigate: (sessionId: string) => voi
                   <button
                     onClick={() => act(wt.path, "remove", { force: true })}
                     disabled={b}
-                    className="rounded-md border border-line bg-paper px-2.5 py-1 text-[11.5px] text-text hover:bg-cream transition disabled:opacity-50"
+                    className="rounded-md border border-line bg-paper px-2.5 py-1 text-[11.5px] text-text hover:bg-cream transition disabled:opacity-50 cursor-pointer"
                   >
                     Remove
                   </button>
@@ -381,14 +536,17 @@ function SeparateCopies({ onNavigate }: { onNavigate: (sessionId: string) => voi
 
           return (
             <div key={wt.path} className="rounded-lg border border-line bg-paper px-4 py-3">
-              <div className="flex items-center gap-3 flex-wrap">
+              {/* Header: branch + state, remove tucked right */}
+              <div className="flex items-center gap-2.5 flex-wrap">
                 <span style={{ fontFamily: "var(--font-mono)" }} className="text-[12px] text-ink truncate max-w-[240px]" title={wt.branch ?? ""}>
-                  {wt.branch ?? "(detached)"}
+                  ⎇ {wt.branch ?? "(detached)"}
                 </span>
-                <span className="text-[11px] uppercase tracking-wider text-text-muted" style={{ fontFamily: "var(--font-mono)" }}>
+                <span className="text-[10.5px] uppercase tracking-wider text-text-muted" style={{ fontFamily: "var(--font-mono)" }}>
                   {wt.repo}
                 </span>
-                {wt.merged ? (
+                {hasActiveSession(wt) ? (
+                  <StatusPill kind="live">working</StatusPill>
+                ) : wt.merged ? (
                   <StatusPill kind="ok">merged</StatusPill>
                 ) : (
                   <StatusPill kind="idle">
@@ -401,23 +559,46 @@ function SeparateCopies({ onNavigate }: { onNavigate: (sessionId: string) => voi
                     uncommitted
                   </span>
                 )}
+                {touched > 0 && (
+                  <span className="text-[10.5px] text-text-muted" style={{ fontFamily: "var(--font-mono)" }}>
+                    {timeAgo(touched)}
+                  </span>
+                )}
                 <div className="flex-1" />
+                {removeButton(wt)}
+              </div>
+
+              {/* Sessions inside this copy */}
+              <div className="mt-2 flex flex-col gap-1">
                 {wt.sessions.map((s) => (
                   <button
                     key={s.id}
                     onClick={() => onNavigate(s.id)}
-                    className="text-[11px] text-text-muted hover:text-ink transition truncate max-w-[180px]"
+                    className="flex items-center gap-2 text-left rounded-md px-2 py-1 -mx-2 hover:bg-cream transition cursor-pointer"
                     title={s.title}
                   >
-                    {s.title}
+                    <AgentBrandIcon backend={s.backend} className="text-ink flex-shrink-0" />
+                    <span className="text-[12px] text-ink truncate flex-1">{s.title}</span>
+                    <span className="text-[10px] text-text-muted flex-shrink-0" style={{ fontFamily: "var(--font-mono)" }}>
+                      {s.updated_at ? timeAgo(s.updated_at) : ""}
+                    </span>
+                    <StatusPill kind={statusKind(s.status)}>{statusLabel(s.status)}</StatusPill>
                   </button>
                 ))}
+                <button
+                  onClick={() => onNewSession(wt)}
+                  className="self-start text-[11.5px] text-text-muted hover:text-ink transition px-2 py-1 -mx-2 rounded-md hover:bg-cream cursor-pointer"
+                  title="Start another agent session in this copy"
+                >
+                  + New session in this copy
+                </button>
               </div>
 
-              <div className="flex items-center gap-2 flex-wrap mt-2.5">
+              {/* Actions */}
+              <div className="flex items-center gap-2 flex-wrap mt-2">
                 <button
                   onClick={() => toggleDiff(wt.path)}
-                  className="rounded-md border border-line bg-paper px-2.5 py-1 text-[11.5px] text-text hover:bg-cream transition"
+                  className="rounded-md border border-line bg-paper px-2.5 py-1 text-[11.5px] text-text hover:bg-cream transition cursor-pointer"
                 >
                   {openDiff[wt.path] ? "Hide changes" : "View changes"}
                 </button>
@@ -436,40 +617,11 @@ function SeparateCopies({ onNavigate }: { onNavigate: (sessionId: string) => voi
                     <button
                       onClick={() => openPr(wt.path, targetBranch)}
                       disabled={b || !targetBranch.trim()}
-                      className="rounded-md border border-line bg-paper px-2.5 py-1 text-[11.5px] text-text hover:bg-cream transition disabled:opacity-50"
+                      className="rounded-md border border-line bg-paper px-2.5 py-1 text-[11.5px] text-text hover:bg-cream transition disabled:opacity-50 cursor-pointer"
                     >
-                      Open PR to {targetBranch || wt.base}
+                      Open PR
                     </button>
                   </>
-                )}
-                {confirmRemove[wt.path] ? (
-                  <span className="inline-flex items-center gap-2">
-                    <span className="text-[11.5px] text-text-muted">
-                      This copy has uncommitted changes. Remove anyway?
-                    </span>
-                    <button
-                      onClick={() => act(wt.path, "remove", { force: true })}
-                      disabled={b}
-                      className="rounded-md border border-line bg-paper px-2.5 py-1 text-[11.5px] hover:bg-cream transition disabled:opacity-50"
-                      style={{ color: "var(--danger)" }}
-                    >
-                      Remove anyway
-                    </button>
-                    <button
-                      onClick={() => setConfirmRemove((c) => ({ ...c, [wt.path]: false }))}
-                      className="text-[11px] text-text-muted hover:text-ink transition"
-                    >
-                      Cancel
-                    </button>
-                  </span>
-                ) : (
-                  <button
-                    onClick={() => (wt.dirty ? setConfirmRemove((c) => ({ ...c, [wt.path]: true })) : act(wt.path, "remove"))}
-                    disabled={b}
-                    className="rounded-md border border-line bg-paper px-2.5 py-1 text-[11.5px] text-text-muted hover:bg-cream transition disabled:opacity-50"
-                  >
-                    Remove
-                  </button>
                 )}
               </div>
 
@@ -492,14 +644,14 @@ function SeparateCopies({ onNavigate }: { onNavigate: (sessionId: string) => voi
                   <button
                     onClick={() => openCopyInVsCode(wt.path)}
                     disabled={b}
-                    className="rounded-md border border-line bg-paper px-2.5 py-1 text-[11px] text-text hover:bg-cream transition disabled:opacity-50"
+                    className="rounded-md border border-line bg-paper px-2.5 py-1 text-[11px] text-text hover:bg-cream transition disabled:opacity-50 cursor-pointer"
                   >
                     Review in VS Code
                   </button>
                   <button
                     onClick={() => resolveConflictWithAi(wt)}
                     disabled={b}
-                    className="rounded-md border border-line bg-paper px-2.5 py-1 text-[11px] text-text hover:bg-cream transition disabled:opacity-50"
+                    className="rounded-md border border-line bg-paper px-2.5 py-1 text-[11px] text-text hover:bg-cream transition disabled:opacity-50 cursor-pointer"
                   >
                     Resolve using AI
                   </button>
@@ -523,6 +675,63 @@ function SeparateCopies({ onNavigate }: { onNavigate: (sessionId: string) => voi
           );
         })}
       </div>
+
+      {/* Merged, settled copies — folded away with one-click cleanup */}
+      {settledTrees.length > 0 && (
+        <div className="mt-4 rounded-lg border border-line bg-cream/40">
+          <div className="flex items-center gap-3 px-4 py-2.5">
+            <button
+              onClick={() => setMergedOpen((v) => !v)}
+              className="flex items-center gap-2 text-[12.5px] text-text hover:text-ink transition cursor-pointer"
+            >
+              <span className="text-[10px]">{mergedOpen ? "▾" : "▸"}</span>
+              Merged copies ({settledTrees.length})
+            </button>
+            <div className="flex-1" />
+            <button
+              onClick={clearSettled}
+              disabled={clearing !== null}
+              className="rounded-md border border-line bg-paper px-2.5 py-1 text-[11.5px] text-text hover:bg-cream transition disabled:opacity-50 cursor-pointer"
+            >
+              {clearing ? `Clearing ${clearing.done}/${clearing.total}…` : "Clear all merged"}
+            </button>
+          </div>
+          {mergedOpen && (
+            <div className="border-t border-line px-4 py-2 flex flex-col">
+              {settledTrees.map((wt) => (
+                <div key={wt.path} className="flex items-center gap-2.5 py-1.5">
+                  <span style={{ fontFamily: "var(--font-mono)" }} className="text-[11.5px] text-text-muted truncate max-w-[260px]" title={wt.path}>
+                    ⎇ {wt.branch ?? "(detached)"}
+                  </span>
+                  {wt.sessions.length > 0 && (
+                    <button
+                      onClick={() => onNavigate(wt.sessions[0].id)}
+                      className="text-[10.5px] text-text-muted hover:text-ink transition truncate max-w-[180px] cursor-pointer"
+                      title={wt.sessions[0].title}
+                    >
+                      {wt.sessions[0].title}
+                    </button>
+                  )}
+                  <div className="flex-1" />
+                  <span className="text-[10px] text-text-muted" style={{ fontFamily: "var(--font-mono)" }}>
+                    {lastActivity(wt) > 0 ? timeAgo(lastActivity(wt)) : ""}
+                  </span>
+                  <button
+                    onClick={() => act(wt.path, "remove")}
+                    disabled={busy[wt.path] || clearing !== null}
+                    className="text-[11px] text-text-muted hover:text-ink transition disabled:opacity-50 cursor-pointer"
+                  >
+                    Remove
+                  </button>
+                  {errors[wt.path] && (
+                    <span className="text-[10.5px]" style={{ color: "var(--danger)" }}>{errors[wt.path]}</span>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/orchestrator/src/agents/routes.ts
+++ b/orchestrator/src/agents/routes.ts
@@ -114,6 +114,8 @@ export function registerAgentRoutes(app: FastifyInstance): void {
   //   {error}                                — 400.
   // `placement` (optional): "in_place" starts anyway in the same folder;
   // "separate_copy" branches the checkout into a worktree and runs there.
+  // `worktreePath` (optional): run in an EXISTING managed copy — the "+ new
+  // session" action on a copy card. No collision prompt; targeting is deliberate.
   app.post("/v1/agents/sessions", async (req, reply) => {
     const body = req.body as {
       backend?: string;
@@ -121,6 +123,7 @@ export function registerAgentRoutes(app: FastifyInstance): void {
       prompt?: string;
       placement?: string;
       workFolder?: string;
+      worktreePath?: string;
       owner?: string;
       config?: Record<string, string | boolean>;
       modeId?: string;
@@ -166,12 +169,15 @@ export function registerAgentRoutes(app: FastifyInstance): void {
       data: a.data,
       mimeType: a.mimeType,
     }));
+    const worktreePath =
+      typeof body.worktreePath === "string" && body.worktreePath.trim() ? body.worktreePath.trim() : undefined;
     const result = await createSession({
       backend,
       repo: body.repo,
       prompt: body.prompt.trim(),
       placement,
       workFolder,
+      worktreePath,
       config,
       modeId,
       attachments: attachments.length ? attachments : undefined,

--- a/orchestrator/src/agents/runtime.ts
+++ b/orchestrator/src/agents/runtime.ts
@@ -1064,6 +1064,10 @@ export async function createSession(opts: {
   // repo's knowledge, but make the changes in THIS checkout." Overrides the
   // repo's default surface.
   workFolder?: string;
+  // Run inside an EXISTING managed separate copy (the "+ new session" action
+  // on a copy card). The copy is already isolated, so no collision prompt —
+  // targeting it is deliberate.
+  worktreePath?: string;
   // Kickoff-chosen session config (model selector, thought-level toggles, …)
   // picked from the backend's advertised configOptions — applied right after
   // newSession, before the first turn. Same RPCs the session page uses live.
@@ -1075,11 +1079,22 @@ export async function createSession(opts: {
 }): Promise<CreateSessionResult> {
   const found = listRepoOptions().find((r) => r.name === opts.repo);
   if (!found) return { error: `Unknown repo "${opts.repo}" — connect it first` };
-  if (!found.cloned && !opts.workFolder) return { error: `Repo "${opts.repo}" is not cloned yet` };
+  // EXISTING COPY target: validate it up front. A managed copy bypasses the
+  // work-folder guards below — it was branched off a work folder already.
+  if (opts.worktreePath) {
+    if (!isManagedWorktree(opts.worktreePath)) return { error: "That path isn't a Flow-managed copy." };
+    if (!existsSync(opts.worktreePath)) return { error: `Copy folder not found: ${opts.worktreePath}` };
+    if (managedRepoOf(opts.worktreePath) !== opts.repo) {
+      return { error: `That copy doesn't belong to "${opts.repo}".` };
+    }
+  }
+  if (!found.cloned && !opts.workFolder && !opts.worktreePath) {
+    return { error: `Repo "${opts.repo}" is not cloned yet` };
+  }
   // BRAIN/WORK separation: a GitHub-added repo's only checkout is Flow's
   // managed clone, which the indexer force-resets at will — never a place to
   // run agents. Sessions over these repos require an explicit work folder.
-  if (found.surface === "managed" && !opts.workFolder) {
+  if (found.surface === "managed" && !opts.workFolder && !opts.worktreePath) {
     return {
       error: `"${opts.repo}" was connected from GitHub, so Flow only indexes it. Pick one of your folders to run the agent in.`,
     };
@@ -1097,8 +1112,9 @@ export async function createSession(opts: {
   // COLLISION check (in-place default only). When the caller hasn't yet chosen a
   // placement and the target folder is already held by a live session, stop and
   // ask — starting a second agent in the same working tree lets them overwrite
-  // each other's edits.
-  if (!opts.placement) {
+  // each other's edits. Skipped for an explicit copy target: clicking "+ new
+  // session" on a copy that's already busy is an informed choice.
+  if (!opts.placement && !opts.worktreePath) {
     const active = findCollision(repoOpt.path);
     if (active) {
       return { collision: true, active: { id: active.id, title: active.title, status: active.status } };
@@ -1111,7 +1127,10 @@ export async function createSession(opts: {
   // to in_place — running in place is exactly what the user asked to avoid.
   let cwd = repoOpt.path;
   let worktreeId: string | undefined;
-  if (opts.placement === "separate_copy") {
+  if (opts.worktreePath) {
+    cwd = opts.worktreePath;
+    worktreeId = opts.worktreePath;
+  } else if (opts.placement === "separate_copy") {
     const wt = await createSessionWorktree({
       repoName: repoOpt.name,
       srcCheckout: repoOpt.path,
@@ -1853,16 +1872,26 @@ export async function listRepoBranches(repo: string): Promise<{ branches: string
 // createSession stores the raw dest path, `git worktree list` emits realpaths,
 // and on macOS those differ (/var vs /private/var). Live status wins over the
 // stored row status when the session is in the live map.
-function sessionsForWorktree(treePath: string): Array<{ id: string; title: string; status: SessionStatus }> {
+function sessionsForWorktree(
+  treePath: string
+): Array<{ id: string; title: string; status: SessionStatus; backend: string; updated_at: number }> {
   const real = realpathOrSelf(treePath);
   const rows = db
-    .prepare(`SELECT id, title, status, worktree_id FROM agent_sessions WHERE worktree_id IS NOT NULL ORDER BY created_at DESC`)
-    .all() as Array<{ id: string; title: string; status: string; worktree_id: string }>;
+    .prepare(
+      `SELECT id, title, status, backend, updated_at, worktree_id FROM agent_sessions WHERE worktree_id IS NOT NULL ORDER BY updated_at DESC`
+    )
+    .all() as Array<{ id: string; title: string; status: string; backend: string; updated_at: number; worktree_id: string }>;
   return rows
     .filter((r) => realpathOrSelf(r.worktree_id) === real)
     .map((r) => {
       const live = sessions.get(r.id);
-      return { id: r.id, title: r.title, status: (live?.status ?? r.status) as SessionStatus };
+      return {
+        id: r.id,
+        title: r.title,
+        status: (live?.status ?? r.status) as SessionStatus,
+        backend: r.backend,
+        updated_at: live?.updatedAt ?? r.updated_at,
+      };
     });
 }
 
@@ -1875,7 +1904,7 @@ export interface ManagedWorktree {
   dirty: boolean;
   merged: boolean;
   health: "ok" | "broken";
-  sessions: Array<{ id: string; title: string; status: SessionStatus }>;
+  sessions: Array<{ id: string; title: string; status: SessionStatus; backend: string; updated_at: number }>;
   github: boolean; // repo has a GitHub url → PR action is available
 }
 


### PR DESCRIPTION
## Problem

The agents page rendered every separate copy (worktree) as one flat, effectively unsorted pile — merged copies never left, there was no timestamp to anchor any order, and the Sessions list sat orphaned below the fold. Starting a second session in an existing copy had no UI at all (only the collision prompt could ever land one there).

## Changes

**Dashboard**
- Split view below the composer: **Workspaces (separate copies)** left, **Sessions** right (stacks on narrow screens).
- Copies sort by activity: working copies pinned first, then most recently touched; each card shows a last-activity stamp so the order is legible.
- Merged/clean/inactive copies fold into a collapsed **Merged copies (N)** group with one-click **Clear all merged** (sequential removes with progress). Per-card Remove is now a compact one-click ×, inline confirm only when the copy has uncommitted changes.
- Copy cards list their sessions (engine icon, title, time, status — clickable) and gain **"+ New session in this copy"**: scrolls to the composer and swaps the folder chip for a `⎇ branch · separate copy` chip, reusing the full engine/model/mode/attachment machinery. @-mentions autocomplete against the copy's checkout.
- Session rows carry a `⎇ copy-name` badge when they ran on a separate copy; list caps at 12 with "Show all N".

**Orchestrator**
- `POST /v1/agents/sessions` accepts `worktreePath` — run the session inside an existing managed copy. Validated (Flow-managed, exists, belongs to the repo); bypasses work-folder guards and the collision prompt since targeting a copy is deliberate.
- `sessionsForWorktree` now returns `backend` + `updated_at`, powering the recency sort and per-session rows.

## Testing

- Orchestrator worktree, work-folder, and agent-diff suites pass (43 tests).
- `tsc --noEmit` clean on all touched files (remaining errors are pre-existing and unrelated).

Note: UI and orchestrator ship together — the old orchestrator ignores `worktreePath`, so the new "+ New session in this copy" needs both deployed.