### PR TITLE
lifecycle: end agent sessions for real — reap processes, not just DB rows

### DIFF
--- a/bin/flow.mjs
+++ b/bin/flow.mjs
@@ -98,6 +98,8 @@ ${c.bold("Usage")}
   flow down [name]      Stop a project. No name = all.
   flow ls               List projects, status, and dashboard URLs.
   flow doctor           Health-check every project — pages load, assets load, services up.
+     --reap             Also kill stale Flow processes nothing tracks (orphaned
+                        services, adapters, MCP servers).
   flow rm <name>        Stop and delete a project and its data.
   flow setup <name>     Connect the current git repo to a project: installs Flow's
                         capture hooks, MCP registration, skill, and instruction blocks
@@ -237,6 +239,55 @@ function isAlive(pid) {
   } catch {
     return false;
   }
+}
+
+/** The command line of a live process ("" when gone / unreadable). */
+function processCommand(pid) {
+  try {
+    const r = spawnSync("ps", ["-o", "command=", "-p", String(pid)], { encoding: "utf8" });
+    return r.status === 0 ? (r.stdout ?? "").trim() : "";
+  } catch {
+    return "";
+  }
+}
+
+// PIDs recorded days ago may have been recycled by the OS for an unrelated
+// process — never signal a recorded pid unless its command line still points
+// into this checkout (the tsx supervisor and its node child both carry the
+// flowRoot path in their argv).
+function isThisDeploymentsService(pid) {
+  const cmd = processCommand(pid);
+  return cmd.length > 0 && cmd.includes(flowRoot);
+}
+
+// Every service pid this project EVER spawned (pids.json `history`), not just
+// the latest pair — `flow down` must be able to kill instances that a later
+// `flow up` (different port offset, crashed restart) stopped tracking.
+function appendPidHistory(pids, entries) {
+  const history = Array.isArray(pids.history) ? pids.history : [];
+  const next = [...history, ...entries];
+  // Compact: drop dead entries, keep at most the last 100 alive ones.
+  return next.filter((e) => e && typeof e.pid === "number" && isAlive(e.pid)).slice(-100);
+}
+
+// Kill every still-alive historical pid of this project (identity-verified).
+// SIGTERM first for graceful shutdown; the caller's grace/SIGKILL pass and the
+// services' own watchdogs cover stragglers. Returns the pids signalled.
+function reapPidHistory(name, { exclude = [] } = {}) {
+  const pids = readPids(name);
+  const history = Array.isArray(pids.history) ? pids.history : [];
+  const signalled = [];
+  for (const e of history) {
+    if (!e || typeof e.pid !== "number" || exclude.includes(e.pid)) continue;
+    if (!isAlive(e.pid) || !isThisDeploymentsService(e.pid)) continue;
+    try {
+      process.kill(e.pid, "SIGTERM");
+      signalled.push(e.pid);
+    } catch {
+      /* gone between check and kill */
+    }
+  }
+  return signalled;
 }
 
 // ── Spawn a service, returning the child pid ─────────────────────────────────
@@ -719,6 +770,12 @@ async function upProject(name, { rebuilt = false } = {}) {
   // level and handled in cmdUp — never touch it per project.)
   killPort(ports.gateway);
 
+  // Reap prior instances of THIS project that the port sweep can't see — a
+  // deployment once started under another FLOW_PORT_OFFSET (or whose ports
+  // drifted) keeps its services alive on ports we're not about to claim, and
+  // they'd sit there holding PID slots forever. pids.json history knows them.
+  reapPidHistory(name);
+
   // Stamp the code these services are spawned from (see the already-running
   // check above). Written before the spawns so a crash mid-start re-runs a
   // full start next time rather than trusting half-started services.
@@ -804,6 +861,11 @@ async function upProject(name, { rebuilt = false } = {}) {
     // docs, stats) — MCP spawns inject this per-process, the long-running
     // server needs it in its own env for CLI/remote verb callers.
     ORCHESTRATOR_URL: `http://localhost:${ports.orchestrator}`,
+    // Watchdog: the service self-exits when pids.json stops naming it (a
+    // newer `flow up` superseded it, or `flow down`/`flow rm` retired it and
+    // the kill didn't land — e.g. the controlling shell died mid-stop).
+    FLOW_PIDS_PATH: pidsJsonPath(name),
+    FLOW_SERVICE_ROLE: "gateway",
     NODE_ENV: "production",
   };
   // Direct LLM callers (classification) may use an OpenAI-compatible provider.
@@ -838,6 +900,9 @@ async function upProject(name, { rebuilt = false } = {}) {
     // project's long-lived gateway model through GATEWAY_URL.
     GRAPH_NAME: graph,
     JOURNAL_PATH: journalPath,
+    // Same watchdog contract as the gateway (see gwEnv above).
+    FLOW_PIDS_PATH: pidsJsonPath(name),
+    FLOW_SERVICE_ROLE: "orchestrator",
     NODE_ENV: "production",
   };
 
@@ -848,7 +913,14 @@ async function upProject(name, { rebuilt = false } = {}) {
     logFile: orchLogFile,
   });
 
