### PR TITLE
agents: semantic session search over embeddings

### DIFF
--- a/dashboard/src/app/api/agents/sessions/search/route.ts
+++ b/dashboard/src/app/api/agents/sessions/search/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSessionToken } from "@/lib/auth";
+import { orcFetch } from "@/lib/orchestrator";
+
+// GET /api/agents/sessions/search?q=… — proxy to the orchestrator's semantic
+// session search.
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const token = await getSessionToken();
+  if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const q = req.nextUrl.searchParams.get("q")?.trim();
+  if (!q) return NextResponse.json({ error: "q required" }, { status: 400 });
+  const limit = req.nextUrl.searchParams.get("limit");
+  try {
+    const path = `/v1/agents/sessions/search?q=${encodeURIComponent(q)}${limit ? `&limit=${encodeURIComponent(limit)}` : ""}`;
+    const res = await orcFetch(path, token);
+    return NextResponse.json(await res.json(), { status: res.status });
+  } catch (err) {
+    return NextResponse.json({ error: (err as Error).message }, { status: 502 });
+  }
+}

--- a/dashboard/src/components/AgentsView.tsx
+++ b/dashboard/src/components/AgentsView.tsx
@@ -188,6 +188,45 @@ export function AgentsView() {
 
 const SESSIONS_SHOWN = 12;
 
+interface SessionSearchHit extends Omit<SessionRow, "live"> {
+  score: number;
+  snippet: string | null;
+}
+
+function SessionCard({
+  s,
+  snippet,
+  onNavigate,
+}: {
+  s: Omit<SessionRow, "live">;
+  snippet?: string | null;
+  onNavigate: (sid: string) => void;
+}) {
+  return (
+    <button
+      onClick={() => onNavigate(s.id)}
+      className="text-left rounded-lg border border-line bg-paper px-3.5 py-2.5 hover:bg-cream transition flex items-center gap-3 cursor-pointer"
+    >
+      <AgentBrandIcon backend={s.backend} className="text-ink flex-shrink-0" />
+      <div className="min-w-0 flex-1">
+        <p className="text-ink text-[13px] truncate font-medium" style={{ fontFamily: "var(--font-display)" }}>
+          {s.title}
+        </p>
+        <p style={{ fontFamily: "var(--font-mono)" }} className="text-[10px] uppercase tracking-wider text-text-muted mt-0.5 truncate">
+          {s.backend} · {timeAgo(s.updated_at)}
+          {s.worktree_id ? (
+            <span className="normal-case" title={`Ran on separate copy ${s.worktree_id}`}>
+              {" "}· ⎇ {s.worktree_id.split("/").pop()}
+            </span>
+          ) : null}
+        </p>
+        {snippet ? <p className="text-text-muted text-[11.5px] mt-1 line-clamp-2">{snippet}</p> : null}
+      </div>
+      <StatusPill kind={statusKind(s.status)}>{statusLabel(s.status)}</StatusPill>
+    </button>
+  );
+}
+
 function SessionsColumn({
   sessions,
   loading,
@@ -197,8 +236,35 @@ function SessionsColumn({
   loading: boolean;
   onNavigate: (sid: string) => void;
 }) {
+  const { prefix } = useProject();
   const [showAll, setShowAll] = useState(false);
+  const [query, setQuery] = useState("");
+  // null = not searching (show the recency list); [] = searched, no matches.
+  const [results, setResults] = useState<SessionSearchHit[] | null>(null);
+  const [searching, setSearching] = useState(false);
   const shown = showAll ? sessions : sessions.slice(0, SESSIONS_SHOWN);
+
+  // Debounced semantic search — describe the session, not just its title.
+  useEffect(() => {
+    const q = query.trim();
+    if (!q) return;
+    let stale = false;
+    const t = setTimeout(async () => {
+      try {
+        const r = await fetch(prefix(`/api/agents/sessions/search?q=${encodeURIComponent(q)}`));
+        const j = (r.ok ? await r.json() : {}) as { results?: SessionSearchHit[] };
+        if (!stale) setResults(j.results ?? []);
+      } catch {
+        if (!stale) setResults([]);
+      } finally {
+        if (!stale) setSearching(false);
+      }
+    }, 300);
+    return () => {
+      stale = true;
+      clearTimeout(t);
+    };
+  }, [query, prefix]);
 
   return (
     <div>
@@ -206,35 +272,47 @@ function SessionsColumn({
       <p className="text-text-muted text-[12.5px] mt-1 mb-3">
         Every agent run, newest first. ⎇ marks runs on a separate copy.
       </p>
+      <input
+        type="search"
+        value={query}
+        onChange={(e) => {
+          const v = e.target.value;
+          setQuery(v);
+          if (v.trim()) {
+            setSearching(true);
+          } else {
+            setResults(null);
+            setSearching(false);
+          }
+        }}
+        placeholder="Search sessions — describe what you were working on…"
+        className="w-full mb-3 rounded-lg border border-line bg-paper px-3.5 py-2 text-[13px] text-ink placeholder:text-text-muted focus:outline-none focus:border-ink/40 transition"
+      />
       <div className="flex flex-col gap-2">
-        {sessions.length === 0 && !loading && (
-          <p className="text-text-muted text-[13px]">No sessions yet — start one above.</p>
+        {results !== null ? (
+          <>
+            {searching && results.length === 0 && (
+              <p className="text-text-muted text-[13px]">Searching…</p>
+            )}
+            {!searching && results.length === 0 && (
+              <p className="text-text-muted text-[13px]">No sessions match that.</p>
+            )}
+            {results.map((s) => (
+              <SessionCard key={s.id} s={s} snippet={s.snippet} onNavigate={onNavigate} />
+            ))}
+          </>
+        ) : (
+          <>
+            {sessions.length === 0 && !loading && (
+              <p className="text-text-muted text-[13px]">No sessions yet — start one above.</p>
+            )}
+            {shown.map((s) => (
+              <SessionCard key={s.id} s={s} onNavigate={onNavigate} />
+            ))}
+          </>
         )}
-        {shown.map((s) => (
-          <button
-            key={s.id}
-            onClick={() => onNavigate(s.id)}
-            className="text-left rounded-lg border border-line bg-paper px-3.5 py-2.5 hover:bg-cream transition flex items-center gap-3 cursor-pointer"
-          >
-            <AgentBrandIcon backend={s.backend} className="text-ink flex-shrink-0" />
-            <div className="min-w-0 flex-1">
-              <p className="text-ink text-[13px] truncate font-medium" style={{ fontFamily: "var(--font-display)" }}>
-                {s.title}
-              </p>
-              <p style={{ fontFamily: "var(--font-mono)" }} className="text-[10px] uppercase tracking-wider text-text-muted mt-0.5 truncate">
-                {s.backend} · {timeAgo(s.updated_at)}
-                {s.worktree_id ? (
-                  <span className="normal-case" title={`Ran on separate copy ${s.worktree_id}`}>
-                    {" "}· ⎇ {s.worktree_id.split("/").pop()}
-                  </span>
-                ) : null}
-              </p>
-            </div>
-            <StatusPill kind={statusKind(s.status)}>{statusLabel(s.status)}</StatusPill>
-          </button>
-        ))}
       </div>
-      {sessions.length > SESSIONS_SHOWN && (
+      {results === null && sessions.length > SESSIONS_SHOWN && (
         <button
           onClick={() => setShowAll((v) => !v)}
           className="mt-2 text-[12px] text-text-muted hover:text-ink transition cursor-pointer"

--- a/orchestrator/package.json
+++ b/orchestrator/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts",
-    "test": "node --import tsx/esm --test test/fake-opencode.ts test/orchestrator.test.ts test/adapters.test.ts test/outbox-approve.test.ts test/llmlog.test.ts test/smoke.ts test/notify.test.ts test/pollers.test.ts test/poller.test.ts test/settings.test.ts test/sources.test.ts test/agent-diff.test.ts test/worktrees.test.ts test/memory.test.ts test/llm.test.ts test/indexer-runtime.test.ts test/index-queue.test.ts test/change-branch.test.ts test/repo-removed.test.ts test/index-incremental.test.ts test/work-folders.test.ts test/ingest.test.ts test/flow-hook.test.ts",
+    "test": "node --import tsx/esm --test test/fake-opencode.ts test/orchestrator.test.ts test/adapters.test.ts test/outbox-approve.test.ts test/llmlog.test.ts test/smoke.ts test/notify.test.ts test/pollers.test.ts test/poller.test.ts test/settings.test.ts test/sources.test.ts test/agent-diff.test.ts test/worktrees.test.ts test/memory.test.ts test/llm.test.ts test/indexer-runtime.test.ts test/index-queue.test.ts test/change-branch.test.ts test/repo-removed.test.ts test/index-incremental.test.ts test/work-folders.test.ts test/ingest.test.ts test/flow-hook.test.ts test/session-search.test.ts",
     "verify": "npm test",
     "verify:real": "tsx test/real-integrations.ts",
     "verify:session": "tsx test/real-session.ts"

--- a/orchestrator/src/agents/routes.ts
+++ b/orchestrator/src/agents/routes.ts
@@ -1,6 +1,7 @@
 // Agents v1 HTTP surface. Everything the dashboard needs:
 //   GET  /v1/agents                       installed agents + connected repos
 //   GET  /v1/agents/sessions              session list (newest first)
+//   GET  /v1/agents/sessions/search       {q, limit?} — semantic session search
 //   POST /v1/agents/sessions              {backend, repo, prompt} → {id}
 //   GET  /v1/agents/sessions/:id          metadata + full transcript replay
 //   GET  /v1/agents/sessions/:id/events   SSE: replay then live events
@@ -53,6 +54,7 @@ import {
   steer,
   subscribe,
 } from "./runtime.js";
+import { searchSessions } from "./session-search.js";
 
 export function registerAgentRoutes(app: FastifyInstance): void {
   app.get<{ Querystring: { owner?: string } }>("/v1/agents", async (req) => {
@@ -102,6 +104,18 @@ export function registerAgentRoutes(app: FastifyInstance): void {
   });
 
   app.get("/v1/agents/sessions", async () => ({ sessions: listSessions() }));
+
+  // Semantic session search: cosine over per-session embeddings (gateway's
+  // local model) + lexical boost. `semantic:false` in the response means the
+  // query couldn't be embedded (model loading / gateway down) and results are
+  // lexical-only. Registered before /:id so "search" never binds as an id.
+  app.get("/v1/agents/sessions/search", async (req, reply) => {
+    const { q, limit } = req.query as { q?: string; limit?: string };
+    const query = q?.trim();
+    if (!query) return reply.code(400).send({ error: "q required" });
+    const lim = Math.max(1, Math.min(50, Number(limit) || 20));
+    return await searchSessions(query, lim);
+  });
 
   // Create a session. Response is one of:
   //   {id, separateCopy}                     — started (separateCopy=true → runs

--- a/orchestrator/src/agents/runtime.ts
+++ b/orchestrator/src/agents/runtime.ts
@@ -19,6 +19,7 @@ import { fileURLToPath } from "node:url";
 import * as acp from "@agentclientprotocol/sdk";
 import db from "../db.js";
 import { onSessionClosed, setTranscriptReader, startIdleSweep } from "../memory/trigger.js";
+import { setSessionTranscriptReader, startSessionEmbedSweep } from "./session-search.js";
 import {
   createSessionWorktree,
   listWorktrees,
@@ -446,6 +447,8 @@ export function listRepoOptions(): RepoOption[] {
 //   start_untracked — JSON array of untracked paths that pre-existed the
 //                     session (excluded from the SESSION-scope diff).
 //   worktree_id     — reserved for Phase B (isolated worktrees); unused today.
+//   search_text/embedding/embedded_at — semantic session search (existing DBs
+//   get them via migration 15; see session-search.ts).
 db.exec(`
   CREATE TABLE IF NOT EXISTS agent_sessions (
     id TEXT PRIMARY KEY,
@@ -461,6 +464,9 @@ db.exec(`
     start_untracked TEXT,
     worktree_id TEXT,
     last_distilled_seq INTEGER,
+    search_text TEXT,
+    embedding BLOB,
+    embedded_at INTEGER,
     created_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL
   )
@@ -737,6 +743,11 @@ export function readTranscript(id: string, sinceSeq = 0): SessionEvent[] {
 // sessions don't spin up a timer; FLOW_DISTILLER=0 disables both.
 setTranscriptReader((id) => readTranscript(id).map((e) => ({ seq: e.seq, kind: e.kind, data: e.data })));
 startIdleSweep();
+
+// Same wiring for semantic session search (embeds session docs off the hot
+// path; FLOW_SESSION_SEARCH=0 disables the sweep).
+setSessionTranscriptReader((id) => readTranscript(id).map((e) => ({ kind: e.kind, data: e.data })));
+startSessionEmbedSweep();
 
 // ---------------------------------------------------------------------------
 // ACP connections — one adapter process per backend, shared across sessions

--- a/orchestrator/src/agents/session-search.ts
+++ b/orchestrator/src/agents/session-search.ts
@@ -1,0 +1,293 @@
+// session-search.ts — semantic search over agent sessions ("find that session
+// where we fixed the nginx DNS thing"). Each session gets a compact SEARCH DOC
+// (title + repo/branch + user prompts + the last agent conclusion) embedded
+// through the gateway's shared model (embed.ts → POST /v1/embed) into the
+// agent_sessions row itself (search_text, embedding, embedded_at — migration 15).
+//
+// Docs are (re)embedded off the hot path by a periodic sweep: a session is
+// pending when it has no vector yet or its row moved since the last embed
+// (updated_at advances on every status transition, so new turns re-embed on
+// the next sweep). Query time is pure read: cosine over the stored BLOBs plus
+// a lexical-overlap boost — and when the query vector is unavailable (model
+// still loading, gateway down) search degrades to lexical-only rather than
+// going silent, mirroring memory search's best-effort posture.
+//
+// The transcript reader is INJECTED (same pattern and reason as
+// memory/trigger.ts): runtime.ts owns the transcript store and wires us up at
+// its module load, and tests feed synthetic transcripts.
+
+import db from "../db.js";
+import { blobToVec, cosine, embedText as gatewayEmbed, vecToBlob } from "../embed.js";
+import { stripPreamble, type SlimEvent } from "../memory/slim.js";
+
+export type Embedder = (text: string) => Promise<Float32Array | null>;
+let _embedder: Embedder = gatewayEmbed;
+export function setEmbedder(fn: Embedder): void {
+  _embedder = fn;
+}
+
+type TranscriptReader = (id: string) => SlimEvent[];
+let _readTranscript: TranscriptReader = () => [];
+export function setSessionTranscriptReader(fn: TranscriptReader): void {
+  _readTranscript = fn;
+}
+
+// ---------------------------------------------------------------------------
+// Search doc
+
+const DOC_CAP = 4000; // ~1k tokens — well inside the embedding model's window
+const PROMPT_CAP = 500;
+const CONCLUSION_TAIL = 600;
+
+// The doc favors what a user remembers a session BY: their own prompts, then
+// the closing agent message (the "what happened" summary). Tool noise and
+// mid-turn chatter never make it in.
+export function buildSearchText(meta: { title?: string | null; repo?: string | null }, events: SlimEvent[]): string {
+  const prompts: string[] = [];
+  let branch = "";
+  let agentBuf = "";
+  let lastConclusion = "";
+  for (const e of events) {
+    if (e.kind === "created") {
+      const d = (e.data ?? {}) as { branch?: string };
+      if (d.branch) branch = d.branch;
+    } else if (e.kind === "user_prompt") {
+      if (agentBuf.trim()) lastConclusion = agentBuf.trim();
+      agentBuf = "";
+      const d = (e.data ?? {}) as { text?: string };
+      const t = stripPreamble(d.text || "").trim();
+      if (t) prompts.push(t.length > PROMPT_CAP ? t.slice(0, PROMPT_CAP) + "…" : t);
+    } else if (e.kind === "update") {
+      const d = (e.data ?? {}) as Record<string, unknown>;
+      const u = ((d.update ?? d) as Record<string, unknown>) ?? {};
+      if (u.sessionUpdate === "agent_message_chunk") {
+        agentBuf += (u.content as { text?: string } | undefined)?.text || "";
+      }
+    }
+  }
+  if (agentBuf.trim()) lastConclusion = agentBuf.trim();
+
+  const parts = [meta.title ?? "", [meta.repo ?? "", branch].filter(Boolean).join(" "), ...prompts];
+  if (lastConclusion) {
+    parts.push(lastConclusion.length > CONCLUSION_TAIL ? "…" + lastConclusion.slice(-CONCLUSION_TAIL) : lastConclusion);
+  }
+  let doc = parts.filter(Boolean).join("\n").trim();
+  if (doc.length > DOC_CAP) {
+    // Keep both ends: the title+first prompts define the task, the tail holds
+    // the conclusion.
+    doc = doc.slice(0, DOC_CAP / 2) + "\n…\n" + doc.slice(-DOC_CAP / 2);
+  }
+  return doc;
+}
+
+// ---------------------------------------------------------------------------
+// Embed sweep — keeps agent_sessions vectors converged with the transcripts
+
+// Statements are prepared lazily: agent_sessions is created at runtime.ts
+// module load, AFTER this module first evaluates (same hazard as trigger.ts).
+function pendingSessions(limit: number): Array<{ id: string }> {
+  return db
+    .prepare(
+      `SELECT id FROM agent_sessions
+       WHERE embedding IS NULL OR embedded_at IS NULL OR updated_at > embedded_at
+       ORDER BY updated_at DESC LIMIT ?`
+    )
+    .all(limit) as Array<{ id: string }>;
+}
+
+// Recompute one session's doc + vector. "skipped" = nothing new to embed
+// (doc unchanged, or session has no content); "failed" = embedder unavailable —
+// embedded_at stays NULL so the next sweep retries.
+export async function embedSessionNow(id: string): Promise<"embedded" | "skipped" | "failed"> {
+  const row = db
+    .prepare(`SELECT id, title, repo, search_text, embedding IS NOT NULL AS has_vec FROM agent_sessions WHERE id = ?`)
+    .get(id) as { id: string; title: string | null; repo: string | null; search_text: string | null; has_vec: number } | undefined;
+  if (!row) return "failed";
+
+  const doc = buildSearchText({ title: row.title, repo: row.repo }, _readTranscript(id));
+  const now = Date.now();
+  if (!doc) {
+    // Empty session — stamp it so the sweep stops revisiting until it changes.
+    db.prepare(`UPDATE agent_sessions SET embedded_at = ? WHERE id = ?`).run(now, id);
+    return "skipped";
+  }
+  if (doc === row.search_text && row.has_vec) {
+    // Row moved (status flip) but content didn't — restamp, skip the model call.
+    db.prepare(`UPDATE agent_sessions SET embedded_at = ? WHERE id = ?`).run(now, id);
+    return "skipped";
+  }
+
+  const vec = await _embedder(doc);
+  if (!vec) {
+    // Store the doc anyway — lexical search works meanwhile; embedded_at stays
+    // NULL so the vector is retried next sweep.
+    db.prepare(`UPDATE agent_sessions SET search_text = ? WHERE id = ?`).run(doc, id);
+    return "failed";
+  }
+  db.prepare(`UPDATE agent_sessions SET search_text = ?, embedding = ?, embedded_at = ? WHERE id = ?`).run(
+    doc,
+    vecToBlob(vec),
+    now,
+    id
+  );
+  return "embedded";
+}
+
+let _sweeping = false;
+export async function sweepSessionEmbeddings(limit = 50): Promise<number> {
+  if (_sweeping) return 0;
+  _sweeping = true;
+  let embedded = 0;
+  try {
+    for (const r of pendingSessions(limit)) {
+      if ((await embedSessionNow(r.id)) === "embedded") embedded++;
+    }
+  } finally {
+    _sweeping = false;
+  }
+  return embedded;
+}
+
+const SWEEP_INTERVAL_MS = 3 * 60 * 1000;
+
+let _timer: ReturnType<typeof setInterval> | null = null;
+export function startSessionEmbedSweep(): void {
+  if (_timer || process.env.FLOW_SESSION_SEARCH === "0") return;
+  const kick = () => {
+    sweepSessionEmbeddings().catch((err) => {
+      console.warn(`[session-search] sweep failed: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  };
+  // First pass shortly after boot (give the gateway a moment to come up —
+  // a not-ready model just means a retry on the next interval).
+  const boot = setTimeout(kick, 15_000);
+  boot.unref?.();
+  _timer = setInterval(kick, SWEEP_INTERVAL_MS);
+  _timer.unref?.();
+}
+export function stopSessionEmbedSweep(): void {
+  if (_timer) {
+    clearInterval(_timer);
+    _timer = null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Query
+
+const STOPWORDS = new Set([
+  "the", "a", "an", "and", "or", "of", "to", "in", "for", "on", "with",
+  "that", "this", "was", "were", "is", "are", "it", "at", "by", "we",
+  "where", "when", "what", "session", "sessions", "agent",
+]);
+
+export function queryTerms(q: string): string[] {
+  return [
+    ...new Set(
+      q
+        .toLowerCase()
+        .split(/[^a-z0-9_./-]+/)
+        .filter((t) => t.length >= 3 && !STOPWORDS.has(t))
+    ),
+  ];
+}
+
+// Fraction of query terms present in the doc — the same cheap keyword-overlap
+// boost memory search layers over cosine.
+export function lexicalOverlap(terms: string[], text: string): number {
+  if (terms.length === 0 || !text) return 0;
+  const hay = text.toLowerCase();
+  let hit = 0;
+  for (const t of terms) if (hay.includes(t)) hit++;
+  return hit / terms.length;
+}
+
+export function snippetFor(terms: string[], text: string | null): string | null {
+  if (!text) return null;
+  const hay = text.toLowerCase();
+  for (const t of terms) {
+    const i = hay.indexOf(t);
+    if (i < 0) continue;
+    const start = Math.max(0, i - 60);
+    const end = Math.min(text.length, i + t.length + 90);
+    const head = start > 0 ? "…" : "";
+    const tail = end < text.length ? "…" : "";
+    return head + text.slice(start, end).replace(/\s+/g, " ").trim() + tail;
+  }
+  return null;
+}
+
+// Vector-only hits below this cosine are noise for Gemma-768 (memory search
+// gates at 0.55; session docs are longer/noisier so we sit slightly lower).
+const COSINE_FLOOR = 0.45;
+const LEX_WEIGHT = 0.3;
+
+export interface SessionSearchHit {
+  id: string;
+  backend: string;
+  repo: string;
+  title: string;
+  status: string;
+  worktree_id: string | null;
+  created_at: number;
+  updated_at: number;
+  score: number;
+  snippet: string | null;
+}
+
+export async function searchSessions(
+  query: string,
+  limit = 20
+): Promise<{ results: SessionSearchHit[]; semantic: boolean }> {
+  const terms = queryTerms(query);
+  const qvec = await _embedder(query);
+
+  // Opportunistically converge stragglers while someone is actually searching
+  // (fire-and-forget; the guard in sweepSessionEmbeddings dedupes overlaps).
+  void sweepSessionEmbeddings().catch(() => {});
+
+  const rows = db
+    .prepare(
+      `SELECT id, backend, repo, title, status, worktree_id, created_at, updated_at, search_text, embedding
+       FROM agent_sessions`
+    )
+    .all() as Array<{
+    id: string;
+    backend: string;
+    repo: string;
+    title: string;
+    status: string;
+    worktree_id: string | null;
+    created_at: number;
+    updated_at: number;
+    search_text: string | null;
+    embedding: Buffer | null;
+  }>;
+
+  const scored = rows
+    .map((r) => {
+      const text = r.search_text || r.title || "";
+      const cos = qvec && r.embedding ? cosine(qvec, blobToVec(r.embedding)) : 0;
+      const lex = lexicalOverlap(terms, text);
+      return { r, cos, lex, score: qvec ? cos + LEX_WEIGHT * lex : lex };
+    })
+    .filter((x) => (x.cos >= COSINE_FLOOR ? true : x.lex > 0))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit);
+
+  return {
+    semantic: Boolean(qvec),
+    results: scored.map(({ r, score }) => ({
+      id: r.id,
+      backend: r.backend,
+      repo: r.repo,
+      title: r.title,
+      status: r.status,
+      worktree_id: r.worktree_id,
+      created_at: r.created_at,
+      updated_at: r.updated_at,
+      score: Math.round(score * 1000) / 1000,
+      snippet: snippetFor(terms, r.search_text),
+    })),
+  };
+}

--- a/orchestrator/src/migrations.ts
+++ b/orchestrator/src/migrations.ts
@@ -220,6 +220,41 @@ export const MIGRATIONS: Migration[] = [
       db.exec(ORIENT_DOCS_SCHEMA);
     },
   },
+  {
+    id: 15,
+    name: "agent_sessions: semantic session search (search_text, embedding, embedded_at)",
+    up: (db) => {
+      // Same sequencing hazard as migration 7: agent_sessions is created at
+      // runtime.ts module load, AFTER migrations. Any DB below 7 gets the table
+      // from migration 7 earlier in this walk; this guard covers a DB stamped
+      // 7-14 that somehow never materialized it. No-op when it exists.
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS agent_sessions (
+          id TEXT PRIMARY KEY,
+          backend TEXT NOT NULL,
+          repo TEXT NOT NULL,
+          cwd TEXT NOT NULL,
+          title TEXT NOT NULL,
+          status TEXT NOT NULL,
+          acp_session_id TEXT,
+          stop_reason TEXT,
+          error TEXT,
+          start_sha TEXT,
+          start_untracked TEXT,
+          worktree_id TEXT,
+          last_distilled_seq INTEGER,
+          created_at INTEGER NOT NULL,
+          updated_at INTEGER NOT NULL
+        )
+      `);
+      // search_text — the compact doc that was embedded (also serves lexical
+      // fallback); embedding — 768-dim Gemma BLOB (see embed.ts); embedded_at —
+      // ms stamp compared against updated_at to detect stale vectors.
+      db.exec("ALTER TABLE agent_sessions ADD COLUMN search_text TEXT");
+      db.exec("ALTER TABLE agent_sessions ADD COLUMN embedding BLOB");
+      db.exec("ALTER TABLE agent_sessions ADD COLUMN embedded_at INTEGER");
+    },
+  },
 ];
 
 // Orient docs — the AMBIENT memory tier. One rendered document per scope

--- a/orchestrator/test/session-search.test.ts
+++ b/orchestrator/test/session-search.test.ts
@@ -1,0 +1,212 @@
+// session-search.test.ts — semantic search over agent sessions. Fully offline:
+// in-memory DB, injected transcript reader, deterministic stub embedder (same
+// token-hash scheme as memory.test.ts) — no gateway, no model.
+
+import { test, describe, before, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+// Env BEFORE importing anything that touches the DB.
+process.env.DB_PATH = ":memory:";
+process.env.FLOW_ADMIN_TOKEN = "test-admin-token-session-search";
+process.env.FLOW_SESSION_SEARCH = "0"; // no timers in tests
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+let db: any;
+let ss: typeof import("../src/agents/session-search.js");
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+const DIM = 64;
+function stubVec(text: string): Float32Array {
+  const v = new Float32Array(DIM);
+  const tokens = text.toLowerCase().match(/[a-z0-9]+/g) ?? [];
+  for (const tok of tokens) {
+    let h = 0;
+    for (let i = 0; i < tok.length; i++) h = (h * 31 + tok.charCodeAt(i)) >>> 0;
+    v[h % DIM] += 1;
+  }
+  let n = 0;
+  for (const x of v) n += x * x;
+  n = Math.sqrt(n) || 1;
+  for (let i = 0; i < DIM; i++) v[i] /= n;
+  return v;
+}
+const stubEmbedder = async (t: string) => stubVec(t);
+
+// Synthetic transcripts, keyed by session id — the injected reader.
+const transcripts = new Map<string, Array<{ kind: string; data: unknown }>>();
+
+function insertSession(id: string, title: string, opts: { repo?: string; status?: string; updatedAt?: number } = {}): void {
+  db.prepare(
+    `INSERT INTO agent_sessions (id, backend, repo, cwd, title, status, created_at, updated_at)
+     VALUES (?, 'claude', ?, '/tmp', ?, ?, ?, ?)`
+  ).run(id, opts.repo ?? "flow", title, opts.status ?? "closed", Date.now() - 1000, opts.updatedAt ?? Date.now() - 1000);
+}
+
+function chunk(text: string): { kind: string; data: unknown } {
+  return { kind: "update", data: { sessionUpdate: "agent_message_chunk", content: { text } } };
+}
+
+before(async () => {
+  db = (await import("../src/db.js")).default;
+  // agent_sessions is created at runtime.ts module load; these tests bypass
+  // runtime entirely, so create the current baseline shape directly.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS agent_sessions (
+      id TEXT PRIMARY KEY,
+      backend TEXT NOT NULL,
+      repo TEXT NOT NULL,
+      cwd TEXT NOT NULL,
+      title TEXT NOT NULL,
+      status TEXT NOT NULL,
+      acp_session_id TEXT,
+      stop_reason TEXT,
+      error TEXT,
+      start_sha TEXT,
+      start_untracked TEXT,
+      worktree_id TEXT,
+      last_distilled_seq INTEGER,
+      search_text TEXT,
+      embedding BLOB,
+      embedded_at INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+  ss = await import("../src/agents/session-search.js");
+  ss.setEmbedder(stubEmbedder);
+  ss.setSessionTranscriptReader((id) => transcripts.get(id) ?? []);
+});
+
+beforeEach(() => {
+  db.exec("DELETE FROM agent_sessions");
+  transcripts.clear();
+});
+
+describe("buildSearchText", () => {
+  test("keeps title, repo/branch, prompts, and only the LAST agent conclusion", () => {
+    const doc = ss.buildSearchText({ title: "Fix nginx", repo: "bs365" }, [
+      { kind: "created", data: { branch: "dev" } },
+      { kind: "user_prompt", data: { text: "the proxy caches stale DNS" } },
+      chunk("first turn conclusion about resolvers"),
+      { kind: "user_prompt", data: { text: "now add a variable proxy_pass" } },
+      chunk("final: switched to metadata resolver"),
+    ]);
+    assert.match(doc, /Fix nginx/);
+    assert.match(doc, /bs365 dev/);
+    assert.match(doc, /stale DNS/);
+    assert.match(doc, /variable proxy_pass/);
+    assert.match(doc, /metadata resolver/);
+    assert.doesNotMatch(doc, /first turn conclusion/);
+  });
+
+  test("caps long docs keeping head and tail", () => {
+    const doc = ss.buildSearchText({ title: "t", repo: "r" }, [
+      { kind: "user_prompt", data: { text: "start-marker " + "x".repeat(6000) } },
+      chunk("y".repeat(3000) + " end-marker"),
+    ]);
+    assert.ok(doc.length <= 4100);
+    assert.match(doc, /start-marker/);
+    assert.match(doc, /end-marker/);
+  });
+
+  test("strips the MCP orientation preamble from prompts", () => {
+    const preamble =
+      "You have access to the flow-graph tools. Consult it FIRST to orient yourself before diving into files.\n\n" +
+      "fix the login bug on the settings page and add a regression test for it";
+    const doc = ss.buildSearchText({ title: "t", repo: "r" }, [{ kind: "user_prompt", data: { text: preamble } }]);
+    assert.match(doc, /fix the login bug/);
+    assert.doesNotMatch(doc, /Consult it FIRST/);
+  });
+});
+
+describe("query helpers", () => {
+  test("queryTerms drops stopwords and short tokens", () => {
+    assert.deepEqual(ss.queryTerms("the session where we fixed nginx DNS"), ["fixed", "nginx", "dns"]);
+  });
+
+  test("lexicalOverlap is the matched fraction", () => {
+    assert.equal(ss.lexicalOverlap(["nginx", "dns"], "nginx resolver work"), 0.5);
+    assert.equal(ss.lexicalOverlap([], "anything"), 0);
+  });
+
+  test("snippetFor windows around the first matching term", () => {
+    const snip = ss.snippetFor(["resolver"], "a".repeat(200) + " the metadata resolver fix " + "b".repeat(200));
+    assert.ok(snip);
+    assert.match(snip!, /metadata resolver fix/);
+    assert.ok(snip!.startsWith("…") && snip!.endsWith("…"));
+  });
+});
+
+describe("embed sweep", () => {
+  test("embeds pending sessions, then skips unchanged ones on re-sweep", async () => {
+    insertSession("s1", "Fix nginx DNS caching");
+    transcripts.set("s1", [{ kind: "user_prompt", data: { text: "nginx pins upstream IPs, add a resolver" } }]);
+
+    assert.equal(await ss.sweepSessionEmbeddings(), 1);
+    const row = db.prepare("SELECT search_text, embedding, embedded_at FROM agent_sessions WHERE id='s1'").get();
+    assert.match(row.search_text, /resolver/);
+    assert.ok(row.embedding && row.embedded_at);
+
+    // Row moves (status flip) but content is unchanged → restamp, no re-embed.
+    db.prepare("UPDATE agent_sessions SET updated_at = ? WHERE id='s1'").run(Date.now() + 60_000);
+    assert.equal(await ss.embedSessionNow("s1"), "skipped");
+  });
+
+  test("embedder unavailable stores the doc, leaves the vector pending", async () => {
+    insertSession("s1", "Some task");
+    transcripts.set("s1", [{ kind: "user_prompt", data: { text: "investigate the flaky login test" } }]);
+    ss.setEmbedder(async () => null);
+    try {
+      assert.equal(await ss.embedSessionNow("s1"), "failed");
+    } finally {
+      ss.setEmbedder(stubEmbedder);
+    }
+    const row = db.prepare("SELECT search_text, embedding, embedded_at FROM agent_sessions WHERE id='s1'").get();
+    assert.match(row.search_text, /flaky login/);
+    assert.equal(row.embedding, null);
+    assert.equal(row.embedded_at, null);
+  });
+});
+
+describe("searchSessions", () => {
+  test("ranks the semantically-matching session first", async () => {
+    insertSession("nginx", "Fix proxy outage");
+    transcripts.set("nginx", [
+      { kind: "user_prompt", data: { text: "nginx caches DNS forever, the upstream IP rotated and broke the proxy" } },
+    ]);
+    insertSession("billing", "Billing work");
+    transcripts.set("billing", [
+      { kind: "user_prompt", data: { text: "charge the project owner pool for editor builds" } },
+    ]);
+    await ss.sweepSessionEmbeddings();
+
+    const { results, semantic } = await ss.searchSessions("nginx DNS caching proxy");
+    assert.equal(semantic, true);
+    assert.ok(results.length >= 1);
+    assert.equal(results[0].id, "nginx");
+    assert.ok(results[0].snippet && /DNS/.test(results[0].snippet));
+  });
+
+  test("degrades to lexical-only when the query cannot be embedded", async () => {
+    insertSession("s1", "Fix nginx DNS caching");
+    transcripts.set("s1", [{ kind: "user_prompt", data: { text: "nginx resolver work" } }]);
+    await ss.sweepSessionEmbeddings();
+
+    ss.setEmbedder(async () => null);
+    try {
+      const { results, semantic } = await ss.searchSessions("nginx resolver");
+      assert.equal(semantic, false);
+      assert.equal(results[0]?.id, "s1");
+    } finally {
+      ss.setEmbedder(stubEmbedder);
+    }
+  });
+
+  test("unrelated queries return nothing", async () => {
+    insertSession("s1", "Fix nginx DNS caching");
+    transcripts.set("s1", [{ kind: "user_prompt", data: { text: "nginx resolver work" } }]);
+    await ss.sweepSessionEmbeddings();
+    const { results } = await ss.searchSessions("kubernetes helm chart upgrade");
+    assert.equal(results.length, 0);
+  });
+});


### PR DESCRIPTION
## What

Search agent sessions by describing them — "the session where we fixed the gateway crashing" — instead of scanning titles. Adds embedding-based search over session history with a search box on the Agents page.

## How

- **Per-session search doc** (`orchestrator/src/agents/session-search.ts`): title + repo/branch + user prompts (orientation preamble stripped) + the last agent conclusion, capped at 4k chars keeping head and tail. Embedded through the gateway's shared local model via the existing `embed.ts` client — one embedding space, no new model or keys.
- **Storage** — migration 15 adds `search_text` / `embedding` / `embedded_at` to `agent_sessions` (baseline updated in `runtime.ts`, which owns that table's creation; same sequencing-hazard guard as migration 7).
- **Sweep** — every 3 min (plus shortly after boot) embeds sessions whose row moved since their last embed, so existing history backfills automatically and new turns re-embed. Embedder unavailable → doc stored, vector retried next sweep. `FLOW_SESSION_SEARCH=0` disables.
- **Query** — `GET /v1/agents/sessions/search?q=` ranks by cosine (floor 0.45) + 0.3 × lexical-overlap boost; degrades to lexical-only with `semantic:false` when the query can't be embedded (model loading / gateway down), mirroring memory search's best-effort posture.
- **Dashboard** — debounced search input in the Sessions column, ranked results with matching-text snippets, via a standard server-side proxy route.

## Testing

- 11 new offline tests (`test/session-search.test.ts`) with an injected stub embedder and transcript reader — doc building, preamble strip, cap behavior, sweep skip/retry paths, ranking, lexical degradation.
- Full orchestrator suite: 293 pass / 0 fail. Dashboard eslint clean on touched files.
- Empirical: ran migration + sweep + queries against a `VACUUM INTO` copy of a live v14 `flow.db` with real transcripts and the live gateway — migration 14→15 clean, all 105 sessions embedded in 68s, semantic queries ranked the expected sessions first.

## Deploy note

Feature activates on the next orchestrator restart: migration runs at boot, the sweep backfills history automatically. No config needed.