### PR TITLE
knowledge: honest memory timestamps + trash-icon delete

### DIFF
--- a/dashboard/src/app/knowledge/page.tsx
+++ b/dashboard/src/app/knowledge/page.tsx
@@ -34,6 +34,7 @@ interface MemoryItem {
   max_source_weight: string;
   created_at: number;
   updated_at: number;
+  last_reinforced_at: number | null;
   contributors: string[];
   sources: Record<string, number>;
   evidence: EvidenceRow[];
@@ -114,19 +115,26 @@ function DeleteButton({ onClick, title }: { onClick: () => void; title: string }
     <button
       onClick={onClick}
       title={title}
+      aria-label={title}
       style={{
         background: "transparent",
-        border: "1px solid var(--border)",
+        border: "none",
         borderRadius: 6,
         color: "var(--text-muted)",
         cursor: "pointer",
-        padding: "3px 8px",
-        fontSize: 11,
-        lineHeight: 1,
+        padding: 4,
+        lineHeight: 0,
         flexShrink: 0,
       }}
+      onMouseEnter={(e) => (e.currentTarget.style.color = "var(--danger, #b91c1c)")}
+      onMouseLeave={(e) => (e.currentTarget.style.color = "var(--text-muted)")}
     >
-      Delete
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+        <path d="M3 6h18" />
+        <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2" />
+        <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+        <path d="M10 11v6M14 11v6" />
+      </svg>
     </button>
   );
 }
@@ -314,7 +322,7 @@ export default function KnowledgePage() {
                         <Chip color={TIER_COLORS[m.tier]}>{m.tier}</Chip>
                         {m.repo && <Chip>{m.repo}</Chip>}
                         <span style={{ flex: 1 }} />
-                        <span style={{ fontSize: 11, color: "var(--text-muted)" }}>{timeAgo(m.updated_at * 1000)}</span>
+                        <span style={{ fontSize: 11, color: "var(--text-muted)" }}>{timeAgo((m.last_reinforced_at ?? m.created_at) * 1000)}</span>
                         <DeleteButton onClick={() => deleteItem(m.id, "memory")} title="Delete this memory and its evidence" />
                       </div>
                       <div style={{ fontSize: 13, color: "var(--text-primary)", lineHeight: 1.5 }}>{m.claim}</div>

--- a/orchestrator/src/memory/knowledge.ts
+++ b/orchestrator/src/memory/knowledge.ts
@@ -113,6 +113,7 @@ export interface KnowledgeMemory {
   max_source_weight: string;
   created_at: number;
   updated_at: number;
+  last_reinforced_at: number | null;
   contributors: string[];
   sources: Record<string, number>;
   evidence: KnowledgeEvidence[];
@@ -140,8 +141,11 @@ export function listKnowledge(opts: {
   limit?: number;
   offset?: number;
 } = {}): KnowledgeList {
+  // NOT updated_at: the decay sweep rewrites updated_at on every active row
+  // (sweepMemories runs after each distill), so it always reads "minutes ago".
+  // Reinforcement time is the honest freshness signal.
   const memories = db
-    .prepare(`SELECT * FROM memories WHERE status = 'active' ORDER BY updated_at DESC LIMIT ?`)
+    .prepare(`SELECT * FROM memories WHERE status = 'active' ORDER BY COALESCE(last_reinforced_at, created_at) DESC LIMIT ?`)
     .all(MEMORY_CAP) as MemoryRow[];
 
   const attached = db
@@ -172,6 +176,7 @@ export function listKnowledge(opts: {
       max_source_weight: m.max_source_weight,
       created_at: m.created_at,
       updated_at: m.updated_at,
+      last_reinforced_at: m.last_reinforced_at,
       contributors: contributors.slice(0, 6),
       sources,
       evidence: obs.slice(0, EVIDENCE_PER_MEMORY).map((o) => ({


### PR DESCRIPTION
Follow-up to #63, which was merged before this fix was pushed.

- Memories were all showing "10m ago": the decay sweep rewrites `updated_at` on every active row after each distill, so it always read as minutes ago. Sort + display now use `last_reinforced_at` (fallback `created_at`).
- Delete is now a trash-icon button (hover-red, tooltip, aria-label) instead of a text button.