### PR TITLE
Revert #55: brain-graph memory overlay

### DIFF
--- a/dashboard/src/app/api/graph/overview/route.ts
+++ b/dashboard/src/app/api/graph/overview/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
 import { getSessionToken } from "@/lib/auth";
 import { requireProject } from "@/lib/projectContext";
-import { orcFetch } from "@/lib/orchestrator";
 
 // GET /api/graph/overview
 // Calls the graph-gateway POST /v1/verbs/read_query with safe read-only Cypher
@@ -10,8 +9,6 @@ import { orcFetch } from "@/lib/orchestrator";
 // `MATCH (n) OPTIONAL MATCH (n)-[r]->(m)` query multiplies rows by out-degree,
 // so any row LIMIT silently drops whole subgraphs once the graph grows.
 // We omit `graph` from the body so the gateway uses its configured default graph.
-// Distilled memories (orchestrator flow.db) are overlaid as Memory nodes with
-// ANCHORED_TO edges — best-effort, skipped when the orchestrator is unreachable.
 
 const NODES_CYPHER = `MATCH (n) RETURN n`;
 const EDGES_CYPHER = `MATCH ()-[r]->() RETURN r`;
@@ -48,19 +45,6 @@ interface CyEdge {
   source: string;
   target: string;
   label: string;
-}
-
-// Memories live in the orchestrator's flow.db, not FalkorDB. The anchors
-// table owns the memory↔node join (anchors.ts: "any graph representation is
-// a rebuildable projection") — so the overlay is fetched per request and
-// projected onto the graph as Memory nodes + ANCHORED_TO edges.
-interface OverlayMemory {
-  id: string;
-  claim: string;
-  kind: string;
-  repo: string | null;
-  strength: number;
-  anchors: string[];
 }
 
 export async function GET() {
@@ -125,38 +109,6 @@ export async function GET() {
       if (!edgesSet.has(key)) {
         edgesSet.add(key);
         edges.push({ source: s, target: t, label });
-      }
-    }
-
-    // Overlay memories onto the graph. Anchored memories link to their
-    // resolved nodes; unanchored ones fall back to their repo node (the same
-    // repo-level fallback the anchor resolver uses). Orchestrator down or an
-    // empty brain → no overlay, never a failed overview.
-    if (nodesMap.size > 0) {
-      try {
-        const res = await orcFetch("/v1/memory/graph-overlay", token);
-        if (res.ok) {
-          const { memories } = (await res.json()) as { memories: OverlayMemory[] };
-          for (const m of memories) {
-            let targets = m.anchors.filter((id) => nodesMap.has(id));
-            if (targets.length === 0 && m.repo && nodesMap.has(`repo:${m.repo}`)) {
-              targets = [`repo:${m.repo}`];
-            }
-            if (targets.length === 0) continue;
-            const memId = `mem:${m.id}`;
-            nodesMap.set(memId, {
-              id: memId,
-              data: {
-                name: m.claim.length > 80 ? `${m.claim.slice(0, 80)}…` : m.claim,
-                type: "Memory",
-                description: `(${m.kind}) ${m.claim}`,
-              },
-            });
-            for (const t of targets) edges.push({ source: memId, target: t, label: "ANCHORED_TO" });
-          }
-        }
-      } catch {
-        // overlay is best-effort
       }
     }
 

--- a/dashboard/src/components/BrainGraph.tsx
+++ b/dashboard/src/components/BrainGraph.tsx
@@ -25,8 +25,6 @@ const TYPE_COLORS: Record<string, string> = {
   Repo:         "#B8D4C8",
   file:         "#D4C8B8", // warm gray
   File:         "#D4C8B8",
-  memory:       "#F2E39B", // pale gold — distilled memories overlaid from flow.db
-  Memory:       "#F2E39B",
 };
 
 const DEFAULT_NODE_COLOR = "rgb(162, 163, 148)"; // --text-muted adapted

--- a/orchestrator/src/memory/routes.ts
+++ b/orchestrator/src/memory/routes.ts
@@ -16,10 +16,6 @@
 //   GET  /v1/memory/orient-doc?repo=<name>           → {global, repo} rendered
 //                                                     ambient-tier docs (null
 //                                                     when a scope has none).
-//   GET  /v1/memory/graph-overlay                    → {memories:[{id, claim,
-//                                                     kind, repo, strength,
-//                                                     anchors:[node_id]}]} for
-//                                                     the brain-graph overlay.
 
 import type { FastifyInstance } from "fastify";
 import db from "../db.js";
@@ -162,28 +158,6 @@ export function registerMemoryRoutes(app: FastifyInstance): void {
       return reply.code(202).send({ status: "queued" });
     },
   );
-
-  // Graph overlay — every active memory with the graph node ids it is
-  // anchored to. flow.db owns the item↔node edges (see anchors.ts DESIGN:
-  // any graph representation is a rebuildable projection); the dashboard's
-  // brain canvas renders this as Memory nodes + ANCHORED_TO edges. Memories
-  // with no anchors still ship (with their repo) so the caller can fall
-  // back to the repo-level node.
-  app.get("/v1/memory/graph-overlay", async () => {
-    const memories = db
-      .prepare(`SELECT id, claim, kind, repo, strength FROM memories WHERE status = 'active'`)
-      .all() as Array<{ id: string; claim: string; kind: string; repo: string | null; strength: number }>;
-    const anchorRows = db
-      .prepare(`SELECT item_id, node_id FROM anchors WHERE item_type = 'memory'`)
-      .all() as Array<{ item_id: string; node_id: string }>;
-    const byItem = new Map<string, string[]>();
-    for (const a of anchorRows) {
-      const list = byItem.get(a.item_id) ?? [];
-      list.push(a.node_id);
-      byItem.set(a.item_id, list);
-    }
-    return { memories: memories.map((m) => ({ ...m, anchors: byItem.get(m.id) ?? [] })) };
-  });
 
   // The ambient tier — rendered orient docs, served verbatim into the
   // gateway's orient(). A scope with no members returns null, never "".


### PR DESCRIPTION
Reverts the PR #55 merge (c5b58c5) — backs the memory overlay (Memory nodes + ANCHORED_TO edges in the brain graph) out of dev.

The feature returns, together with the anchor-resolution fixes it needs, in a follow-up PR to be merged after this one.