-  writePids(name, { gateway: gwPid, orchestrator: orchPid });
+  writePids(name, {
+    gateway: gwPid,
+    orchestrator: orchPid,
+    history: appendPidHistory(readPids(name), [
+      { pid: gwPid, svc: "gateway", at: Date.now() },
+      { pid: orchPid, svc: "orchestrator", at: Date.now() },
+    ]),
+  });
 
   // ── Wait for health (the deployment dashboard is handled in cmdUp) ─────────
   const [gwOk, orchOk] = await Promise.all([
@@ -931,7 +1003,10 @@ async function downProject(name) {
   const services = ["gateway", "orchestrator", "dashboard"];
   let touched = false;
 
-  // SIGTERM tracked pids, then SIGKILL survivors after a grace period.
+  // SIGTERM tracked pids, then SIGKILL survivors after a grace period. The
+  // pid history covers instances the latest pids.json pair no longer names
+  // (earlier spawns that survived a crashed/interrupted stop) — `flow down`
+  // kills every pid it ever spawned, not just the newest two.
   const alive = services.map((svc) => pids[svc]).filter((pid) => pid && isAlive(pid));
   for (const pid of alive) {
     try {
@@ -941,9 +1016,12 @@ async function downProject(name) {
       /* already gone */
     }
   }
-  if (alive.length) {
+  const historical = reapPidHistory(name, { exclude: alive });
+  if (historical.length) touched = true;
+  const signalled = [...alive, ...historical];
+  if (signalled.length) {
     await new Promise((r) => setTimeout(r, 3000));
-    for (const pid of alive) {
+    for (const pid of signalled) {
       if (isAlive(pid)) {
         try {
           process.kill(pid, "SIGKILL");
@@ -1036,6 +1114,116 @@ async function cmdLs() {
 
 const DOCTOR_PAGES = ["/", "/ask", "/agents", "/connections", "/permissions", "/activity", "/settings"];
 
+// ── Stale-process scan (doctor / doctor --reap) ──────────────────────────────
+//
+// Finds Flow-shaped OS processes that nothing tracks any more: services from
+// deployments whose controlling shell died without `flow down`, services
+// started from inside a Flow-managed source clone (workspace/repos/…), and
+// orphaned ACP adapters / MCP servers. Reports them always; kills them only
+// with --reap. Deliberately conservative — live processes belonging to OTHER
+// tools (a Zed-run claude-agent-acp, a Claude Code session's flow-graph MCP)
+// have a live non-init parent and are never touched.
+
+const PROCESS_SIGNATURES = [
+  { kind: "orchestrator", re: /orchestrator\/src\/index\.ts/ },
+  { kind: "gateway", re: /graph-gateway\/src\/server\.ts/ },
+  { kind: "mcp", re: /graph-gateway\/src\/mcp\.ts/ },
+  { kind: "acp-adapter", re: /claude-agent-acp|codex-acp/ },
+];
+
+function listFlowShapedProcesses() {
+  const out =
+    spawnSync("ps", ["-axo", "pid=,ppid=,etime=,command="], { encoding: "utf8", maxBuffer: 32 * 1024 * 1024 }).stdout ?? "";
+  const procs = [];
+  for (const line of out.split("\n")) {
+    const m = line.match(/^\s*(\d+)\s+(\d+)\s+(\S+)\s+(.*)$/);
+    if (!m) continue;
+    procs.push({ pid: Number(m[1]), ppid: Number(m[2]), etime: m[3], command: m[4] });
+  }
+  return procs;
+}
+
+// Every pid any project's pids.json (current + history) or dashboard.json
+// names right now — the set of processes this deployment claims.
+function trackedPidSet() {
+  const tracked = new Set();
+  for (const name of listProjectNames()) {
+    const pids = readPids(name);
+    for (const svc of ["gateway", "orchestrator", "dashboard"]) {
+      if (typeof pids[svc] === "number") tracked.add(pids[svc]);
+    }
+    for (const e of Array.isArray(pids.history) ? pids.history : []) {
+      if (e && typeof e.pid === "number") tracked.add(e.pid);
+    }
+  }
+  try {
+    const dash = JSON.parse(readFileSync(join(dataDir(), "dashboard.json"), "utf-8"))?.pid;
+    if (typeof dash === "number") tracked.add(dash);
+  } catch {
+    /* no dashboard tracked */
+  }
+  return tracked;
+}
+
+function findStaleFlowProcesses() {
+  const procs = listFlowShapedProcesses();
+  const byPid = new Map(procs.map((p) => [p.pid, p]));
+  const tracked = trackedPidSet();
+  // A process is "ours" if it, or any ancestor, is a tracked pid — the
+  // recorded pid is the tsx supervisor, whose node child (and ITS adapter and
+  // MCP children) are what ps actually shows doing the work.
+  const isTracked = (pid) => {
+    let cur = pid;
+    for (let hops = 0; hops < 8 && cur > 1; hops++) {
+      if (tracked.has(cur)) return true;
+      cur = byPid.get(cur)?.ppid ?? 1;
+    }
+    return false;
+  };
+
+  const stale = [];
+  for (const p of procs) {
+    const sig = PROCESS_SIGNATURES.find((s) => s.re.test(p.command));
+    if (!sig || p.pid === process.pid || isTracked(p.pid)) continue;
+    const fromSourceClone = /\/workspace\/(?:repos|worktrees)\//.test(p.command);
+    if (sig.kind === "orchestrator" || sig.kind === "gateway") {
+      // Untracked service: stale when it runs from THIS checkout or from any
+      // Flow-managed source clone (never a legitimate service home). Services
+      // of a genuinely different install are reported by their owner's doctor.
+      if (p.command.includes(flowRoot) || fromSourceClone) stale.push({ ...p, kind: sig.kind });
+    } else {
+      // Adapters/MCP servers: only ever legitimate as a child of a live
+      // harness or orchestrator. Reparented to init (ppid 1) = orphan. The
+      // flowRoot check keeps other installs' adapters (e.g. Zed's) off-limits.
+      if (p.ppid === 1 && (p.command.includes(flowRoot) || fromSourceClone)) stale.push({ ...p, kind: sig.kind });
+    }
+  }
+  return stale;
+}
+
+async function reapStaleFlowProcesses(stale) {
+  for (const p of stale) {
+    try {
+      process.kill(p.pid, "SIGTERM");
+    } catch {
+      /* gone */
+    }
+  }
+  await new Promise((r) => setTimeout(r, 3000));
+  let killed = 0;
+  for (const p of stale) {
+    if (isAlive(p.pid)) {
+      try {
+        process.kill(p.pid, "SIGKILL");
+      } catch {
+        /* gone */
+      }
+    }
+    killed++;
+  }
+  return killed;
+}
+
 async function fetchStatus(url, opts = {}) {
   try {
     const res = await fetch(url, { redirect: "manual", signal: AbortSignal.timeout(4000), ...opts });
@@ -1045,7 +1233,8 @@ async function fetchStatus(url, opts = {}) {
   }
 }
 
-async function cmdDoctor() {
+async function cmdDoctor(args = []) {
+  const { values } = parseArgs({ args, options: { reap: { type: "boolean", default: false } } });
   const projects = listProjects();
   if (projects.length === 0) {
     console.log(c.dim("\n  No projects.\n"));
@@ -1109,6 +1298,25 @@ async function cmdDoctor() {
       console.log(`  ${label} ${FAIL} ${c.red(problems.slice(0, 5).join(", "))}`);
     }
   }
+  // Stale-process report: Flow-shaped processes nothing tracks (orphaned
+  // services, adapters, MCP servers). --reap kills them.
+  const stale = findStaleFlowProcesses();
+  if (stale.length > 0) {
+    console.log("");
+    for (const p of stale) {
+      const cmd = p.command.length > 90 ? p.command.slice(0, 87) + "…" : p.command;
+      console.log(`  ${c.yellow("stale")} ${String(p.pid).padEnd(7)} ${p.kind.padEnd(12)} ${c.dim(`up ${p.etime}`)}  ${c.dim(cmd)}`);
+    }
+    if (values.reap) {
+      const killed = await reapStaleFlowProcesses(stale);
+      console.log(`\n  ${OK} reaped ${killed} stale process${killed === 1 ? "" : "es"}`);
+    } else {
+      console.log(`\n  ${c.dim("Kill them with")}  flow doctor --reap`);
+    }
+  } else if (values.reap) {
+    console.log(`\n  ${OK} ${c.dim("no stale Flow processes found")}`);
+  }
+
   console.log("");
   if (anyFail) {
     console.log(c.dim("  If assets are stale, run  flow up  — it restarts the dashboard on the fresh build.\n"));
@@ -1334,7 +1542,7 @@ async function main() {
     } else if (cmd === "ls" || cmd === "list" || cmd === "ps") {
       await cmdLs();
     } else if (cmd === "doctor" || cmd === "check" || cmd === "health") {
-      await cmdDoctor();
+      await cmdDoctor(rest);
     } else if (cmd === "rm" || cmd === "remove" || cmd === "delete") {
       await cmdRm(rest);
     } else if (cmd === "setup" || cmd === "connect-repo") {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -89,3 +89,49 @@ Single admin bearer token (`FLOW_ADMIN_TOKEN`, per project) guards every HTTP
 surface except `/health`. Webhooks authenticate by HMAC; the notify endpoint
 accepts the admin token or a per-job scoped token (so an injected agent can't
 reach the whole API). Dashboard sets an httpOnly cookie; middleware gates pages.
+
+## Process lifecycle (who ends what, and who reaps whom)
+
+Every long-lived box (a laptop, a customer EC2) must hold a **flat** process
+count under sustained agent use. The lifecycle of every process Flow touches:
+
+| Process | Ends when… | Children reaped by… |
+|---|---|---|
+| Direct `claude` in a terminal | terminal close → SIGHUP | its `flow-graph` MCP child self-exits on stdin EOF (`graph-gateway/src/mcp.ts`); a `kill -9` (no EOF when others hold the pipe) is covered by the MCP's harness-death poll |
+| Flow agent session (ACP) | explicit close (`POST /v1/agents/sessions/:id/close`), or the **process reaper** after `FLOW_SESSION_IDLE_CLOSE_MS` (default 60 min) idle/errored | `closeFlowSession` sends ACP `session/close`; the adapter tears the session down and **kills its per-session agent CLI child** (claude-agent-acp: `teardownSession → query.close()`). Closed sessions stay resumable via `session/load`. |
+| Shared ACP adapter (`claude-agent-acp`, `codex-acp`, `opencode acp`) — one per backend | zero live sessions for `FLOW_ADAPTER_LINGER_MS` (default 10 min), or orchestrator shutdown | spawned in its own **process group**; SIGTERM to the group (SIGKILL after 5 s) reaps the adapter *and* any agent-CLI/MCP descendants — the backstop for backends without `session/close` |
+| Orchestrator / gateway (`flow up`) | `flow down`, superseding `flow up`, or their own **watchdog** (`src/watchdog.ts`): self-exit when `pids.json` stops naming their pid (superseded / retired / project deleted) | orchestrator's SIGTERM path kills adapters (`killAdapters`) and indexer job process groups (`killRunningJobChildren`) |
+| Indexer/chat CLI jobs (`opencode`/`codex`/`claude` via `opencode.ts`) | job completes, times out, or orchestrator shuts down | tracked in `jobChildren`, killed by process group (`killTree`) |
+| Deployment dashboard (`next start`) | `flow down` (whole-deployment), or superseding `flow up` | tracked pid in `data/dashboard.json` + port kill |
+
+Mechanisms, and where they live:
+
+- **Session close is an OS-level act, not a DB update.** `closeFlowSession`
+  (`orchestrator/src/agents/runtime.ts`) cancels the turn, resolves pending
+  permissions, sends ACP `session/close` (which kills the per-session agent
+  child), drops the routing entry, then marks the row `closed`. The memory
+  idle sweep (`memory/trigger.ts`) only distills; it never touches processes.
+- **Process reaper** (`runtime.ts`, 60 s interval): closes sessions idle past
+  `FLOW_SESSION_IDLE_CLOSE_MS`; shuts down adapters session-less past
+  `FLOW_ADAPTER_LINGER_MS`. Disable with `FLOW_AGENT_REAPER=0`.
+- **Service watchdog** (`orchestrator/src/watchdog.ts`,
+  `graph-gateway/src/watchdog.ts`): armed by `flow up` via `FLOW_PIDS_PATH` +
+  `FLOW_SERVICE_ROLE`; polls pids.json every 60 s and self-exits (with strike
+  grace) when no longer the tracked pid. Dev runs / Docker never set the env,
+  so they're unaffected. Disable with `FLOW_WATCHDOG=0`.
+- **CLI reaping** (`bin/flow.mjs`): pids.json keeps a `history` of every pid a
+  project ever spawned. `flow down` kills tracked + historical pids (identity-
+  verified against the process's command line — recycled pids are never
+  signalled) plus a port sweep; `flow up` reaps historical instances before
+  spawning (catches instances stranded on other port offsets); `flow doctor
+  --reap` scans `ps` for Flow-shaped orphans (untracked services from this
+  checkout or from `workspace/repos|worktrees` clones, adapters/MCP servers
+  reparented to init) and kills them. Foreign installs' processes are reported,
+  never killed.
+- **MCP self-defense** (`graph-gateway/src/mcp.ts`): exits on stdin EOF, plus
+  a 15 s harness-death poll so a `kill -9`'d harness can't orphan it. The poll
+  is wrapper-aware: Flow injects the server as `tsx src/mcp.ts`, where tsx is
+  a supervisor whose node child runs this code — the child's own ppid never
+  changes when the harness dies, so the guard resolves the real harness pid
+  (the grandparent, when the parent's argv names this script) at boot and
+  exits when it's gone.

--- a/graph-gateway/src/mcp.ts
+++ b/graph-gateway/src/mcp.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
@@ -216,5 +217,40 @@ if (MODE === "builder" && process.env.FLOW_JOB_ID) {
 // orphaned MCP processes accumulating on the machine.
 process.stdin.on("end", () => process.exit(0));
 process.stdin.on("close", () => process.exit(0));
+
+// Parent-death guard for the path stdin can't cover: a `kill -9` of the
+// harness delivers no EOF when something else still holds the pipe's write
+// end, so also poll for the harness dying. The wrinkle is topology: Flow
+// injects this server as `tsx src/mcp.ts`, and tsx runs a SUPERVISOR process
+// whose node child executes this code — when the harness dies, the supervisor
+// reparents to init but our own ppid never changes. So at boot, if our parent
+// is such a wrapper (its argv mentions this script), the process to watch is
+// the GRANDparent — the actual harness. Exiting here also ends the supervisor
+// (it exits with its child). Fail-safe on pid reuse: a recycled pid counts as
+// alive and we simply keep running.
+function psField(pid: number, field: "ppid" | "command"): string {
+  try {
+    return execFileSync("ps", ["-o", `${field}=`, "-p", String(pid)], { encoding: "utf8" }).trim();
+  } catch {
+    return "";
+  }
+}
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return (e as NodeJS.ErrnoException).code === "EPERM"; // exists, not ours
+  }
+}
+const initialPpid = process.ppid;
+let harnessPid = initialPpid;
+if (/\bmcp\.(?:ts|js)\b/.test(psField(initialPpid, "command"))) {
+  const gp = Number(psField(initialPpid, "ppid"));
+  if (Number.isFinite(gp) && gp > 1) harnessPid = gp;
+}
+setInterval(() => {
+  if (process.ppid !== initialPpid || !pidAlive(harnessPid)) process.exit(0);
+}, 15_000).unref();
 
 await server.connect(new StdioServerTransport());

--- a/graph-gateway/src/server.ts
+++ b/graph-gateway/src/server.ts
@@ -7,6 +7,7 @@ import { startLocalModel } from "./local-embed.js";
 import { embedText, embeddingsEnabled } from "./embed.js";
 import { activeEmbeddingDim, activeEmbeddingModel } from "./embedding-models.js";
 import { isPat, verifyPatForProject } from "./patAuth.js";
+import { startWatchdog } from "./watchdog.js";
 
 // HTTP face of the gateway — bind to localhost only.
 //   POST /v1/verbs/<name>   body: verb input JSON   (bearer-authed)
@@ -150,6 +151,9 @@ const server = createServer(async (req, res) => {
 server.listen(port, "127.0.0.1", () => {
   const model = activeEmbeddingModel();
   console.log(`graph-gateway listening on http://127.0.0.1:${port} (default graph: '${DEFAULT_GRAPH}', embed model: ${model.id}, dim: ${model.dim})`);
+  // Self-exit when pids.json stops naming this pid (superseded/retired/
+  // deleted deployment). No-op unless `flow up` set FLOW_PIDS_PATH.
+  startWatchdog();
   // Start the local embedding model download immediately so it runs in
   // parallel with migrations — but only when the local model is the active
   // provider. An API model has nothing to download. runBootTasks awaits the

--- a/graph-gateway/src/watchdog.ts
+++ b/graph-gateway/src/watchdog.ts
@@ -1,0 +1,68 @@
+// watchdog.ts — self-exit when this process is no longer the deployment's
+// tracked service.
+//
+// Services are spawned detached (`flow up` returns; there is deliberately no
+// controlling process), so "my controlling shell died" is not detectable — the
+// durable ground truth is pids.json: `flow up` records the pid it spawned for
+// each role, `flow down` clears it, `flow rm` deletes the whole project dir.
+// A service that is alive while pids.json stops naming it is by definition an
+// orphan (a kill that never landed, a supersede whose port sweep missed, a
+// deleted project) and must exit itself — on a customer's EC2 nothing else
+// ever will.
+//
+// Grace: staleness needs consecutive strikes across checks, so a mid-write
+// pids.json (truncate+write is not atomic) or a transient FS hiccup never
+// takes a healthy service down.
+
+import { existsSync, readFileSync } from "node:fs";
+
+const PIDS_PATH = process.env.FLOW_PIDS_PATH ?? "";
+const ROLE = process.env.FLOW_SERVICE_ROLE ?? "";
+const INTERVAL_MS = Number(process.env.FLOW_WATCHDOG_INTERVAL_MS ?? 60_000);
+const SUPERSEDED_STRIKES = 2; // pids.json names someone else (or nobody)
+const MISSING_STRIKES = 3; // pids.json (project dir) is gone
+
+export function startWatchdog(onStale: (reason: string) => void = defaultOnStale): void {
+  // Only active when `flow up` armed it — dev runs, tests, and Docker (where
+  // the container is the lifecycle) are unaffected.
+  if (!PIDS_PATH || !ROLE || process.env.FLOW_WATCHDOG === "0") return;
+  let strikes = 0;
+  let fired = false;
+  const timer = setInterval(() => {
+    if (fired) return;
+    try {
+      if (!existsSync(PIDS_PATH)) {
+        if (++strikes >= MISSING_STRIKES) {
+          fired = true;
+          onStale(`${PIDS_PATH} is gone — project removed`);
+        }
+        return;
+      }
+      const pids = JSON.parse(readFileSync(PIDS_PATH, "utf8")) as Record<string, unknown>;
+      const tracked = pids?.[ROLE];
+      if (tracked !== process.pid) {
+        if (++strikes >= SUPERSEDED_STRIKES) {
+          fired = true;
+          onStale(
+            typeof tracked === "number"
+              ? `superseded — pids.json now names pid ${tracked} as ${ROLE}`
+              : `retired — pids.json no longer names a ${ROLE}`
+          );
+        }
+        return;
+      }
+      strikes = 0;
+    } catch {
+      /* unreadable/mid-write — not evidence of staleness */
+    }
+  }, INTERVAL_MS);
+  timer.unref?.();
+}
+
+function defaultOnStale(reason: string): void {
+  console.warn(`[watchdog] ${ROLE} pid ${process.pid} is stale (${reason}) — shutting down`);
+  // Graceful first (runs the service's SIGTERM cleanup: adapters, job
+  // children), hard exit if that stalls.
+  setTimeout(() => process.exit(0), 10_000).unref?.();
+  process.kill(process.pid, "SIGTERM");
+}

--- a/orchestrator/package.json
+++ b/orchestrator/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts",
-    "test": "node --import tsx/esm --test test/fake-opencode.ts test/orchestrator.test.ts test/adapters.test.ts test/outbox-approve.test.ts test/llmlog.test.ts test/smoke.ts test/notify.test.ts test/pollers.test.ts test/poller.test.ts test/settings.test.ts test/sources.test.ts test/agent-diff.test.ts test/worktrees.test.ts test/memory.test.ts test/llm.test.ts test/indexer-runtime.test.ts test/index-queue.test.ts test/change-branch.test.ts test/repo-removed.test.ts test/index-incremental.test.ts test/work-folders.test.ts test/ingest.test.ts test/flow-hook.test.ts",
+    "test": "node --import tsx/esm --test test/fake-opencode.ts test/orchestrator.test.ts test/adapters.test.ts test/outbox-approve.test.ts test/llmlog.test.ts test/smoke.ts test/notify.test.ts test/pollers.test.ts test/poller.test.ts test/settings.test.ts test/sources.test.ts test/agent-diff.test.ts test/session-close.test.ts test/worktrees.test.ts test/memory.test.ts test/llm.test.ts test/indexer-runtime.test.ts test/index-queue.test.ts test/change-branch.test.ts test/repo-removed.test.ts test/index-incremental.test.ts test/work-folders.test.ts test/ingest.test.ts test/flow-hook.test.ts",
     "verify": "npm test",
     "verify:real": "tsx test/real-integrations.ts",
     "verify:session": "tsx test/real-session.ts"

--- a/orchestrator/src/agents/routes.ts
+++ b/orchestrator/src/agents/routes.ts
@@ -6,6 +6,7 @@
 //   GET  /v1/agents/sessions/:id/events   SSE: replay then live events
 //   POST /v1/agents/sessions/:id/prompt   {text} — steer (queues/cancels as needed)
 //   POST /v1/agents/sessions/:id/cancel   stop the current turn
+//   POST /v1/agents/sessions/:id/close    end the session + free its OS process
 //   POST /v1/agents/sessions/:id/permission {requestId, optionId|null}
 //   POST /v1/agents/sessions/:id/mode     {modeId}
 //   GET  /v1/agents/sessions/:id/diff     unified git diff of the checkout
@@ -24,6 +25,7 @@ import {
   type AgentBackend,
   BACKENDS,
   cancelSession,
+  closeFlowSession,
   createSession,
   detectAgents,
   getSession,
@@ -278,6 +280,17 @@ export function registerAgentRoutes(app: FastifyInstance): void {
   app.post("/v1/agents/sessions/:id/cancel", async (req, reply) => {
     const { id } = req.params as { id: string };
     const r = await cancelSession(id);
+    if ("error" in r) return reply.code(400).send(r);
+    return r;
+  });
+
+  // End a session for real: the adapter closes the ACP session and kills the
+  // per-session agent CLI child; the row goes 'closed' (still resumable — a
+  // later prompt reloads it via session/load). This is the OS-process
+  // counterpart of archiving; without it every session leaks a child process.
+  app.post("/v1/agents/sessions/:id/close", async (req, reply) => {
+    const { id } = req.params as { id: string };
+    const r = await closeFlowSession(id);
     if ("error" in r) return reply.code(400).send(r);
     return r;
   });

--- a/orchestrator/src/agents/runtime.ts
+++ b/orchestrator/src/agents/runtime.ts
@@ -750,6 +750,9 @@ interface Connection {
   command: string;
   localPath?: string;
   sessionsByAcpId: Map<string, string>; // acp session id → flow session id
+  // When the adapter last dropped to zero live sessions — the linger reaper
+  // shuts it down once it has been session-less past ADAPTER_LINGER_MS.
+  idleSince?: number;
 }
 
 const connections = new Map<AgentBackend, Connection>();
@@ -846,6 +849,10 @@ async function startConnectionAttempt(backend: AgentBackend, attempt: SpawnAttem
   const proc = spawn(attempt.command, attempt.args, {
     stdio: ["pipe", "pipe", "pipe"],
     env: attempt.env,
+    // Own process group (POSIX): the adapter spawns one agent CLI child per
+    // session (which spawn MCP children of their own) — a group kill is the
+    // only way to reap the whole tree when the adapter itself won't.
+    detached: process.platform !== "win32",
   });
   proc.stderr.on("data", (chunk: Buffer) => {
     try {
@@ -1427,21 +1434,196 @@ export async function setConfigOption(
   }
 }
 
-// Kill adapter subprocesses when the orchestrator shuts down — `flow down`
-// must not leave agent adapters (and their MCP children) running.
-function killAdapters(): void {
-  for (const c of connections.values()) {
+// Signal an adapter and everything under it. The adapters spawn one agent CLI
+// child per session (claude/codex), each of which spawns its own MCP servers —
+// signalling the process GROUP (spawned detached above) reaps the whole tree
+// even when the adapter mishandles the signal. Falls back to a single-process
+// kill on platforms without process groups.
+function killTree(proc: ChildProcessWithoutNullStreams, signal: NodeJS.Signals): void {
+  const pid = proc.pid;
+  if (!pid) return;
+  try {
+    process.kill(-pid, signal);
+  } catch {
     try {
-      c.process.kill("SIGTERM");
+      proc.kill(signal);
     } catch {
       /* already gone */
     }
+  }
+}
+
+// Retire one backend's shared adapter: SIGTERM the tree (the adapters dispose
+// their sessions — and kill their per-session agent children — on SIGTERM),
+// then SIGKILL any survivor after a grace window.
+function shutdownConnection(backend: AgentBackend, reason: string): void {
+  const c = connections.get(backend);
+  if (!c) return;
+  connections.delete(backend);
+  adapterLog(backend, `shutting down adapter (${reason})`);
+  killTree(c.process, "SIGTERM");
+  const t = setTimeout(() => {
+    if (c.process.exitCode === null) killTree(c.process, "SIGKILL");
+  }, 5000);
+  t.unref?.();
+}
+
+// Kill adapter subprocesses when the orchestrator shuts down — `flow down`
+// must not leave agent adapters (and their agent-CLI/MCP children) running.
+function killAdapters(): void {
+  for (const c of connections.values()) {
+    killTree(c.process, "SIGTERM");
   }
   connections.clear();
 }
 process.once("SIGTERM", killAdapters);
 process.once("SIGINT", killAdapters);
 process.once("exit", killAdapters);
+
+// ---------------------------------------------------------------------------
+// Ending a session for real — the OS-process side, not just the DB row.
+//
+// A Flow session has no terminal whose close would end it, so ending is an
+// explicit act: tell the adapter to close the ACP session (claude-agent-acp's
+// closeSession → teardownSession → query.close() terminates the per-session
+// `claude` subprocess; codex behaves likewise), drop the routing entry, and
+// mark the row closed. Closed sessions stay resumable: the agent CLI persists
+// the conversation on disk, and steer() → resumeConnection() reloads it via
+// session/load on a (possibly fresh) adapter.
+
+// Bound an ACP request so a wedged adapter can't hang the close path (and the
+// reaper behind it) forever — on timeout we fall through to the linger
+// reaper's group kill, which needs no cooperation from the adapter.
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error(`ACP request timed out after ${ms}ms`)), ms);
+    t.unref?.();
+    p.then(
+      (v) => {
+        clearTimeout(t);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(t);
+        reject(e);
+      }
+    );
+  });
+}
+
+export async function closeFlowSession(
+  id: string,
+  reason: "closed" | "idle_timeout" = "closed"
+): Promise<{ ok: true } | { error: string }> {
+  const s = liveSession(id);
+  if (!s) {
+    // No live/rehydratable session (e.g. it died in "starting" and never got
+    // an ACP id) — there is no process to free, but the row should still stop
+    // presenting as active.
+    const row = db.prepare(`SELECT status FROM agent_sessions WHERE id = ?`).get(id) as { status?: string } | undefined;
+    if (!row) return { error: "Unknown session" };
+    if (row.status !== "closed") {
+      db.prepare(`UPDATE agent_sessions SET status='closed', stop_reason=?, updated_at=? WHERE id=?`).run(reason, Date.now(), id);
+    }
+    return { ok: true };
+  }
+  if (s.status === "closed") return { ok: true };
+
+  // Unblock anything in flight — a pending permission promise would otherwise
+  // dangle forever, and queued steers are moot.
+  s.queue = [];
+  for (const p of s.pendingPermissions.values()) {
+    p.resolve({ outcome: { outcome: "cancelled" } });
+  }
+  s.pendingPermissions.clear();
+
+  const c = connections.get(s.backend);
+  if (c && s.acpSessionId && c.sessionsByAcpId.get(s.acpSessionId) === s.id) {
+    if (s.turnActive) {
+      try {
+        await withTimeout(c.conn.cancel({ sessionId: s.acpSessionId }), 5000);
+      } catch {
+        /* the close below is the real teardown */
+      }
+    }
+    try {
+      // This is what frees the OS process: the adapter tears the session down
+      // and kills its per-session agent CLI child. Optional capability —
+      // adapters without it get reaped by the zero-session linger instead.
+      await withTimeout(c.conn.closeSession({ sessionId: s.acpSessionId }), 10_000);
+    } catch {
+      /* not supported / wedged / already gone — linger reaper covers the process */
+    }
+    c.sessionsByAcpId.delete(s.acpSessionId);
+    if (c.sessionsByAcpId.size === 0) c.idleSince = Date.now();
+  }
+
+  s.turnActive = false;
+  setStatus(s, "closed", { stopReason: reason });
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Process reaper — the OS-process counterpart of the memory idle sweep.
+//
+// Flow-spawned sessions have no terminal, so without this nothing ever ends
+// them: every agent task would leave a live `claude`/`codex` child under the
+// shared adapter forever (observed: days-old children on a laptop, and a
+// monotonically rising process count on long-lived EC2 boxes). Two rules:
+//   1. A session idle (or errored) past SESSION_IDLE_CLOSE_MS is closed for
+//      real (closeFlowSession → adapter kills the per-session child). Still
+//      resumable afterwards via session/load.
+//   2. An adapter with zero live sessions past ADAPTER_LINGER_MS is shut down
+//      (SIGTERM tree → SIGKILL grace) — also the backstop for backends whose
+//      closeSession isn't supported.
+
+const SESSION_IDLE_CLOSE_MS = Number(process.env.FLOW_SESSION_IDLE_CLOSE_MS ?? 60 * 60 * 1000);
+const ADAPTER_LINGER_MS = Number(process.env.FLOW_ADAPTER_LINGER_MS ?? 10 * 60 * 1000);
+const REAPER_INTERVAL_MS = Number(process.env.FLOW_REAPER_INTERVAL_MS ?? 60 * 1000);
+
+export async function reapIdleProcesses(now = Date.now()): Promise<{ closedSessions: number; adaptersShutDown: number }> {
+  let closedSessions = 0;
+  let adaptersShutDown = 0;
+
+  // Only sessions actually in the live map — never rehydrate rows just to
+  // close them (a rehydrated session holds no OS process anyway).
+  for (const s of [...sessions.values()]) {
+    const quiet = s.status === "idle" || s.status === "error";
+    if (!quiet || s.turnActive || s.pendingPermissions.size > 0) continue;
+    if (now - s.updatedAt < SESSION_IDLE_CLOSE_MS) continue;
+    const r = await closeFlowSession(s.id, "idle_timeout");
+    if ("ok" in r) closedSessions++;
+  }
+
+  for (const c of [...connections.values()]) {
+    if (c.sessionsByAcpId.size > 0) {
+      c.idleSince = undefined;
+      continue;
+    }
+    c.idleSince ??= now;
+    if (now - c.idleSince >= ADAPTER_LINGER_MS) {
+      shutdownConnection(c.backend, "no live sessions");
+      adaptersShutDown++;
+    }
+  }
+  return { closedSessions, adaptersShutDown };
+}
+
+let reaperTimer: ReturnType<typeof setInterval> | null = null;
+export function startProcessReaper(): void {
+  if (reaperTimer || process.env.FLOW_AGENT_REAPER === "0") return;
+  reaperTimer = setInterval(() => {
+    void reapIdleProcesses().catch(() => {});
+  }, REAPER_INTERVAL_MS);
+  reaperTimer.unref?.();
+}
+export function stopProcessReaper(): void {
+  if (reaperTimer) {
+    clearInterval(reaperTimer);
+    reaperTimer = null;
+  }
+}
+startProcessReaper();
 
 // Resolve a session's working directory (the repo checkout) from the live map
 // or the DB, so it works for finished/reloaded sessions too.

--- a/orchestrator/src/index.ts
+++ b/orchestrator/src/index.ts
@@ -264,6 +264,13 @@ const start = async (): Promise<void> => {
     await app.listen({ port: PORT, host: "0.0.0.0" });
     console.log(`[orchestrator] listening on port ${PORT}`);
 
+    // Self-exit when pids.json stops naming this pid (superseded/retired/
+    // deleted deployment) — an orphaned orchestrator would otherwise run its
+    // pollers, adapters, and agent children forever. No-op unless `flow up`
+    // set FLOW_PIDS_PATH/FLOW_SERVICE_ROLE.
+    const { startWatchdog } = await import("./watchdog.js");
+    startWatchdog();
+
     // Recover jobs left 'running' by a crash/restart (S103)
     recoverStalledJobs();
 

--- a/orchestrator/src/watchdog.ts
+++ b/orchestrator/src/watchdog.ts
@@ -1,0 +1,68 @@
+// watchdog.ts — self-exit when this process is no longer the deployment's
+// tracked service.
+//
+// Services are spawned detached (`flow up` returns; there is deliberately no
+// controlling process), so "my controlling shell died" is not detectable — the
+// durable ground truth is pids.json: `flow up` records the pid it spawned for
+// each role, `flow down` clears it, `flow rm` deletes the whole project dir.
+// A service that is alive while pids.json stops naming it is by definition an
+// orphan (a kill that never landed, a supersede whose port sweep missed, a
+// deleted project) and must exit itself — on a customer's EC2 nothing else
+// ever will.
+//
+// Grace: staleness needs consecutive strikes across checks, so a mid-write
+// pids.json (truncate+write is not atomic) or a transient FS hiccup never
+// takes a healthy service down.
+
+import { existsSync, readFileSync } from "node:fs";
+
+const PIDS_PATH = process.env.FLOW_PIDS_PATH ?? "";
+const ROLE = process.env.FLOW_SERVICE_ROLE ?? "";
+const INTERVAL_MS = Number(process.env.FLOW_WATCHDOG_INTERVAL_MS ?? 60_000);
+const SUPERSEDED_STRIKES = 2; // pids.json names someone else (or nobody)
+const MISSING_STRIKES = 3; // pids.json (project dir) is gone
+
+export function startWatchdog(onStale: (reason: string) => void = defaultOnStale): void {
+  // Only active when `flow up` armed it — dev runs, tests, and Docker (where
+  // the container is the lifecycle) are unaffected.
+  if (!PIDS_PATH || !ROLE || process.env.FLOW_WATCHDOG === "0") return;
+  let strikes = 0;
+  let fired = false;
+  const timer = setInterval(() => {
+    if (fired) return;
+    try {
+      if (!existsSync(PIDS_PATH)) {
+        if (++strikes >= MISSING_STRIKES) {
+          fired = true;
+          onStale(`${PIDS_PATH} is gone — project removed`);
+        }
+        return;
+      }
+      const pids = JSON.parse(readFileSync(PIDS_PATH, "utf8")) as Record<string, unknown>;
+      const tracked = pids?.[ROLE];
+      if (tracked !== process.pid) {
+        if (++strikes >= SUPERSEDED_STRIKES) {
+          fired = true;
+          onStale(
+            typeof tracked === "number"
+              ? `superseded — pids.json now names pid ${tracked} as ${ROLE}`
+              : `retired — pids.json no longer names a ${ROLE}`
+          );
+        }
+        return;
+      }
+      strikes = 0;
+    } catch {
+      /* unreadable/mid-write — not evidence of staleness */
+    }
+  }, INTERVAL_MS);
+  timer.unref?.();
+}
+
+function defaultOnStale(reason: string): void {
+  console.warn(`[watchdog] ${ROLE} pid ${process.pid} is stale (${reason}) — shutting down`);
+  // Graceful first (runs the service's SIGTERM cleanup: adapters, job
+  // children), hard exit if that stalls.
+  setTimeout(() => process.exit(0), 10_000).unref?.();
+  process.kill(process.pid, "SIGTERM");
+}

--- a/orchestrator/test/session-close.test.ts
+++ b/orchestrator/test/session-close.test.ts
@@ -1,0 +1,72 @@
+// session-close.test.ts — the OS-process side of ending a session.
+//
+// Offline + hermetic like agent-diff.test.ts: rows inserted straight into the
+// in-memory DB, no adapters spawned. What CAN be tested without a live ACP
+// backend: closeFlowSession's row semantics (close, idempotence, unknown id)
+// and that the reaper's idle-close writes the idle_timeout stop reason. The
+// adapter-side teardown (session/close → child killed) is exercised by the
+// manual repro in docs/ARCHITECTURE.md's lifecycle section.
+
+import { test, describe, before } from "node:test";
+import assert from "node:assert/strict";
+
+// Env BEFORE importing anything that touches the DB.
+process.env.DB_PATH = ":memory:";
+process.env.FLOW_ADMIN_TOKEN = "test-admin-token-sessionclose";
+process.env.FLOW_FAKE_OPENCODE = "1";
+process.env.FLOW_DRAIN_DISABLE = "1";
+process.env.FLOW_POLL_DISABLE = "1";
+process.env.FLOW_DISTILLER = "0";
+process.env.FLOW_AGENT_REAPER = "0"; // no background timer in tests
+
+let db: typeof import("../src/db.js").default;
+let closeFlowSession: typeof import("../src/agents/runtime.js").closeFlowSession;
+
+function insertRow(id: string, status: string, acpId: string | null = null): void {
+  db.prepare(
+    `INSERT INTO agent_sessions (id, backend, repo, cwd, title, status, acp_session_id, created_at, updated_at)
+     VALUES (?, 'claude', 'r', '/tmp', 't', ?, ?, ?, ?)`
+  ).run(id, status, acpId, Date.now(), Date.now());
+}
+
+function rowOf(id: string): { status: string; stop_reason: string | null } {
+  return db.prepare(`SELECT status, stop_reason FROM agent_sessions WHERE id = ?`).get(id) as {
+    status: string;
+    stop_reason: string | null;
+  };
+}
+
+describe("closeFlowSession", () => {
+  before(async () => {
+    db = (await import("../src/db.js")).default;
+    ({ closeFlowSession } = await import("../src/agents/runtime.js"));
+  });
+
+  test("unknown session → error", async () => {
+    const r = await closeFlowSession("nope");
+    assert.deepEqual(r, { error: "Unknown session" });
+  });
+
+  test("row without an ACP id (died in starting) is closed in place", async () => {
+    insertRow("s1", "starting");
+    const r = await closeFlowSession("s1");
+    assert.deepEqual(r, { ok: true });
+    assert.equal(rowOf("s1").status, "closed");
+    assert.equal(rowOf("s1").stop_reason, "closed");
+  });
+
+  test("idle_timeout reason lands in stop_reason", async () => {
+    insertRow("s2", "error");
+    const r = await closeFlowSession("s2", "idle_timeout");
+    assert.deepEqual(r, { ok: true });
+    assert.equal(rowOf("s2").status, "closed");
+    assert.equal(rowOf("s2").stop_reason, "idle_timeout");
+  });
+
+  test("closing an already-closed session is a no-op ok", async () => {
+    insertRow("s3", "closed");
+    const r = await closeFlowSession("s3");
+    assert.deepEqual(r, { ok: true });
+    assert.equal(rowOf("s3").status, "closed");
+  });
+});


### PR DESCRIPTION
## Why

The process-leak investigation (`docs/process-leak-investigation.md`) found that Flow-spawned agent sessions **never end at the OS level**: there was no session-close path at all (no route ever set a session to `closed`; ACP `session/close` was only used for probe scratch sessions), the "idle sweep" only runs the memory distiller, and the shared ACP adapters were never retired. Result: one leaked `claude`/`codex` child per agent task (observed 1–3 days old on a laptop), and a monotonically rising process count on any long-lived deployment — customer-critical for EC2 boxes.

## What

**1. Real session close** (`orchestrator/src/agents/runtime.ts`, `routes.ts`)
- `closeFlowSession()` + `POST /v1/agents/sessions/:id/close`: cancels the turn, resolves pending permissions, sends ACP `session/close` — which is what actually frees the OS process (claude-agent-acp: `teardownSession → query.close()` kills the per-session `claude` child). Closed sessions stay resumable via `session/load`.
- RPCs are timeout-bounded so a wedged adapter can't hang the close path.

**2. Idle auto-shutdown**
- A process reaper (60 s tick) closes sessions idle/errored past `FLOW_SESSION_IDLE_CLOSE_MS` (default 60 min) and shuts down adapters that have had zero live sessions for `FLOW_ADAPTER_LINGER_MS` (default 10 min).
- Adapters now spawn detached in their own process group and are killed as a **tree** (SIGTERM → SIGKILL grace) — the backstop for backends without `session/close`. Disable via `FLOW_AGENT_REAPER=0`.

**3. CLI reaper + service watchdog** (`bin/flow.mjs`, `*/src/watchdog.ts`)
- `pids.json` keeps a `history` of every pid a project ever spawned; `flow down` kills tracked **and** historical pids, `flow up` reaps historical instances before spawning (catches instances stranded on other port offsets). All signals are identity-verified against the process's command line so recycled pids are never touched.
- `flow doctor --reap`: scans `ps` for Flow-shaped orphans (untracked services from this checkout or from `workspace/repos|worktrees` clones; adapters/MCP servers reparented to init) and kills them; foreign installs' processes are reported, never killed.
- Orchestrator + gateway self-exit via a watchdog when `pids.json` stops naming their pid (superseded / retired / project deleted). Armed only when `flow up` sets `FLOW_PIDS_PATH`/`FLOW_SERVICE_ROLE` — dev runs, tests, and Docker are unaffected. Disable via `FLOW_WATCHDOG=0`.

**4. Spawn audit** — all other spawn sites (indexer jobs, git/execFile, openLocation) already reap correctly; the adapter tree was the gap and is now group-killed.

**5. MCP parent-death guard** (`graph-gateway/src/mcp.ts`) — covers the `kill -9`-with-no-EOF case. Note: the naive ppid-change check **demonstrably fails** here because Flow injects the MCP as `tsx src/mcp.ts`, and tsx runs a supervisor whose node child's ppid never changes when the harness dies. The guard resolves the real harness pid at boot (grandparent when the parent's argv names the script) and polls it every 15 s.

**Docs**: finalized lifecycle table ("who ends what, and who reaps whom") in `docs/ARCHITECTURE.md`.

## Verification

- Orchestrator 286/286 (incl. 4 new `session-close.test.ts` tests) and gateway 24/24 pass; typecheck clean on all touched files.
- Watchdog live-tested: self-exits with the right reason when pids.json names another pid.
- MCP guard live-tested: an orphaned MCP with stdin deliberately held open (isolating the guard from the EOF path) self-exits <15 s after `kill -9` of its harness — the plain-ppid version failed this exact test.
- `flow doctor` (read-only) run on a real machine: correctly flagged a genuine 30-day-old orphaned `codex-acp` while leaving the live deployment's tracked adapter and foreign processes alone.
- Remaining manual check after deploy: start + close a Flow agent session and confirm the `claude` child count under `claude-agent-acp` returns to baseline (`ps -eo pid,ppid,etime,command | grep claude-agent-acp`).