### PR TITLE
dashboard: update banner with one-tap install

### DIFF
--- a/dashboard/src/app/api/update-status/route.ts
+++ b/dashboard/src/app/api/update-status/route.ts
@@ -1,9 +1,11 @@
 import { NextResponse } from "next/server";
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { promisify } from "node:util";
-import { existsSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync, writeSync } from "node:fs";
+import { randomBytes } from "node:crypto";
 import { join, resolve } from "node:path";
-import { getSessionToken } from "@/lib/auth";
+import { getSessionToken, requireOwner } from "@/lib/auth";
+import { FLOW_DATA_DIR, IS_LOCAL } from "@/lib/config";
 
 const exec = promisify(execFile);
 
@@ -60,11 +62,61 @@ async function checkUpstream(): Promise<UpdateStatus> {
   }
 }
 
+// Identifies THIS dashboard process. flow up restarts the dashboard, so the
+// update banner knows the install landed when the bootId it polls changes.
+const BOOT_ID = randomBytes(8).toString("hex");
+
 export async function GET() {
   const token = await getSessionToken();
   if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   if (!cache || Date.now() - cache.checkedAt > TTL_MS) {
     cache = await checkUpstream();
   }
-  return NextResponse.json(cache);
+  return NextResponse.json({ ...cache, bootId: BOOT_ID });
+}
+
+// Tapping the banner runs the same command the old badge told users to type:
+// `flow up`. The CLI owns the whole update path — ff-only pull, npm install
+// when the lockfile moved, dashboard rebuild, restart of every service
+// INCLUDING this process — so the child must be detached, with output going
+// to data/logs/self-update.log. The client keeps polling GET and reloads when
+// bootId changes. The cache is deliberately left alone here: polling must not
+// trigger a fresh `git fetch` while the updater is mid-pull.
+let installStartedAt = 0;
+
+export async function POST() {
+  const token = await getSessionToken();
+  if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!IS_LOCAL && !(await requireOwner())) {
+    return NextResponse.json({ error: "Only owners can install updates" }, { status: 403 });
+  }
+  // Double-tap / multi-tab guard; a successful install replaces this process,
+  // so the flag clearing itself on restart is exactly right.
+  if (installStartedAt && Date.now() - installStartedAt < 10 * 60 * 1000) {
+    return NextResponse.json({ ok: true, alreadyRunning: true, bootId: BOOT_ID });
+  }
+  installStartedAt = Date.now();
+
+  const logDir = join(FLOW_DATA_DIR, "logs");
+  mkdirSync(logDir, { recursive: true });
+  const fd = openSync(join(logDir, "self-update.log"), "a");
+  writeSync(fd, `\n── update triggered from dashboard ${new Date().toISOString()} ──\n`);
+
+  // The env flow up gave THIS process would leak into the services the child
+  // spawns ({...process.env, ...env}) — strip the dashboard-specific parts and
+  // let the CLI re-derive them.
+  const stripped = ["PORT", "NODE_ENV", "FLOW_DATA_DIR", "FLOW_AUTH_PATH", "FLOW_MODE"];
+  const env = Object.fromEntries(
+    Object.entries(process.env).filter(([k]) => !stripped.includes(k)),
+  ) as NodeJS.ProcessEnv;
+
+  const child = spawn(process.execPath, [join(FLOW_ROOT, "bin", "flow.mjs"), "up"], {
+    cwd: FLOW_ROOT,
+    env,
+    detached: true,
+    stdio: ["ignore", fd, fd],
+  });
+  child.unref();
+  closeSync(fd);
+  return NextResponse.json({ ok: true, bootId: BOOT_ID });
 }

--- a/dashboard/src/components/Nav.tsx
+++ b/dashboard/src/components/Nav.tsx
@@ -2,7 +2,6 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useMode } from "@/lib/useMode";
-import { useUpdateStatus } from "@/lib/useUpdateStatus";
 import { useProject } from "@/lib/useProject";
 import { ProjectSwitcher } from "@/components/ProjectSwitcher";
 
