### PR TITLE
Knowledge Base: replace Inbox with /knowledge — memories with attribution, corpus, delete

### DIFF
--- a/dashboard/src/app/api/corrections/route.ts
+++ b/dashboard/src/app/api/corrections/route.ts
@@ -3,7 +3,8 @@ import { getSessionToken } from "@/lib/auth";
 import { orcFetch } from "@/lib/orchestrator";
 
 // GET /api/corrections — proxy the orchestrator's corrections queue (agent
-// flags being verified against base-branch checkouts) for the inbox page.
+// flags being verified against base-branch checkouts) for the Knowledge Base
+// page's corrections section.
 
 export async function GET(req: Request) {
   const token = await getSessionToken();

--- a/dashboard/src/app/api/memory/list/route.ts
+++ b/dashboard/src/app/api/memory/list/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { getSessionToken } from "@/lib/auth";
+import { orcFetch } from "@/lib/orchestrator";
+
+// GET /api/memory/list — proxy the orchestrator's Knowledge Base listing
+// (memories with attribution + paged corpus). Query string passes through
+// verbatim: ?q=&source=&limit=&offset=.
+
+export async function GET(req: Request) {
+  const token = await getSessionToken();
+  if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const url = new URL(req.url);
+  try {
+    const res = await orcFetch(`/v1/memory/list${url.search}`, token);
+    if (!res.ok) return NextResponse.json({ error: `Orchestrator ${res.status}` }, { status: 502 });
+    return NextResponse.json(await res.json());
+  } catch (e) {
+    return NextResponse.json({ error: e instanceof Error ? e.message : "Orchestrator unreachable" }, { status: 502 });
+  }
+}

--- a/dashboard/src/app/api/memory/route.ts
+++ b/dashboard/src/app/api/memory/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { getSessionToken } from "@/lib/auth";
+import { orcFetch } from "@/lib/orchestrator";
+
+// DELETE /api/memory?id=<uuid>&type=memory|observation — the Knowledge Base's
+// one curation act, proxied to the orchestrator's cascade-delete routes.
+
+export async function DELETE(req: Request) {
+  const token = await getSessionToken();
+  if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const url = new URL(req.url);
+  const id = url.searchParams.get("id");
+  if (!id) return NextResponse.json({ error: "id is required" }, { status: 400 });
+  const type = url.searchParams.get("type") === "observation" ? "observation" : "memory";
+  const path =
+    type === "observation"
+      ? `/v1/memory/observation/${encodeURIComponent(id)}`
+      : `/v1/memory/${encodeURIComponent(id)}`;
+  try {
+    const res = await orcFetch(path, token, { method: "DELETE" });
+    if (!res.ok) return NextResponse.json({ error: `Orchestrator ${res.status}` }, { status: res.status === 404 ? 404 : 502 });
+    return NextResponse.json(await res.json());
+  } catch (e) {
+    return NextResponse.json({ error: e instanceof Error ? e.message : "Orchestrator unreachable" }, { status: 502 });
+  }
+}

--- a/dashboard/src/app/inbox/page.tsx
+++ b/dashboard/src/app/inbox/page.tsx
@@ -1,137 +1,16 @@
 "use client";
-import { Shell } from "@/components/Shell";
-import { timeAgo } from "@/lib/time";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { useProject } from "@/lib/useProject";
 
-// Review inbox — correction flags filed by agents when graph content
-// contradicts the code. Verified by the indexer against the repo's base
-// branch; shown here so unclear/failed ones get human eyes. (Durable rules no
-// longer pass through here: they flow through the distiller into memory and
-// earn their way into the orient docs — nothing to approve.)
-
-interface CorrectionRow {
-  id: string;
-  target_ids: string;
-  reason: string;
-  evidence?: string | null;
-  repo?: string | null;
-  actor?: string | null;
-  status: string;
-  resolution?: string | null;
-  created_at: number;
-}
-
-const CORRECTION_COLORS: Record<string, string> = {
-  pending: "var(--text-muted)",
-  verifying: "var(--accent-hover)",
-  applied: "var(--ok)",
-  rejected: "var(--text-secondary)",
-  unclear: "var(--warn, #b45309)",
-  failed: "var(--danger, #b91c1c)",
-};
-
-function StatusChip({ status }: { status: string }) {
-  return (
-    <span
-      style={{
-        fontFamily: "monospace",
-        fontSize: 10,
-        textTransform: "uppercase",
-        letterSpacing: "0.08em",
-        color: CORRECTION_COLORS[status] ?? "var(--text-muted)",
-        border: "1px solid var(--border)",
-        borderRadius: 999,
-        padding: "2px 8px",
-        whiteSpace: "nowrap",
-      }}
-    >
-      {status}
-    </span>
-  );
-}
-
-export default function InboxPage() {
-  const [corrections, setCorrections] = useState<CorrectionRow[]>([]);
-  const [loading, setLoading] = useState(true);
+// The Inbox became the Knowledge Base — memories with attribution, corpus
+// knowledge from Slack/Linear/meetings, and the correction flags that used to
+// live here. Old links land there.
+export default function InboxRedirect() {
+  const router = useRouter();
   const { prefix } = useProject();
-
-  const load = useCallback(() => {
-    fetch(prefix("/api/corrections"))
-      .then((r) => r.json())
-      .catch(() => ({ rows: [] }))
-      .then((c) => {
-        setCorrections(((c as { rows?: CorrectionRow[] }).rows ?? []));
-        setLoading(false);
-      });
-  }, [prefix]);
-
   useEffect(() => {
-    load();
-  }, [load]);
-
-  return (
-    <Shell>
-      <div style={{ marginBottom: 28 }}>
-        <h1 style={{ margin: 0, fontSize: 22, fontWeight: 700, color: "var(--text-primary)" }}>Inbox</h1>
-        <p style={{ margin: "6px 0 0", fontSize: 13, color: "var(--text-secondary)" }}>
-          Correction flags from agent sessions, verified automatically against each repo&apos;s base branch.
-        </p>
-      </div>
-
-      {loading ? (
-        <div style={{ color: "var(--text-muted)", fontSize: 13 }}>Loading…</div>
-      ) : (
-        <section>
-          <h2 style={{ margin: "0 0 12px", fontSize: 15, fontWeight: 700, color: "var(--text-primary)" }}>
-            Corrections {corrections.length > 0 && <span style={{ color: "var(--text-muted)" }}>({corrections.length})</span>}
-          </h2>
-          {corrections.length === 0 ? (
-            <div style={{ fontSize: 13, color: "var(--text-muted)" }}>No correction flags yet. Agents file these when graph content contradicts the code.</div>
-          ) : (
-            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-              {corrections.map((c) => {
-                let targets: string[] = [];
-                try {
-                  targets = JSON.parse(c.target_ids) as string[];
-                } catch {
-                  /* leave empty */
-                }
-                return (
-                  <div
-                    key={c.id}
-                    style={{
-                      background: "var(--surface)",
-                      border: "1px solid var(--border)",
-                      borderRadius: 8,
-                      padding: "12px 16px",
-                    }}
-                  >
-                    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, marginBottom: 6 }}>
-                      <div style={{ fontFamily: "monospace", fontSize: 11, color: "var(--text-secondary)", overflow: "hidden", textOverflow: "ellipsis" }}>
-                        {targets.join(", ")}
-                      </div>
-                      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                        <span style={{ fontSize: 11, color: "var(--text-muted)" }}>{timeAgo(c.created_at)}</span>
-                        <StatusChip status={c.status} />
-                      </div>
-                    </div>
-                    <div style={{ fontSize: 13, color: "var(--text-primary)" }}>{c.reason}</div>
-                    {c.evidence && (
-                      <div style={{ fontFamily: "monospace", fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}>{c.evidence}</div>
-                    )}
-                    {c.resolution && (
-                      <div style={{ fontSize: 12, color: "var(--text-secondary)", marginTop: 6, borderTop: "1px solid var(--border)", paddingTop: 6 }}>
-                        {c.resolution}
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </section>
-      )}
-    </Shell>
-  );
+    router.replace(prefix("/knowledge"));
+  }, [router, prefix]);
+  return null;
 }

--- a/dashboard/src/app/knowledge/page.tsx
+++ b/dashboard/src/app/knowledge/page.tsx
@@ -1,0 +1,514 @@
+"use client";
+import { Shell } from "@/components/Shell";
+import { timeAgo } from "@/lib/time";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useProject } from "@/lib/useProject";
+
+// Knowledge Base — everything Flow has learned, in one place: distilled
+// memories (from agent sessions and explicit "remember" calls) plus the raw
+// corpus knowledge mirrored from Slack, Linear and meetings. Each item shows
+// where it came from and who contributed it, and can be deleted — the one
+// human curation act. Correction flags (formerly the Inbox) live at the
+// bottom of this page.
+
+interface EvidenceRow {
+  id: string;
+  source: string;
+  claim: string;
+  source_url: string | null;
+  source_weight: string;
+  created_at: number;
+  by: string | null;
+}
+
+interface MemoryItem {
+  id: string;
+  claim: string;
+  kind: string;
+  repo: string | null;
+  strength: number;
+  tier: string;
+  evidence_count: number;
+  people_count: number;
+  contradiction_count: number;
+  max_source_weight: string;
+  created_at: number;
+  updated_at: number;
+  contributors: string[];
+  sources: Record<string, number>;
+  evidence: EvidenceRow[];
+}
+
+interface CorpusItem {
+  id: string;
+  source: string;
+  claim: string;
+  source_url: string | null;
+  repo: string | null;
+  created_at: number;
+  by: string | null;
+}
+
+interface KnowledgeResponse {
+  stats?: { memories: number; observations: number; bySource: Record<string, number> };
+  memories?: MemoryItem[];
+  corpus?: { rows: CorpusItem[]; total: number; limit: number; offset: number };
+}
+
+interface CorrectionRow {
+  id: string;
+  target_ids: string;
+  reason: string;
+  evidence?: string | null;
+  repo?: string | null;
+  status: string;
+  resolution?: string | null;
+  created_at: number;
+}
+
+const SOURCE_FILTERS = [
+  { key: "", label: "All" },
+  { key: "session", label: "Sessions" },
+  { key: "slack", label: "Slack" },
+  { key: "linear", label: "Linear" },
+  { key: "meeting", label: "Meetings" },
+];
+
+const TIER_COLORS: Record<string, string> = {
+  strong: "var(--ok)",
+  medium: "var(--accent-hover, #b45309)",
+  weak: "var(--text-muted)",
+};
+
+const CORRECTION_COLORS: Record<string, string> = {
+  pending: "var(--text-muted)",
+  verifying: "var(--accent-hover)",
+  applied: "var(--ok)",
+  rejected: "var(--text-secondary)",
+  unclear: "var(--warn, #b45309)",
+  failed: "var(--danger, #b91c1c)",
+};
+
+function Chip({ children, color }: { children: React.ReactNode; color?: string }) {
+  return (
+    <span
+      style={{
+        fontFamily: "monospace",
+        fontSize: 10,
+        textTransform: "uppercase",
+        letterSpacing: "0.08em",
+        color: color ?? "var(--text-muted)",
+        border: "1px solid var(--border)",
+        borderRadius: 999,
+        padding: "2px 8px",
+        whiteSpace: "nowrap",
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function DeleteButton({ onClick, title }: { onClick: () => void; title: string }) {
+  return (
+    <button
+      onClick={onClick}
+      title={title}
+      style={{
+        background: "transparent",
+        border: "1px solid var(--border)",
+        borderRadius: 6,
+        color: "var(--text-muted)",
+        cursor: "pointer",
+        padding: "3px 8px",
+        fontSize: 11,
+        lineHeight: 1,
+        flexShrink: 0,
+      }}
+    >
+      Delete
+    </button>
+  );
+}
+
+function sourcesLine(sources: Record<string, number>): string {
+  return Object.entries(sources)
+    .map(([s, n]) => (n > 1 ? `${s} ×${n}` : s))
+    .join(" · ");
+}
+
+export default function KnowledgePage() {
+  const [data, setData] = useState<KnowledgeResponse>({});
+  const [corpusRows, setCorpusRows] = useState<CorpusItem[]>([]);
+  const [corpusTotal, setCorpusTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [q, setQ] = useState("");
+  const [source, setSource] = useState("");
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [corrections, setCorrections] = useState<CorrectionRow[]>([]);
+  const [showCorrections, setShowCorrections] = useState(false);
+  const { prefix } = useProject();
+
+  const load = useCallback(
+    (opts: { q: string; source: string; offset: number; append: boolean }) => {
+      const params = new URLSearchParams();
+      if (opts.q.trim()) params.set("q", opts.q.trim());
+      if (opts.source) params.set("source", opts.source);
+      params.set("limit", "50");
+      params.set("offset", String(opts.offset));
+      fetch(prefix(`/api/memory/list?${params}`))
+        .then((r) => r.json())
+        .catch(() => ({}))
+        .then((d: KnowledgeResponse) => {
+          setData((prev) => (opts.append ? prev : d));
+          setCorpusRows((prev) => (opts.append ? [...prev, ...(d.corpus?.rows ?? [])] : (d.corpus?.rows ?? [])));
+          setCorpusTotal(d.corpus?.total ?? 0);
+          setLoading(false);
+        });
+    },
+    [prefix],
+  );
+
+  // Search + source filter drive a debounced server refetch (the corpus is
+  // paged server-side; memories re-arrive too, cheap either way).
+  useEffect(() => {
+    const t = setTimeout(() => load({ q, source, offset: 0, append: false }), q ? 250 : 0);
+    return () => clearTimeout(t);
+  }, [q, source, load]);
+
+  useEffect(() => {
+    fetch(prefix("/api/corrections"))
+      .then((r) => r.json())
+      .catch(() => ({ rows: [] }))
+      .then((c) => setCorrections((c as { rows?: CorrectionRow[] }).rows ?? []));
+  }, [prefix]);
+
+  const memories = useMemo(() => {
+    let rows = data.memories ?? [];
+    if (source) rows = rows.filter((m) => (m.sources[source] ?? 0) > 0);
+    const needle = q.trim().toLowerCase();
+    if (needle) {
+      rows = rows.filter(
+        (m) =>
+          m.claim.toLowerCase().includes(needle) ||
+          (m.repo ?? "").toLowerCase().includes(needle) ||
+          m.contributors.some((c) => c.toLowerCase().includes(needle)),
+      );
+    }
+    return rows;
+  }, [data.memories, q, source]);
+
+  function toggleExpand(id: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  async function deleteItem(id: string, type: "memory" | "observation") {
+    const what = type === "memory" ? "this memory and all its evidence" : "this item";
+    if (!window.confirm(`Delete ${what}? Agents will no longer recall it. This cannot be undone.`)) return;
+    const res = await fetch(prefix(`/api/memory?id=${encodeURIComponent(id)}&type=${type}`), { method: "DELETE" });
+    if (!res.ok) return;
+    if (type === "memory") {
+      setData((d) => ({ ...d, memories: (d.memories ?? []).filter((m) => m.id !== id) }));
+    } else {
+      setCorpusRows((rows) => rows.filter((r) => r.id !== id));
+      setCorpusTotal((n) => Math.max(0, n - 1));
+    }
+  }
+
+  const stats = data.stats;
+
+  return (
+    <Shell>
+      <div style={{ marginBottom: 24 }}>
+        <h1 style={{ margin: 0, fontSize: 22, fontWeight: 700, color: "var(--text-primary)" }}>Knowledge Base</h1>
+        <p style={{ margin: "6px 0 0", fontSize: 13, color: "var(--text-secondary)" }}>
+          Everything Flow has learned — distilled memories with who contributed them, plus raw knowledge from Slack,
+          Linear and meetings. Delete anything that&apos;s wrong; agents stop recalling it immediately.
+        </p>
+        {stats && (
+          <div style={{ marginTop: 10, fontFamily: "monospace", fontSize: 11, color: "var(--text-muted)" }}>
+            {stats.memories} memories · {stats.observations} observations
+            {Object.entries(stats.bySource).map(([s, n]) => (
+              <span key={s}> · {s} {n}</span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Search + source filters */}
+      <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 20, flexWrap: "wrap" }}>
+        <input
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Search knowledge…"
+          style={{
+            flex: "1 1 240px",
+            maxWidth: 360,
+            background: "var(--surface)",
+            border: "1px solid var(--border)",
+            borderRadius: 8,
+            padding: "8px 12px",
+            fontSize: 13,
+            color: "var(--text-primary)",
+            outline: "none",
+          }}
+        />
+        <div style={{ display: "flex", gap: 6 }}>
+          {SOURCE_FILTERS.map((f) => (
+            <button
+              key={f.key}
+              onClick={() => setSource(f.key)}
+              style={{
+                fontFamily: "monospace",
+                fontSize: 10,
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
+                color: source === f.key ? "var(--text-primary)" : "var(--text-muted)",
+                background: source === f.key ? "var(--surface)" : "transparent",
+                border: "1px solid var(--border)",
+                borderRadius: 999,
+                padding: "4px 10px",
+                cursor: "pointer",
+              }}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {loading ? (
+        <div style={{ color: "var(--text-muted)", fontSize: 13 }}>Loading…</div>
+      ) : (
+        <>
+          {/* Distilled memories */}
+          <section style={{ marginBottom: 32 }}>
+            <h2 style={{ margin: "0 0 12px", fontSize: 15, fontWeight: 700, color: "var(--text-primary)" }}>
+              Memories {memories.length > 0 && <span style={{ color: "var(--text-muted)" }}>({memories.length})</span>}
+            </h2>
+            {memories.length === 0 ? (
+              <div style={{ fontSize: 13, color: "var(--text-muted)" }}>
+                {q || source ? "Nothing matches this filter." : "No memories yet. They distill automatically from agent sessions, Slack and Linear."}
+              </div>
+            ) : (
+              <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                {memories.map((m) => {
+                  const open = expanded.has(m.id);
+                  return (
+                    <div
+                      key={m.id}
+                      style={{
+                        background: "var(--surface)",
+                        border: "1px solid var(--border)",
+                        borderRadius: 8,
+                        padding: "12px 16px",
+                      }}
+                    >
+                      <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6, flexWrap: "wrap" }}>
+                        <Chip>{m.kind}</Chip>
+                        <Chip color={TIER_COLORS[m.tier]}>{m.tier}</Chip>
+                        {m.repo && <Chip>{m.repo}</Chip>}
+                        <span style={{ flex: 1 }} />
+                        <span style={{ fontSize: 11, color: "var(--text-muted)" }}>{timeAgo(m.updated_at * 1000)}</span>
+                        <DeleteButton onClick={() => deleteItem(m.id, "memory")} title="Delete this memory and its evidence" />
+                      </div>
+                      <div style={{ fontSize: 13, color: "var(--text-primary)", lineHeight: 1.5 }}>{m.claim}</div>
+                      <div
+                        style={{
+                          marginTop: 8,
+                          display: "flex",
+                          alignItems: "center",
+                          gap: 12,
+                          flexWrap: "wrap",
+                          fontSize: 11,
+                          color: "var(--text-muted)",
+                        }}
+                      >
+                        {m.contributors.length > 0 && (
+                          <span style={{ color: "var(--text-secondary)" }}>{m.contributors.join(" · ")}</span>
+                        )}
+                        <span>{sourcesLine(m.sources) || "no attached evidence"}</span>
+                        <button
+                          onClick={() => toggleExpand(m.id)}
+                          style={{
+                            background: "transparent",
+                            border: "none",
+                            color: "var(--text-muted)",
+                            cursor: "pointer",
+                            fontSize: 11,
+                            padding: 0,
+                            textDecoration: "underline",
+                          }}
+                        >
+                          {open ? "hide evidence" : `evidence (${m.evidence_count})`}
+                        </button>
+                      </div>
+                      {open && (
+                        <div style={{ marginTop: 8, borderTop: "1px solid var(--border)", paddingTop: 8, display: "flex", flexDirection: "column", gap: 6 }}>
+                          {m.evidence.map((e) => (
+                            <div key={e.id} style={{ fontSize: 12, color: "var(--text-secondary)" }}>
+                              <span style={{ fontFamily: "monospace", fontSize: 10, color: "var(--text-muted)" }}>
+                                [{e.source}]{e.by ? ` ${e.by}` : ""} · {timeAgo(e.created_at * 1000)}
+                                {e.source_weight === "user_stated" && " · stated by a person"}
+                                {e.source_weight === "error_proven" && " · proven by an error"}
+                              </span>{" "}
+                              {e.claim}
+                              {e.source_url && (
+                                <>
+                                  {" "}
+                                  <a href={e.source_url} target="_blank" rel="noreferrer" style={{ color: "var(--text-muted)" }}>
+                                    source ↗
+                                  </a>
+                                </>
+                              )}
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </section>
+
+          {/* Raw corpus knowledge — slack / linear / meetings */}
+          <section style={{ marginBottom: 32 }}>
+            <h2 style={{ margin: "0 0 4px", fontSize: 15, fontWeight: 700, color: "var(--text-primary)" }}>
+              From Slack, Linear &amp; meetings{" "}
+              {corpusTotal > 0 && <span style={{ color: "var(--text-muted)" }}>({corpusTotal})</span>}
+            </h2>
+            <p style={{ margin: "0 0 12px", fontSize: 12, color: "var(--text-secondary)" }}>
+              Mirrored knowledge agents can search — not yet consolidated into memories.
+            </p>
+            {corpusRows.length === 0 ? (
+              <div style={{ fontSize: 13, color: "var(--text-muted)" }}>
+                {q || source ? "Nothing matches this filter." : "Nothing captured yet. Connect Slack or Linear and this fills up on its own."}
+              </div>
+            ) : (
+              <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+                {corpusRows.map((r) => (
+                  <div
+                    key={r.id}
+                    style={{
+                      background: "var(--surface)",
+                      border: "1px solid var(--border)",
+                      borderRadius: 8,
+                      padding: "10px 16px",
+                      display: "flex",
+                      alignItems: "flex-start",
+                      gap: 10,
+                    }}
+                  >
+                    <Chip>{r.source}</Chip>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ fontSize: 13, color: "var(--text-primary)", lineHeight: 1.5 }}>{r.claim}</div>
+                      <div style={{ marginTop: 4, fontSize: 11, color: "var(--text-muted)" }}>
+                        {r.by && <span style={{ color: "var(--text-secondary)" }}>{r.by} · </span>}
+                        {timeAgo(r.created_at * 1000)}
+                        {r.source_url && (
+                          <>
+                            {" · "}
+                            <a href={r.source_url} target="_blank" rel="noreferrer" style={{ color: "var(--text-muted)" }}>
+                              source ↗
+                            </a>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                    <DeleteButton onClick={() => deleteItem(r.id, "observation")} title="Delete this item" />
+                  </div>
+                ))}
+                {corpusRows.length < corpusTotal && (
+                  <button
+                    onClick={() => load({ q, source, offset: corpusRows.length, append: true })}
+                    style={{
+                      alignSelf: "flex-start",
+                      background: "transparent",
+                      border: "1px solid var(--border)",
+                      borderRadius: 8,
+                      color: "var(--text-secondary)",
+                      cursor: "pointer",
+                      padding: "6px 14px",
+                      fontSize: 12,
+                    }}
+                  >
+                    Load more ({corpusTotal - corpusRows.length} left)
+                  </button>
+                )}
+              </div>
+            )}
+          </section>
+
+          {/* Corrections — the old Inbox, folded in */}
+          <section>
+            <button
+              onClick={() => setShowCorrections((v) => !v)}
+              style={{
+                background: "transparent",
+                border: "none",
+                padding: 0,
+                cursor: "pointer",
+                fontSize: 15,
+                fontWeight: 700,
+                color: "var(--text-primary)",
+                marginBottom: 12,
+              }}
+            >
+              Corrections{" "}
+              {corrections.length > 0 && <span style={{ color: "var(--text-muted)", fontWeight: 400 }}>({corrections.length})</span>}{" "}
+              <span style={{ color: "var(--text-muted)", fontWeight: 400 }}>{showCorrections ? "▾" : "▸"}</span>
+            </button>
+            {showCorrections &&
+              (corrections.length === 0 ? (
+                <div style={{ fontSize: 13, color: "var(--text-muted)" }}>
+                  No correction flags yet. Agents file these when graph content contradicts the code.
+                </div>
+              ) : (
+                <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                  {corrections.map((c) => {
+                    let targets: string[] = [];
+                    try {
+                      targets = JSON.parse(c.target_ids) as string[];
+                    } catch {
+                      /* leave empty */
+                    }
+                    return (
+                      <div
+                        key={c.id}
+                        style={{ background: "var(--surface)", border: "1px solid var(--border)", borderRadius: 8, padding: "12px 16px" }}
+                      >
+                        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12, marginBottom: 6 }}>
+                          <div style={{ fontFamily: "monospace", fontSize: 11, color: "var(--text-secondary)", overflow: "hidden", textOverflow: "ellipsis" }}>
+                            {targets.join(", ")}
+                          </div>
+                          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                            <span style={{ fontSize: 11, color: "var(--text-muted)" }}>{timeAgo(c.created_at)}</span>
+                            <Chip color={CORRECTION_COLORS[c.status]}>{c.status}</Chip>
+                          </div>
+                        </div>
+                        <div style={{ fontSize: 13, color: "var(--text-primary)" }}>{c.reason}</div>
+                        {c.evidence && (
+                          <div style={{ fontFamily: "monospace", fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}>{c.evidence}</div>
+                        )}
+                        {c.resolution && (
+                          <div style={{ fontSize: 12, color: "var(--text-secondary)", marginTop: 6, borderTop: "1px solid var(--border)", paddingTop: 6 }}>
+                            {c.resolution}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              ))}
+          </section>
+        </>
+      )}
+    </Shell>
+  );
+}

--- a/dashboard/src/components/Nav.tsx
+++ b/dashboard/src/components/Nav.tsx
@@ -10,7 +10,7 @@ const PRIMARY_ITEMS = [
   { href: "/", label: "Dashboard (Home)" },
   { href: "/agents", label: "Agents / Sessions" },
   { href: "/connections", label: "Connections" },
-  { href: "/inbox", label: "Inbox" },
+  { href: "/knowledge", label: "Knowledge Base" },
   { href: "/settings", label: "Settings" },
 ];
 

--- a/orchestrator/src/memory/knowledge.ts
+++ b/orchestrator/src/memory/knowledge.ts
@@ -1,0 +1,288 @@
+// knowledge.ts — the Knowledge Base surface (dashboard). Reads the whole
+// memory store with human attribution (who said it, where it came from) and
+// deletes — the one curation act. Deletion is a hard cascade: a memory takes
+// its attached observations and anchors with it (the FTS mirror follows via
+// the observations_ad trigger), so the claim stops surfacing everywhere at
+// once — search_knowledge, find_entity hits, headlines and orient docs alike.
+
+import db from "../db.js";
+import { strengthTier } from "./strength.js";
+import {
+  evidenceCount,
+  getMemory,
+  invalidateVectorCache,
+  recomputePeopleCount,
+  updateMemory,
+  type MemoryRow,
+} from "./store.js";
+import { invalidateHeadlineCache } from "./headline.js";
+import { rebuildOrientDocsFor } from "./orient-doc.js";
+import { sweepMemories } from "./maintenance.js";
+
+// The dashboard loads memories in one shot (a few hundred rows) and pages the
+// corpus (slack/linear/meeting observations can run to thousands).
+const MEMORY_CAP = 500;
+const CORPUS_PAGE_MAX = 200;
+const EVIDENCE_PER_MEMORY = 20;
+
+interface JoinedObsRow {
+  id: string;
+  source: string;
+  repo: string | null;
+  branch: string | null;
+  session_id: string | null;
+  source_url: string | null;
+  claim: string;
+  kind: string;
+  source_weight: string;
+  memory_id: string | null;
+  created_at: number;
+  session_title: string | null;
+  session_backend: string | null;
+  slack_user: string | null;
+  slack_channel: string | null;
+  linear_identifier: string | null;
+  linear_assignee: string | null;
+  meeting_speaker: string | null;
+}
+
+// One join buys attribution for every source: sessions by session_id, corpus
+// rows by source_id (slack corpus ids ARE the observations' source_id — same
+// originating event id; linear/meeting likewise).
+const OBS_JOIN = `
+  SELECT o.id, o.source, o.repo, o.branch, o.session_id, o.source_url, o.claim,
+         o.kind, o.source_weight, o.memory_id, o.created_at,
+         s.title AS session_title, s.backend AS session_backend,
+         sm.user_id AS slack_user, sm.channel AS slack_channel,
+         lt.identifier AS linear_identifier, lt.assignee AS linear_assignee,
+         ms.speaker AS meeting_speaker
+  FROM observations o
+  LEFT JOIN agent_sessions s    ON o.source = 'session' AND s.id = o.session_id
+  LEFT JOIN slack_messages sm   ON o.source = 'slack'   AND sm.id = o.source_id
+  LEFT JOIN linear_tickets lt   ON o.source = 'linear'  AND lt.id = o.source_id
+  LEFT JOIN meeting_segments ms ON o.source = 'meeting' AND ms.id = o.source_id
+`;
+
+// Human attribution line for one observation — who, where. Session capture
+// carries no user identity yet (it's per-machine), so the engine + session
+// title stand in for the person; Slack/Linear/meetings carry real identities.
+function attribution(o: JoinedObsRow): string | null {
+  switch (o.source) {
+    case "session": {
+      const engine = (o.session_backend ?? "").replace(/^ext:/, "");
+      const title = (o.session_title ?? "").trim();
+      if (engine && title) return `${engine} session — ${title}`;
+      if (engine) return `${engine} session`;
+      return o.session_id ? `session ${o.session_id.slice(0, 12)}` : null;
+    }
+    case "slack": {
+      const user = o.slack_user ? `@${o.slack_user}` : "Slack";
+      return o.slack_channel ? `${user} in #${o.slack_channel}` : user;
+    }
+    case "linear": {
+      if (!o.linear_identifier) return "Linear";
+      return o.linear_assignee ? `${o.linear_identifier} — ${o.linear_assignee}` : o.linear_identifier;
+    }
+    case "meeting":
+      return o.meeting_speaker ? `${o.meeting_speaker} (meeting)` : "meeting";
+    default:
+      return null;
+  }
+}
+
+export interface KnowledgeEvidence {
+  id: string;
+  source: string;
+  claim: string;
+  source_url: string | null;
+  source_weight: string;
+  created_at: number;
+  by: string | null;
+}
+
+export interface KnowledgeMemory {
+  id: string;
+  claim: string;
+  kind: string;
+  repo: string | null;
+  strength: number;
+  tier: string;
+  evidence_count: number;
+  people_count: number;
+  contradiction_count: number;
+  max_source_weight: string;
+  created_at: number;
+  updated_at: number;
+  contributors: string[];
+  sources: Record<string, number>;
+  evidence: KnowledgeEvidence[];
+}
+
+export interface KnowledgeCorpusRow {
+  id: string;
+  source: string;
+  claim: string;
+  source_url: string | null;
+  repo: string | null;
+  created_at: number;
+  by: string | null;
+}
+
+export interface KnowledgeList {
+  memories: KnowledgeMemory[];
+  memory_cap: number;
+  corpus: { rows: KnowledgeCorpusRow[]; total: number; limit: number; offset: number };
+}
+
+export function listKnowledge(opts: {
+  q?: string | null;
+  source?: string | null;
+  limit?: number;
+  offset?: number;
+} = {}): KnowledgeList {
+  const memories = db
+    .prepare(`SELECT * FROM memories WHERE status = 'active' ORDER BY updated_at DESC LIMIT ?`)
+    .all(MEMORY_CAP) as MemoryRow[];
+
+  const attached = db
+    .prepare(`${OBS_JOIN} WHERE o.memory_id IS NOT NULL ORDER BY o.created_at DESC`)
+    .all() as JoinedObsRow[];
+  const byMemory = new Map<string, JoinedObsRow[]>();
+  for (const o of attached) {
+    const list = byMemory.get(o.memory_id!) ?? [];
+    list.push(o);
+    byMemory.set(o.memory_id!, list);
+  }
+
+  const memoryItems: KnowledgeMemory[] = memories.map((m) => {
+    const obs = byMemory.get(m.id) ?? [];
+    const contributors = [...new Set(obs.map(attribution).filter((s): s is string => !!s))];
+    const sources: Record<string, number> = {};
+    for (const o of obs) sources[o.source] = (sources[o.source] ?? 0) + 1;
+    return {
+      id: m.id,
+      claim: m.claim,
+      kind: m.kind,
+      repo: m.repo,
+      strength: Math.round(m.strength * 1000) / 1000,
+      tier: strengthTier(m.strength),
+      evidence_count: m.evidence_count,
+      people_count: m.people_count,
+      contradiction_count: m.contradiction_count,
+      max_source_weight: m.max_source_weight,
+      created_at: m.created_at,
+      updated_at: m.updated_at,
+      contributors: contributors.slice(0, 6),
+      sources,
+      evidence: obs.slice(0, EVIDENCE_PER_MEMORY).map((o) => ({
+        id: o.id,
+        source: o.source,
+        claim: o.claim,
+        source_url: o.source_url,
+        source_weight: o.source_weight,
+        created_at: o.created_at,
+        by: attribution(o),
+      })),
+    };
+  });
+
+  // Corpus = observations never consolidated into a memory (slack/linear/
+  // meeting enrichment rows). Paged, filterable by source and substring.
+  const where: string[] = ["o.memory_id IS NULL"];
+  const params: unknown[] = [];
+  if (opts.source) {
+    where.push("o.source = ?");
+    params.push(opts.source);
+  }
+  if (opts.q && opts.q.trim()) {
+    where.push("o.claim LIKE ?");
+    params.push(`%${opts.q.trim()}%`);
+  }
+  const whereSql = where.join(" AND ");
+  const total = (
+    db.prepare(`SELECT COUNT(*) AS n FROM observations o WHERE ${whereSql}`).get(...params) as { n: number }
+  ).n;
+  const limit = Math.min(Math.max(1, opts.limit ?? 50), CORPUS_PAGE_MAX);
+  const offset = Math.max(0, opts.offset ?? 0);
+  const rows = db
+    .prepare(`${OBS_JOIN} WHERE ${whereSql} ORDER BY o.created_at DESC LIMIT ? OFFSET ?`)
+    .all(...params, limit, offset) as JoinedObsRow[];
+
+  return {
+    memories: memoryItems,
+    memory_cap: MEMORY_CAP,
+    corpus: {
+      rows: rows.map((o) => ({
+        id: o.id,
+        source: o.source,
+        claim: o.claim,
+        source_url: o.source_url,
+        repo: o.repo,
+        created_at: o.created_at,
+        by: attribution(o),
+      })),
+      total,
+      limit,
+      offset,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Deletion — the one human curation act. Hard delete, full cascade.
+
+const deleteAnchorsStmt = () => db.prepare(`DELETE FROM anchors WHERE item_type = ? AND item_id = ?`);
+
+export function deleteMemory(id: string): { observations: number } | null {
+  const mem = getMemory(id);
+  if (!mem) return null;
+  const obs = db.prepare(`SELECT id FROM observations WHERE memory_id = ?`).all(id) as Array<{ id: string }>;
+  const tx = db.transaction(() => {
+    deleteAnchorsStmt().run("memory", id);
+    for (const o of obs) deleteAnchorsStmt().run("observation", o.id);
+    db.prepare(`DELETE FROM observations WHERE memory_id = ?`).run(id);
+    db.prepare(`DELETE FROM memories WHERE id = ?`).run(id);
+  });
+  tx();
+  invalidateVectorCache();
+  invalidateHeadlineCache();
+  rebuildOrientDocsFor(mem.repo);
+  return { observations: obs.length };
+}
+
+// Deleting a lone corpus observation just removes it. Deleting a memory's
+// evidence recomputes the parent's counts and strength; a memory whose last
+// evidence is gone is deleted outright (a claim with zero provenance is not
+// knowledge).
+export function deleteObservation(id: string): { memory_deleted: boolean } | null {
+  const row = db.prepare(`SELECT id, repo, memory_id FROM observations WHERE id = ?`).get(id) as
+    | { id: string; repo: string | null; memory_id: string | null }
+    | undefined;
+  if (!row) return null;
+
+  const tx = db.transaction(() => {
+    deleteAnchorsStmt().run("observation", id);
+    db.prepare(`DELETE FROM observations WHERE id = ?`).run(id);
+  });
+  tx();
+
+  let memoryDeleted = false;
+  if (row.memory_id) {
+    const remaining = evidenceCount(row.memory_id);
+    if (remaining === 0) {
+      deleteAnchorsStmt().run("memory", row.memory_id);
+      db.prepare(`DELETE FROM memories WHERE id = ?`).run(row.memory_id);
+      memoryDeleted = true;
+    } else {
+      updateMemory(row.memory_id, {
+        evidence_count: remaining,
+        people_count: recomputePeopleCount(row.memory_id),
+      });
+      sweepMemories();
+    }
+  }
+  invalidateVectorCache();
+  invalidateHeadlineCache();
+  rebuildOrientDocsFor(row.repo);
+  return { memory_deleted: memoryDeleted };
+}

--- a/orchestrator/src/memory/routes.ts
+++ b/orchestrator/src/memory/routes.ts
@@ -16,6 +16,13 @@
 //   GET  /v1/memory/orient-doc?repo=<name>           → {global, repo} rendered
 //                                                     ambient-tier docs (null
 //                                                     when a scope has none).
+//   GET  /v1/memory/list?q=&source=&limit=&offset=   → Knowledge Base: all
+//                                                     memories with attribution
+//                                                     + paged corpus rows.
+//   DELETE /v1/memory/:id                            → cascade-delete a memory
+//                                                     (observations + anchors).
+//   DELETE /v1/memory/observation/:id                → delete one observation
+//                                                     (parent counts recomputed).
 
 import type { FastifyInstance } from "fastify";
 import db from "../db.js";
@@ -31,6 +38,7 @@ import { getCard } from "./cards.js";
 import { memoryHitsForQueries, MEMORY_HIT_QUOTA } from "./find-hits.js";
 import { rememberText } from "./distiller.js";
 import { getOrientDocs } from "./orient-doc.js";
+import { listKnowledge, deleteMemory, deleteObservation } from "./knowledge.js";
 
 export interface MemoryStats {
   memories: number;
@@ -163,5 +171,40 @@ export function registerMemoryRoutes(app: FastifyInstance): void {
   // gateway's orient(). A scope with no members returns null, never "".
   app.get<{ Querystring: { repo?: string } }>("/v1/memory/orient-doc", async (req) => {
     return getOrientDocs(req.query.repo?.trim() || null);
+  });
+
+  // Knowledge Base (dashboard) — every memory with human attribution, plus
+  // the paged corpus of never-consolidated slack/linear/meeting observations.
+  app.get<{ Querystring: { q?: string; source?: string; limit?: string; offset?: string } }>(
+    "/v1/memory/list",
+    async (req) => {
+      const q = req.query;
+      return {
+        stats: memoryStats(),
+        ...listKnowledge({
+          q: q.q ?? null,
+          source: q.source?.trim() || null,
+          limit: q.limit ? Number(q.limit) || undefined : undefined,
+          offset: q.offset ? Number(q.offset) || 0 : 0,
+        }),
+      };
+    },
+  );
+
+  // Deletion — the one human curation act, from the Knowledge Base page.
+  // The observation route registers alongside the param route; Fastify prefers
+  // the static segment, so /observation/:id never collides with /:id.
+  app.delete<{ Params: { id: string } }>("/v1/memory/observation/:id", async (req, reply) => {
+    const out = deleteObservation(decodeURIComponent(req.params.id));
+    if (!out) return reply.code(404).send({ error: "observation not found" });
+    console.log(`[memory] observation ${req.params.id} deleted (memory_deleted=${out.memory_deleted})`);
+    return { ok: true, ...out };
+  });
+
+  app.delete<{ Params: { id: string } }>("/v1/memory/:id", async (req, reply) => {
+    const out = deleteMemory(decodeURIComponent(req.params.id));
+    if (!out) return reply.code(404).send({ error: "memory not found" });
+    console.log(`[memory] memory ${req.params.id} deleted (${out.observations} observation(s) cascaded)`);
+    return { ok: true, ...out };
   });
 }

--- a/orchestrator/test/memory.test.ts
+++ b/orchestrator/test/memory.test.ts
@@ -32,6 +32,7 @@ let headline: typeof import("../src/memory/headline.js");
 let cards: typeof import("../src/memory/cards.js");
 let findHits: typeof import("../src/memory/find-hits.js");
 let corpusObserve: typeof import("../src/memory/corpus-observe.js");
+let knowledge: typeof import("../src/memory/knowledge.js");
 let cosine: (a: Float32Array, b: Float32Array) => number;
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
@@ -81,6 +82,7 @@ before(async () => {
   cards = await import("../src/memory/cards.js");
   findHits = await import("../src/memory/find-hits.js");
   corpusObserve = await import("../src/memory/corpus-observe.js");
+  knowledge = await import("../src/memory/knowledge.js");
   cosine = (await import("../src/embed.js")).cosine;
   store.setEmbedder(stubEmbedder);
 });
@@ -1264,5 +1266,85 @@ describe("find_entity memory hits + quota (Section D)", () => {
     } finally {
       store.setEmbedder(stubEmbedder);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Knowledge Base (dashboard): listKnowledge attribution + the delete cascade.
+describe("knowledge base (list + delete)", () => {
+  before(() => store.setEmbedder(stubEmbedder));
+
+  test("listKnowledge: memories carry attribution; unconsolidated corpus rows page separately", async () => {
+    clearMemory();
+    db.prepare("INSERT OR REPLACE INTO agent_sessions (id, backend, repo, cwd, title, status, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?)")
+      .run("kb-s1", "ext:claude", "acme", "/w", "Fix the webhook retry", "closed", 1, 1);
+    db.prepare("INSERT INTO slack_messages (id, channel, user_id, text, ts, thread_ts, permalink) VALUES (?,?,?,?,?,?,?)")
+      .run("kb-m1", "C-eng", "U-sam", "retries must be idempotent", "1700000000.100", null, "https://slack/kb1");
+
+    // A distilled session observation → memory (attribution via agent_sessions).
+    const o = await store.insertObservation({ source: "session", repo: "acme", claim: "webhook retries must be idempotent", kind: "constraint", source_weight: "user_stated", session_id: "kb-s1" });
+    await consolidate.consolidateObservation(o, async () => ({ verdict: "new" as const }));
+    // A corpus observation that never consolidates (memory_id NULL).
+    await store.insertObservation({ source: "slack", claim: "retries must be idempotent", kind: "gotcha", source_weight: "user_stated", source_id: "kb-m1", source_url: "https://slack/kb1" });
+
+    const out = knowledge.listKnowledge({});
+    assert.equal(out.memories.length, 1);
+    const m = out.memories[0];
+    assert.match(m.claim, /idempotent/);
+    assert.equal(m.tier, strength.strengthTier(m.strength));
+    assert.deepEqual(m.sources, { session: 1 });
+    assert.ok(m.contributors[0].includes("claude session"), `session attribution names the engine: ${m.contributors[0]}`);
+    assert.ok(m.contributors[0].includes("Fix the webhook retry"), "session attribution carries the title");
+    assert.equal(m.evidence.length, 1);
+
+    assert.equal(out.corpus.total, 1);
+    const c = out.corpus.rows[0];
+    assert.equal(c.source, "slack");
+    assert.equal(c.by, "@U-sam in #C-eng", "slack attribution joins user + channel via source_id");
+    assert.equal(c.source_url, "https://slack/kb1");
+
+    // Source + substring filters hit the corpus SQL path.
+    assert.equal(knowledge.listKnowledge({ source: "linear" }).corpus.total, 0);
+    assert.equal(knowledge.listKnowledge({ q: "idempotent" }).corpus.total, 1);
+    assert.equal(knowledge.listKnowledge({ q: "no-such-token" }).corpus.total, 0);
+  });
+
+  test("deleteMemory: hard cascade — observations, anchors and FTS rows all go", async () => {
+    clearMemory();
+    const o = await store.insertObservation({ source: "session", repo: "acme", claim: "zebraflux cache is write-through", kind: "decision", source_weight: "agent_inferred", session_id: "kb-s2" });
+    const res = await consolidate.consolidateObservation(o, async () => ({ verdict: "new" as const }));
+    anchors.setAnchors("memory", res.memoryId, ["svc:cache"], "files");
+    anchors.setAnchors("observation", o.id, ["svc:cache"], "files");
+
+    const out = knowledge.deleteMemory(res.memoryId);
+    assert.deepEqual(out, { observations: 1 });
+    assert.equal(store.getMemory(res.memoryId), undefined);
+    assert.equal(db.prepare("SELECT COUNT(*) AS n FROM observations WHERE memory_id = ?").get(res.memoryId).n, 0);
+    assert.equal(db.prepare("SELECT COUNT(*) AS n FROM anchors").get().n, 0);
+    assert.equal(
+      db.prepare("SELECT COUNT(*) AS n FROM observations_fts WHERE observations_fts MATCH 'zebraflux'").get().n,
+      0,
+      "FTS mirror follows the delete via trigger",
+    );
+    assert.equal(knowledge.deleteMemory("nope"), null);
+  });
+
+  test("deleteObservation: recomputes parent counts; deleting the last evidence deletes the memory", async () => {
+    clearMemory();
+    const o1 = await store.insertObservation({ source: "session", repo: "acme", claim: "gadgetron uses blue-green deploys", kind: "decision", source_weight: "user_stated", session_id: "kb-s3" });
+    const res = await consolidate.consolidateObservation(o1, async () => ({ verdict: "new" as const }));
+    const o2 = await store.insertObservation({ source: "session", repo: "acme", claim: "gadgetron uses blue-green deploys", kind: "decision", source_weight: "user_stated", session_id: "kb-s4", memory_id: res.memoryId });
+    store.updateMemory(res.memoryId, { evidence_count: 2, people_count: 2 });
+
+    const first = knowledge.deleteObservation(o2.id);
+    assert.deepEqual(first, { memory_deleted: false });
+    const m = store.getMemory(res.memoryId)!;
+    assert.equal(m.evidence_count, 1);
+    assert.equal(m.people_count, 1);
+
+    const second = knowledge.deleteObservation(o1.id);
+    assert.deepEqual(second, { memory_deleted: true });
+    assert.equal(store.getMemory(res.memoryId), undefined, "a claim with zero provenance is deleted outright");
+    assert.equal(knowledge.deleteObservation("nope"), null);
   });
 });


### PR DESCRIPTION
## What

Replaces the Inbox tab with a **Knowledge Base** page (`/knowledge`) — one merged view of everything Flow has learned, with attribution for where each item came from and who contributed it, plus delete as the one human curation act.

### Page sections
- **Memories** — all active distilled memories: kind, strength tier, repo, contributor line derived from evidence (session engine + title / `@user in #channel` for Slack / ticket + assignee for Linear / speaker for meetings), expandable evidence with permalinks back to the original artifacts.
- **From Slack, Linear & meetings** — the never-consolidated corpus observations (`memory_id IS NULL`), paged server-side with Load more.
- **Corrections** — the old Inbox content, folded in as a collapsed section (unchanged behavior).
- Search + source filter chips (All / Sessions / Slack / Linear / Meetings) and a stats strip.

### Orchestrator
- New `src/memory/knowledge.ts`:
  - `listKnowledge()` — memories with attribution (single join buys sessions/slack/linear/meeting identity via `session_id` / `source_id`), paged corpus with `q`/`source` filters.
  - `deleteMemory()` — hard cascade: memory + attached observations + anchors; FTS mirror follows via trigger; invalidates vector + headline caches and rebuilds orient docs, so agents stop recalling it everywhere at once.
  - `deleteObservation()` — recomputes the parent memory's evidence/people counts and strength; deleting the last evidence deletes the memory outright (a claim with zero provenance is not knowledge).
- Routes: `GET /v1/memory/list`, `DELETE /v1/memory/:id`, `DELETE /v1/memory/observation/:id`.

### Dashboard
- New `/knowledge` page; Nav item **Inbox → Knowledge Base**; `/inbox` client-redirects to `/knowledge`.
- Proxy routes: `GET /api/memory/list`, `DELETE /api/memory?id=&type=memory|observation`.

## Known limitation
Session capture carries no user identity today (per-machine), so session-sourced memories are attributed to the session (engine + title), not a named teammate. Slack/Linear items show real people. Per-teammate session attribution needs the capture-upload auth identity plumbed into `agent_sessions` — follow-up.

## Testing
- New `knowledge base (list + delete)` suite in `orchestrator/test/memory.test.ts`: attribution joins, corpus filters, delete cascades (anchors + FTS), count recompute, last-evidence memory deletion. Full memory suite: **84/84 pass**.
- Dashboard `tsc --noEmit`, eslint, and `next build` all clean (`/knowledge` + `/api/memory/*` registered).