@@ -25,7 +24,6 @@ export function Nav() {
   const path = usePathname();
   const { prefix } = useProject();
   const { mode, loading } = useMode();
-  const update = useUpdateStatus();
 
   function isActive(href: string) {
     const full = prefix(href);
@@ -81,21 +79,6 @@ export function Nav() {
               style={{ background: mode === "prod" ? "var(--ok)" : "var(--text-muted)" }}
             />
             {mode === "prod" ? "Production" : "Local"}
-          </span>
-        )}
-
-        {/* Update badge — a long-running install that's fallen behind main.
-            flow up applies it (self-update runs at start), hence the hint. */}
-        {update.behind > 0 && (
-          <span
-            style={{ fontFamily: "var(--font-mono)" }}
-            className="inline-flex items-center gap-1.5 text-[10px] uppercase tracking-widest"
-            title={`${update.behind} commit${update.behind === 1 ? "" : "s"} behind (${update.current} → ${update.latest}). Restart with \`flow up\` to apply.`}
-          >
-            <span className="w-1.5 h-1.5 rounded-full" style={{ background: "var(--accent)" }} />
-            <span style={{ color: "var(--ink)" }}>
-              Update · <span className="normal-case">flow up</span>
-            </span>
           </span>
         )}
       </div>

--- a/dashboard/src/components/Shell.tsx
+++ b/dashboard/src/components/Shell.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { Nav } from "./Nav";
+import { UpdateBanner } from "./UpdateBanner";
 
 export function Shell({ children }: { children: React.ReactNode }) {
   return (
@@ -13,6 +14,7 @@ export function Shell({ children }: { children: React.ReactNode }) {
           maxWidth: "calc(100vw - 220px)",
         }}
       >
+        <UpdateBanner />
         {children}
       </main>
     </div>

--- a/dashboard/src/components/UpdateBanner.tsx
+++ b/dashboard/src/components/UpdateBanner.tsx
@@ -1,0 +1,153 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+import { useProject } from "@/lib/useProject";
+import { useUpdateStatus } from "@/lib/useUpdateStatus";
+
+// Update banner — shown across the top of every page when the flow checkout
+// is behind upstream (useUpdateStatus). One tap POSTs /api/update-status,
+// which runs `flow up` detached: pull, rebuild, restart everything including
+// the dashboard serving this page. We then poll GET and reload once the
+// server's bootId changes — a new dashboard process means the new build is
+// live. bootId (not `behind`) is the restart signal on purpose: `behind` can
+// read 0 mid-install (git lock contention makes the check bail), which would
+// reload the tab onto the OLD build and hide the banner for the cache TTL.
+//
+// The watch state lives in sessionStorage because Shell (and this banner)
+// remounts on every client-side navigation — losing the "installing" phase
+// mid-install would strand the tab on dead chunks with no reload.
+
+const WATCH_KEY = "flow-self-update"; // JSON {startedAt, bootId}
+const TIMEOUT_MS = 12 * 60 * 1000; // worst case: npm install (5m cap) + build + restarts
+const POLL_MS = 4000;
+
+interface Watch {
+  startedAt: number;
+  bootId: string;
+}
+
+export function UpdateBanner() {
+  const { prefix } = useProject();
+  const update = useUpdateStatus();
+  const [phase, setPhase] = useState<"idle" | "installing" | "error">("idle");
+  const [message, setMessage] = useState("");
+  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    try {
+      const saved: Watch | null = JSON.parse(sessionStorage.getItem(WATCH_KEY) || "null");
+      if (saved && Date.now() - saved.startedAt < TIMEOUT_MS) watch(saved);
+      else sessionStorage.removeItem(WATCH_KEY);
+    } catch {
+      sessionStorage.removeItem(WATCH_KEY);
+    }
+    return () => {
+      if (timer.current) clearInterval(timer.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function watch(saved: Watch) {
+    setPhase("installing");
+    if (timer.current) clearInterval(timer.current);
+    timer.current = setInterval(async () => {
+      if (Date.now() - saved.startedAt > TIMEOUT_MS) {
+        if (timer.current) clearInterval(timer.current);
+        sessionStorage.removeItem(WATCH_KEY);
+        setMessage(
+          "The update didn't finish — check data/logs/self-update.log, or run `flow up` in a terminal.",
+        );
+        setPhase("error");
+        return;
+      }
+      try {
+        const r = await fetch(prefix("/api/update-status"), { cache: "no-store" });
+        if (!r.ok) return;
+        const d = await r.json();
+        if (d.bootId && d.bootId !== saved.bootId) {
+          if (timer.current) clearInterval(timer.current);
+          sessionStorage.removeItem(WATCH_KEY);
+          window.location.reload(); // new process, new build — pick up the new chunks
+        }
+      } catch {
+        // dashboard down mid-restart — keep polling
+      }
+    }, POLL_MS);
+  }
+
+  async function install() {
+    setPhase("installing");
+    try {
+      const r = await fetch(prefix("/api/update-status"), { method: "POST" });
+      const d = await r.json().catch(() => ({}));
+      if (!r.ok) {
+        setMessage(d.error || "Couldn't start the update.");
+        setPhase("error");
+        return;
+      }
+      const saved: Watch = { startedAt: Date.now(), bootId: String(d.bootId || "") };
+      sessionStorage.setItem(WATCH_KEY, JSON.stringify(saved));
+      watch(saved);
+    } catch {
+      setMessage("Couldn't reach the dashboard to start the update.");
+      setPhase("error");
+    }
+  }
+
+  if (phase === "idle" && update.behind === 0) return null;
+
+  return (
+    <div
+      className="flex items-center gap-3 px-4 py-2.5 mb-5 rounded-lg flex-shrink-0"
+      style={{ background: "var(--paper)", border: "1px solid var(--line)" }}
+    >
+      <span
+        className={`w-2 h-2 rounded-full flex-shrink-0 ${phase === "installing" ? "animate-pulse" : ""}`}
+        style={{
+          background:
+            phase === "error" ? "var(--danger)" : phase === "installing" ? "var(--warn)" : "var(--accent)",
+          border: "1px solid var(--line)",
+        }}
+      />
+      {phase === "idle" && (
+        <>
+          <span className="text-[13px] flex-1" style={{ color: "var(--text)" }}>
+            A new version of Flow is available
+            {update.current && update.latest && (
+              <span style={{ fontFamily: "var(--font-mono)", fontSize: 11, color: "var(--text-muted)" }}>
+                {" "}
+                · {update.current} → {update.latest} ({update.behind} commit{update.behind === 1 ? "" : "s"})
+              </span>
+            )}
+          </span>
+          <button
+            onClick={install}
+            className="px-3 py-1.5 rounded-md transition-colors flex-shrink-0"
+            style={{
+              fontFamily: "var(--font-mono)",
+              fontSize: 10,
+              textTransform: "uppercase",
+              letterSpacing: "0.08em",
+              background: "var(--ink)",
+              color: "var(--cream)",
+              border: "none",
+              cursor: "pointer",
+            }}
+          >
+            Install &amp; restart
+          </button>
+        </>
+      )}
+      {phase === "installing" && (
+        <span className="text-[13px]" style={{ color: "var(--text)" }}>
+          Installing update — Flow is rebuilding and will restart. This page reloads itself when it&apos;s
+          back (a minute or two).
+        </span>
+      )}
+      {phase === "error" && (
+        <span className="text-[13px]" style={{ color: "var(--danger)" }}>
+          {message}
+        </span>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Replaces the nav's small "Update · flow up" badge with a banner across the top of every page when the checkout is behind upstream, with an **Install & restart** button that applies the update in one tap.

## How

- **`POST /api/update-status`** (new): spawns `node bin/flow.mjs up` as a **detached** child (it must survive the dashboard being killed and respawned by the update itself). Output goes to `data/logs/self-update.log`. Dashboard-specific env (`PORT`, `NODE_ENV`, `FLOW_DATA_DIR`, `FLOW_AUTH_PATH`, `FLOW_MODE`) is stripped so it doesn't leak into the services the CLI spawns. 10-minute double-tap guard.
- **`GET /api/update-status`** now returns a per-process `bootId`. The banner polls it after triggering the install and reloads the page when it changes — a new dashboard process means the new build is live. `behind === 0` is deliberately **not** the success signal: the status check can transiently read 0 mid-pull (git lock contention), which would reload onto the old build.
- **`UpdateBanner.tsx`** (new, mounted in `Shell`): idle → installing → error states. Watch state lives in `sessionStorage` so client-side navigation mid-install doesn't strand the tab; 12-minute timeout surfaces a check-the-log error.
- **Auth**: local mode — any session; prod — owners only (an install restarts every service on the deployment).
- Nav badge removed — the banner is the single surface for updates.

## Safety

- Up-to-date installs see zero change (banner renders `null`; GET gains one field).
- Dirty / feature-branch checkouts never see the banner (existing `maybeSelfUpdate` mirror guards).
- `flow up`'s ordering is favorable on failure: the pull and rebuild happen before anything is killed, so a failed update leaves everything running old code.
- Note: install runs a bare `flow up`, restarting **all** projects on the deployment — inherent to applying an update (the code moved under every project).

## Verification

`tsc --noEmit`, ESLint, and `next build` all pass. The tap-to-install path was reasoned through but not exercised end-to-end against a live deployment (doing so restarts services).