### PR TITLE
Anonymous usage telemetry via PostHog (on by default, numbers-only, auditable)

### DIFF
--- a/bin/flow.mjs
+++ b/bin/flow.mjs
@@ -110,6 +110,9 @@ ${c.bold("Usage")}
 
 ${c.bold("Options")}
   --mode local|prod     For a new project (default: local). Local needs no login.
+  --no-telemetry        Turn off Flow's anonymous usage stats (counts only, never
+                        code or names — audit at GET /v1/telemetry). Saved to the
+                        project .env; --telemetry turns it back on.
 
 ${c.bold("Examples")}
   flow up acme          ${c.dim("# start acme — offers to create it if it doesn't exist")}
@@ -139,6 +142,18 @@ function parseEnvFile(filePath) {
     env[key] = val;
   }
   return env;
+}
+
+// Upsert (value string) or remove (value null) a KEY=VALUE line in an env
+// file, leaving comments and other keys untouched. Creates the file on first
+// write.
+function setEnvKey(filePath, key, value) {
+  const lines = existsSync(filePath) ? readFileSync(filePath, "utf-8").split("\n") : [];
+  const re = new RegExp(`^\\s*${key}\\s*=`);
+  const kept = lines.filter((line) => !re.test(line));
+  while (kept.length > 0 && kept[kept.length - 1].trim() === "") kept.pop();
+  if (value !== null) kept.push(`${key}=${value}`);
+  writeFileSync(filePath, kept.length ? kept.join("\n") + "\n" : "", "utf-8");
 }
 
 // The OpenRouter key powers the gateway's semantic find_entity + embed-on-write.
@@ -579,8 +594,15 @@ async function cmdUp(args) {
     options: {
       mode: { type: "string", default: "local" },
       "no-update": { type: "boolean", default: false },
+      // Anonymous usage telemetry (see orchestrator GET /v1/telemetry for the
+      // exact payload). The choice is SAVED to the project .env so it sticks
+      // across restarts — a one-shot flag would silently re-enable later.
+      "no-telemetry": { type: "boolean", default: false },
+      telemetry: { type: "boolean", default: false },
     },
   });
+  if (values["no-telemetry"] && values.telemetry) die("Pick one: --telemetry or --no-telemetry");
+  const telemetryChoice = values["no-telemetry"] ? "off" : values.telemetry ? "on" : null;
   if (!values["no-update"]) maybeSelfUpdate(); // may re-exec and not return
   const targetName = positionals[0] ?? null;
 
@@ -622,9 +644,29 @@ async function cmdUp(args) {
   const rebuilt = ensureDashboardBuild(); // shared .next; only prints if it rebuilds
   console.log("");
 
+  // Persist the telemetry choice BEFORE the spawn so the orchestrator env
+  // picks it up. Written per project: .env is the project-scoped config that
+  // upProject already feeds into every service.
+  if (telemetryChoice) {
+    for (const name of names) {
+      setEnvKey(join(projectDir(name), ".env"), "FLOW_TELEMETRY_DISABLE", telemetryChoice === "off" ? "1" : null);
+    }
+    console.log(c.dim(`  telemetry ${telemetryChoice} — saved to ${names.length > 1 ? "each project's" : "the project"} .env\n`));
+  }
+
   const results = [];
   for (const name of names) {
     results.push(await upProject(name, { rebuilt }));
+  }
+
+  // An already-running project kept its old process (and old env) — the saved
+  // choice only lands on the next restart, and we never bounce services
+  // ourselves.
+  if (telemetryChoice) {
+    const kept = results.filter((r) => r.ok && r.alreadyRunning);
+    for (const r of kept) {
+      console.log(`  ${c.dim(`${r.name}: telemetry ${telemetryChoice} takes effect on restart —`)} flow down ${r.name} && flow up ${r.name}`);
+    }
   }
 
   // Legacy per-project dashboards (pre-single-dashboard installs) die here;

--- a/bin/flow.mjs
+++ b/bin/flow.mjs
@@ -1339,6 +1339,22 @@ async function cmdSetup(rest) {
     /* orchestrator not running — fine */
   }
 
+  // Usage ping via the orchestrator's telemetry pipeline (the CLI holds no
+  // PostHog key). Booleans only — which tools got wired, nothing about the
+  // repo. Best-effort; orchestrator not running = no event.
+  try {
+    const props = { shared: values.share === true, detected_count: detected.length };
+    for (const h of ALL_HARNESSES) props[`harness_${h}`] = harnesses.includes(h);
+    await fetch(`http://localhost:${ports.orchestrator}/v1/telemetry/track`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+      body: JSON.stringify({ event: "flow_setup_run", properties: props }),
+      signal: AbortSignal.timeout(1500),
+    });
+  } catch {
+    /* telemetry is never load-bearing */
+  }
+
   console.log(`
   ${OK} ${c.bold(repoDir)}
     → project ${c.bold(name)} (local), repo ${c.bold(repoName)}${registered ? "" : c.yellow(" (not a registered source — capture works; graph context limited)")}

--- a/orchestrator/package.json
+++ b/orchestrator/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts",
-    "test": "node --import tsx/esm --test test/fake-opencode.ts test/orchestrator.test.ts test/adapters.test.ts test/outbox-approve.test.ts test/llmlog.test.ts test/smoke.ts test/notify.test.ts test/pollers.test.ts test/poller.test.ts test/settings.test.ts test/sources.test.ts test/agent-diff.test.ts test/worktrees.test.ts test/memory.test.ts test/llm.test.ts test/indexer-runtime.test.ts test/index-queue.test.ts test/change-branch.test.ts test/repo-removed.test.ts test/index-incremental.test.ts test/work-folders.test.ts test/ingest.test.ts test/flow-hook.test.ts",
+    "test": "node --import tsx/esm --test test/fake-opencode.ts test/orchestrator.test.ts test/adapters.test.ts test/outbox-approve.test.ts test/llmlog.test.ts test/smoke.ts test/notify.test.ts test/pollers.test.ts test/poller.test.ts test/settings.test.ts test/sources.test.ts test/agent-diff.test.ts test/worktrees.test.ts test/memory.test.ts test/llm.test.ts test/indexer-runtime.test.ts test/index-queue.test.ts test/change-branch.test.ts test/repo-removed.test.ts test/index-incremental.test.ts test/work-folders.test.ts test/ingest.test.ts test/flow-hook.test.ts test/telemetry.test.ts",
     "verify": "npm test",
     "verify:real": "tsx test/real-integrations.ts",
     "verify:session": "tsx test/real-session.ts"

--- a/orchestrator/src/agents/runtime.ts
+++ b/orchestrator/src/agents/runtime.ts
@@ -18,6 +18,7 @@ import { Readable, Writable } from "node:stream";
 import { fileURLToPath } from "node:url";
 import * as acp from "@agentclientprotocol/sdk";
 import db from "../db.js";
+import { track } from "../telemetry.js";
 import { onSessionClosed, setTranscriptReader, startIdleSweep } from "../memory/trigger.js";
 import {
   createSessionWorktree,
@@ -1157,7 +1158,14 @@ export async function createSession(opts: {
     if ("error" in wt) return { error: `Couldn't create a separate copy: ${wt.error}` };
     cwd = wt.path;
     worktreeId = wt.path; // the worktree path is the stable, derivable id
+    track("flow_worktree_created", {});
   }
+
+  track("flow_session_started", {
+    backend: opts.backend,
+    placement: opts.worktreePath ? "existing_worktree" : opts.placement === "separate_copy" ? "separate_copy" : "in_place",
+    native: true,
+  });
 
   const id = crypto.randomUUID();
   const now = Date.now();

--- a/orchestrator/src/index.ts
+++ b/orchestrator/src/index.ts
@@ -29,6 +29,7 @@ import { makeGatewayAnchorProvider } from "./memory/anchor-provider.js";
 import { registerSourceRoutes } from "./sources.js";
 import { startAllPollers, stopAllPollers, getAllPollStatus } from "./pollers/engine.js";
 import { registerSettingsRoutes } from "./settings.js";
+import { registerTelemetryRoutes, startTelemetryReporter, stopTelemetryReporter } from "./telemetry.js";
 
 const PORT = parseInt(process.env.ORCHESTRATOR_PORT ?? "7500", 10);
 
@@ -87,6 +88,7 @@ registerMemoryRoutes(app);
 // repo-level. flow.db is primary — this is a read-only projection lookup.
 setNodeAnchorProvider(makeGatewayAnchorProvider());
 registerSourceRoutes(app);
+registerTelemetryRoutes(app);
 
 // ------------------------------------------------------------------
 // Adapter webhook routes
@@ -240,6 +242,7 @@ app.get<{ Querystring: { status?: string } }>(
 app.addHook("onClose", async () => {
   stopDrainer();
   stopAllPollers();
+  stopTelemetryReporter();
   // Kill live indexer CLIs (and their process groups) — an orphaned indexer
   // surviving a restart would keep writing to the graph while boot recovery
   // re-queues a duplicate job for the same repo.
@@ -283,6 +286,9 @@ const start = async (): Promise<void> => {
 
     // Start all registered pollers (no-ops if FLOW_POLL_DISABLE=1)
     startAllPollers();
+
+    // Daily anonymous usage snapshot to PostHog (idle until the key is set)
+    startTelemetryReporter();
 
     // Boot Slack Socket Mode adapter (no-op if tokens absent)
     bootSlackAdapter().catch((err) =>

--- a/orchestrator/src/ingest/routes.ts
+++ b/orchestrator/src/ingest/routes.ts
@@ -13,6 +13,7 @@
 import type { FastifyInstance } from "fastify";
 import { createHash } from "node:crypto";
 import db from "../db.js";
+import { track } from "../telemetry.js";
 import { appendTranscriptEvents, readTranscript } from "../agents/runtime.js";
 import { onSessionClosed } from "../memory/trigger.js";
 import {
@@ -68,6 +69,7 @@ function upsertExternalSession(a: UpsertArgs): string {
   const row = rowStmt().get(id) as { id: string } | undefined;
   if (!row) {
     insertStmt().run(id, `ext:${a.harness}`, a.repo ?? "", a.cwd ?? "", a.title ?? "", "idle", now, now);
+    track("flow_session_started", { backend: `ext:${a.harness}`, placement: "external", native: false });
   } else {
     touchStmt().run(now, id);
     if (a.title) titleStmt().run(a.title, now, id);

--- a/orchestrator/src/memory/routes.ts
+++ b/orchestrator/src/memory/routes.ts
@@ -31,6 +31,7 @@ import { getCard } from "./cards.js";
 import { memoryHitsForQueries, MEMORY_HIT_QUOTA } from "./find-hits.js";
 import { rememberText } from "./distiller.js";
 import { getOrientDocs } from "./orient-doc.js";
+import { bumpCounter } from "../telemetry.js";
 
 export interface MemoryStats {
   memories: number;
@@ -65,6 +66,7 @@ export function registerMemoryRoutes(app: FastifyInstance): void {
         if (queries.length > SEARCH_MEMORY_MAX_BATCH) {
           return reply.code(400).send({ error: `too many queries (${queries.length}); max ${SEARCH_MEMORY_MAX_BATCH} per call` });
         }
+        bumpCounter("brain_search_total", queries.length);
         const res = await searchMemoryBatch({ queries, repo: b.repo ?? null, limit: b.limit });
         const total = res.groups.reduce((n, g) => n + g.result.memories.length + g.result.corpus.length, 0);
         console.log(`[memory] batch search ${queries.length}q → ${total} hits in ${res.durationMs}ms`);
@@ -78,6 +80,7 @@ export function registerMemoryRoutes(app: FastifyInstance): void {
       if (!b.query || !String(b.query).trim()) {
         return reply.code(400).send({ error: "query is required" });
       }
+      bumpCounter("brain_search_total");
       const res = await searchMemory({ query: String(b.query), repo: b.repo ?? null, limit: b.limit });
       // Log latency to the activity stream (stdout) — the retrieval budget is
       // <300ms; a slow call is a signal worth seeing.
@@ -124,10 +127,12 @@ export function registerMemoryRoutes(app: FastifyInstance): void {
         if (queries.length > SEARCH_MEMORY_MAX_BATCH) {
           return reply.code(400).send({ error: `too many queries (${queries.length}); max ${SEARCH_MEMORY_MAX_BATCH}` });
         }
+        bumpCounter("brain_hits_total", queries.length);
         const groups = await memoryHitsForQueries(queries, repo, { limit: b.limit });
         return reply.send({ quota: MEMORY_HIT_QUOTA, groups });
       }
       if (!b.query || !String(b.query).trim()) return reply.code(400).send({ error: "query is required" });
+      bumpCounter("brain_hits_total");
       const groups = await memoryHitsForQueries([String(b.query)], repo, { limit: b.limit });
       return reply.send({ quota: MEMORY_HIT_QUOTA, hits: groups[0].hits });
     },
@@ -144,6 +149,7 @@ export function registerMemoryRoutes(app: FastifyInstance): void {
       const text = String(b.text ?? "").trim();
       if (!text) return reply.code(400).send({ error: "text is required" });
       if (text.length > 20_000) return reply.code(400).send({ error: "text too long (20k max)" });
+      bumpCounter("memory_remember_total");
       const ctx = {
         text,
         repo: b.repo ? String(b.repo) : null,
@@ -162,6 +168,7 @@ export function registerMemoryRoutes(app: FastifyInstance): void {
   // The ambient tier — rendered orient docs, served verbatim into the
   // gateway's orient(). A scope with no members returns null, never "".
   app.get<{ Querystring: { repo?: string } }>("/v1/memory/orient-doc", async (req) => {
+    bumpCounter("brain_orient_total");
     return getOrientDocs(req.query.repo?.trim() || null);
   });
 }

--- a/orchestrator/src/memory/store.ts
+++ b/orchestrator/src/memory/store.ts
@@ -8,6 +8,7 @@ import db from "../db.js";
 import { blobToVec, vecToBlob, embedText as gatewayEmbed } from "../embed.js";
 import { repoFamily } from "./repo-family.js";
 import type { RawObservation } from "./parse.js";
+import { track, bumpCounter } from "../telemetry.js";
 
 // An embedder returns a 768-dim vector or null (model not ready). Injectable.
 export type Embedder = (text: string) => Promise<Float32Array | null>;
@@ -191,6 +192,10 @@ export function createMemory(o: ObservationRow): MemoryRow {
   });
   db.prepare(`UPDATE observations SET memory_id = ? WHERE id = ?`).run(id, o.id);
   invalidateVectorCache();
+  // Memory creation is rare enough for a discrete event; `source` is the
+  // fixed observation-source enum (session/slack/linear/meeting), never text.
+  bumpCounter("memories_created_total");
+  track("flow_memory_saved", { source: o.source, kind: o.kind });
   return getMemory(id)!;
 }
 

--- a/orchestrator/src/opencode.ts
+++ b/orchestrator/src/opencode.ts
@@ -30,6 +30,9 @@ import {
 } from "./indexer-runtime.js";
 import { finishActivity, recordActivityLine, startActivity } from "./job-activity.js";
 import { indexLog } from "./index-log.js";
+// Circular with telemetry.ts (it reads listWorkspaceRepos) — safe: both sides
+// only dereference inside function bodies, never at module init.
+import { track } from "./telemetry.js";
 import { resolveGithubDefaultBranch } from "./repo-branch.js";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
@@ -173,6 +176,7 @@ export function registerRepo(url: string, branch: string): RepoEntry {
   const entry: RepoEntry = { name, url, branch, lastIndexedCommit: null, addedAt: new Date().toISOString() };
   registry.repos.push(entry);
   writeFileSync(reposJsonPath(), JSON.stringify(registry, null, 2));
+  track("flow_source_added", { kind: "code" });
   return entry;
 }
 
@@ -206,6 +210,7 @@ export function registerSource(entry: SourceRegistration): RepoEntry {
   };
   registry.repos.push(created);
   writeFileSync(reposJsonPath(), JSON.stringify(registry, null, 2));
+  track("flow_source_added", { kind: entry.kind ?? "code" });
   return created;
 }
 
@@ -779,6 +784,11 @@ async function runJob(id: string, opts: JobInput): Promise<void> {
         mode: inc ? `incremental from ${inc.from.slice(0, 10)}` : "full",
         duration_ms: Date.now() - startedAt,
       });
+      track("flow_index_completed", {
+        ok: true,
+        incremental: Boolean(inc),
+        duration_s: Math.round((Date.now() - startedAt) / 1000),
+      });
       // Graph freshness props are code-maintained, not model-invented.
       const branch = (opts.input as { branch?: string }).branch;
       if (branch && !process.env.FLOW_FAKE_OPENCODE) void stampRepoNode(repo, branch, head);
@@ -826,6 +836,10 @@ async function runJob(id: string, opts: JobInput): Promise<void> {
     finishActivity(id, "failed");
     if (opts.type === "index_repo" && repo) {
       indexLog(repo, "failed", id, { error: String(err), duration_ms: Date.now() - startedAt });
+      track("flow_index_completed", {
+        ok: false,
+        duration_s: Math.round((Date.now() - startedAt) / 1000),
+      });
     }
     if (opts.type === "correct_graph") {
       const correctionId = (opts.input as { correction_id?: string }).correction_id;

--- a/orchestrator/src/settings.ts
+++ b/orchestrator/src/settings.ts
@@ -195,6 +195,20 @@ export const SETTINGS: SettingDef[] = [
     description: "Slack channel ID to DM for proposed actions",
     appliesTo: "slack",
   },
+  {
+    key: "FLOW_TELEMETRY_POSTHOG_KEY",
+    secret: false,
+    description:
+      "PostHog project API key (phc_…) for Flow's anonymous usage snapshot — counts and booleans only, audit the exact payload at GET /v1/telemetry. Unset = telemetry off. FLOW_TELEMETRY_DISABLE=1 force-disables.",
+    appliesTo: "pipeline",
+  },
+  {
+    key: "FLOW_TELEMETRY_POSTHOG_HOST",
+    secret: false,
+    description: "PostHog instance host for usage snapshots (EU cloud: https://eu.i.posthog.com)",
+    default: "https://us.i.posthog.com",
+    appliesTo: "pipeline",
+  },
 ];
 
 // Build a lookup map for O(1) access

--- a/orchestrator/src/settings.ts
+++ b/orchestrator/src/settings.ts
@@ -199,7 +199,8 @@ export const SETTINGS: SettingDef[] = [
     key: "FLOW_TELEMETRY_POSTHOG_KEY",
     secret: false,
     description:
-      "PostHog project API key (phc_…) for Flow's anonymous usage snapshot — counts and booleans only, audit the exact payload at GET /v1/telemetry. Unset = telemetry off. FLOW_TELEMETRY_DISABLE=1 force-disables.",
+      "PostHog project API key (phc_…) for Flow's anonymous usage snapshot — counts and booleans only, audit the exact payload at GET /v1/telemetry. The default is Flow's own project (a public write-only key). Set empty or FLOW_TELEMETRY_DISABLE=1 to opt out.",
+    default: "phc_A9NCvdsZWDbNgoDNeku45iBArjCjHFobPyBw2XqRgfB8",
     appliesTo: "pipeline",
   },
   {

--- a/orchestrator/src/telemetry.ts
+++ b/orchestrator/src/telemetry.ts
@@ -63,6 +63,10 @@ export interface TelemetrySnapshot {
   sessions_last_7d: number;
   sessions_last_30d: number;
   sessions_by_backend: Record<string, number>;
+  jobs_total: number;
+  jobs_done: number;
+  jobs_failed: number;
+  errors_since_boot: number;
   worktrees_created_total: number;
   worktrees_active: number;
   work_folders_total: number;
@@ -223,6 +227,10 @@ export async function telemetrySnapshot(): Promise<TelemetrySnapshot> {
       nowSec - 30 * day
     ),
     sessions_by_backend: sessionsByBackend(),
+    jobs_total: count("SELECT count(*) AS c FROM jobs"),
+    jobs_done: count("SELECT count(*) AS c FROM jobs WHERE status = 'done'"),
+    jobs_failed: count("SELECT count(*) AS c FROM jobs WHERE status = 'failed'"),
+    errors_since_boot: errorEventCount,
     worktrees_created_total: count(
       "SELECT count(DISTINCT worktree_id) AS c FROM agent_sessions WHERE worktree_id IS NOT NULL"
     ),
@@ -273,8 +281,68 @@ export async function sendTelemetry(): Promise<boolean> {
   }
 }
 
+// ------------------------------------------------------------------
+// Error reporting — same pipeline, same rules. An error event carries the
+// error CLASS and a Flow-source frame (basename:line of OUR open-source
+// files), never the message: messages routinely embed user paths, repo
+// names, and URLs. Capped per process so a crash loop can't burn the
+// PostHog quota.
+// ------------------------------------------------------------------
+
+const ERROR_EVENTS_MAX_PER_PROCESS = 50;
+let errorEventCount = 0;
+
+// First stack frame that points into Flow's own source, reduced to
+// basename:line ("runtime.ts:1151"). Frames outside our tree (user cwd,
+// node internals) are skipped — their paths are not ours to send.
+function flowFrame(stack: string | undefined): string | null {
+  if (!stack) return null;
+  for (const line of stack.split("\n")) {
+    const m = /\(?([^()\s]+\.(?:ts|mts|mjs|js)):(\d+):\d+\)?$/.exec(line.trim());
+    if (!m) continue;
+    const p = m[1];
+    if (!/\/(?:orchestrator|graph-gateway|dashboard|bin)\/[^ ]*$/.test(p)) continue;
+    return `${path.basename(p)}:${m[2]}`;
+  }
+  return null;
+}
+
+export async function reportError(scope: string, err: unknown): Promise<boolean> {
+  if (errorEventCount >= ERROR_EVENTS_MAX_PER_PROCESS) return false;
+  const target = posthogTarget();
+  if (!target) return false;
+  errorEventCount++;
+  const e = err instanceof Error ? err : new Error(String(err));
+  const code = (e as NodeJS.ErrnoException).code;
+  try {
+    const res = await fetch(target.url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        api_key: target.apiKey,
+        event: "flow_error",
+        distinct_id: telemetryInstanceId(),
+        properties: {
+          scope,
+          error_name: e.name,
+          ...(typeof code === "string" ? { error_code: code } : {}),
+          ...(flowFrame(e.stack) ? { frame: flowFrame(e.stack) } : {}),
+          version: orchestratorVersion(),
+          flow_mode: getFlowMode(),
+          $process_person_profile: false,
+        },
+      }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
 let firstTimer: NodeJS.Timeout | null = null;
 let intervalTimer: NodeJS.Timeout | null = null;
+let monitorInstalled = false;
 
 export function startTelemetryReporter(): void {
   if (process.env.FLOW_TELEMETRY_DISABLE === "1") {
@@ -285,6 +353,13 @@ export function startTelemetryReporter(): void {
   // unconditionally — setting the key from the dashboard later just works.
   if (!posthogTarget()) {
     console.log("[telemetry] idle — set FLOW_TELEMETRY_POSTHOG_KEY to enable usage reporting");
+  }
+  // uncaughtExceptionMonitor OBSERVES crashes without altering crash
+  // behavior (unlike an 'uncaughtException' listener, which would swallow
+  // them). Node 22 throws unhandled rejections, so they land here too.
+  if (!monitorInstalled) {
+    monitorInstalled = true;
+    process.on("uncaughtExceptionMonitor", (err) => void reportError("uncaught", err));
   }
   const interval = parseInt(process.env.FLOW_TELEMETRY_INTERVAL_MS ?? "", 10) || DEFAULT_INTERVAL_MS;
   firstTimer = setTimeout(() => void sendTelemetry(), FIRST_SEND_DELAY_MS);

--- a/orchestrator/src/telemetry.ts
+++ b/orchestrator/src/telemetry.ts
@@ -251,34 +251,60 @@ export async function telemetrySnapshot(): Promise<TelemetrySnapshot> {
 
 function posthogTarget(): { url: string; apiKey: string } | null {
   if (process.env.FLOW_TELEMETRY_DISABLE === "1") return null;
+  // The fake-opencode flag marks a test process — the default key is real,
+  // and a test run must never emit events.
+  if (process.env.FLOW_FAKE_OPENCODE === "1") return null;
   const apiKey = getSetting("FLOW_TELEMETRY_POSTHOG_KEY");
   if (!apiKey) return null;
   const host = getSetting("FLOW_TELEMETRY_POSTHOG_HOST") || "https://us.i.posthog.com";
   return { url: `${host.replace(/\/$/, "")}/capture/`, apiKey };
 }
 
-export async function sendTelemetry(): Promise<boolean> {
+// One capture call — every event goes through here. Best-effort by design:
+// an unreachable PostHog must never affect Flow.
+async function capture(event: string, properties: Record<string, unknown>): Promise<boolean> {
   const target = posthogTarget();
   if (!target) return false;
   try {
-    const snap = await telemetrySnapshot();
-    const { instance_id, ...properties } = snap;
     const res = await fetch(target.url, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         api_key: target.apiKey,
-        event: "flow_snapshot",
-        distinct_id: instance_id,
-        properties: { ...properties, $process_person_profile: false },
+        event,
+        distinct_id: telemetryInstanceId(),
+        properties: {
+          ...properties,
+          version: orchestratorVersion(),
+          flow_mode: getFlowMode(),
+          $process_person_profile: false,
+        },
       }),
       signal: AbortSignal.timeout(10_000),
     });
     return res.ok;
   } catch {
-    // Best-effort by design: an unreachable PostHog must never affect Flow.
     return false;
   }
+}
+
+export async function sendTelemetry(): Promise<boolean> {
+  try {
+    const snap = await telemetrySnapshot();
+    const { instance_id, ...properties } = snap;
+    void instance_id; // identity travels as distinct_id only
+    return await capture("flow_snapshot", properties);
+  } catch {
+    return false;
+  }
+}
+
+// Discrete usage events — the "verbs" layer next to the snapshot's "nouns":
+// individually timestamped by PostHog, so frequency/retention insights work.
+// Same privacy rules as everything here: values must be numbers, booleans, or
+// fixed enums (backend ids, placement kinds) — never titles, names, or paths.
+export function track(event: string, properties: Record<string, number | boolean | string>): void {
+  void capture(event, properties);
 }
 
 // ------------------------------------------------------------------
@@ -309,35 +335,17 @@ function flowFrame(stack: string | undefined): string | null {
 
 export async function reportError(scope: string, err: unknown): Promise<boolean> {
   if (errorEventCount >= ERROR_EVENTS_MAX_PER_PROCESS) return false;
-  const target = posthogTarget();
-  if (!target) return false;
+  if (!posthogTarget()) return false;
   errorEventCount++;
   const e = err instanceof Error ? err : new Error(String(err));
   const code = (e as NodeJS.ErrnoException).code;
-  try {
-    const res = await fetch(target.url, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        api_key: target.apiKey,
-        event: "flow_error",
-        distinct_id: telemetryInstanceId(),
-        properties: {
-          scope,
-          error_name: e.name,
-          ...(typeof code === "string" ? { error_code: code } : {}),
-          ...(flowFrame(e.stack) ? { frame: flowFrame(e.stack) } : {}),
-          version: orchestratorVersion(),
-          flow_mode: getFlowMode(),
-          $process_person_profile: false,
-        },
-      }),
-      signal: AbortSignal.timeout(10_000),
-    });
-    return res.ok;
-  } catch {
-    return false;
-  }
+  const frame = flowFrame(e.stack);
+  return capture("flow_error", {
+    scope,
+    error_name: e.name,
+    ...(typeof code === "string" ? { error_code: code } : {}),
+    ...(frame ? { frame } : {}),
+  });
 }
 
 let firstTimer: NodeJS.Timeout | null = null;
@@ -379,6 +387,22 @@ export function stopTelemetryReporter(): void {
 // Route — the audit window: exactly what a phone-home would send.
 // ------------------------------------------------------------------
 
+// Events the CLI may relay through us (it has no PostHog key of its own).
+// A whitelist plus number/boolean-only properties keeps this from becoming an
+// arbitrary-string funnel into our project under the admin token.
+const CLI_TRACKABLE = new Set(["flow_setup_run"]);
+
+export function sanitizeTrackProps(raw: unknown): Record<string, number | boolean> {
+  const out: Record<string, number | boolean> = {};
+  if (typeof raw !== "object" || raw === null) return out;
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    if (Object.keys(out).length >= 20) break;
+    if (!/^[a-z0-9_]{1,40}$/.test(k)) continue;
+    if (typeof v === "number" || typeof v === "boolean") out[k] = v;
+  }
+  return out;
+}
+
 export function registerTelemetryRoutes(app: FastifyInstance): void {
   app.get("/v1/telemetry", async (_req, reply) => {
     const snapshot = await telemetrySnapshot();
@@ -387,4 +411,16 @@ export function registerTelemetryRoutes(app: FastifyInstance): void {
       reporting: posthogTarget() ? "on" : "off",
     });
   });
+
+  app.post<{ Body: { event?: string; properties?: unknown } }>(
+    "/v1/telemetry/track",
+    async (req, reply) => {
+      const { event, properties } = req.body ?? {};
+      if (!event || !CLI_TRACKABLE.has(event)) {
+        return reply.code(400).send({ error: "unknown event" });
+      }
+      track(event, sanitizeTrackProps(properties));
+      return reply.code(202).send({ ok: true });
+    }
+  );
 }

--- a/orchestrator/src/telemetry.ts
+++ b/orchestrator/src/telemetry.ts
@@ -66,7 +66,10 @@ export interface TelemetrySnapshot {
   jobs_total: number;
   jobs_done: number;
   jobs_failed: number;
+  jobs_by_type: Record<string, number>;
+  corrections_total: number;
   errors_since_boot: number;
+  counters: Record<string, number>;
   worktrees_created_total: number;
   worktrees_active: number;
   work_folders_total: number;
@@ -76,6 +79,36 @@ export interface TelemetrySnapshot {
   connected_github: boolean;
   connected_fireflies: boolean;
   connected_llm_key: boolean;
+}
+
+// Durable counters for HIGH-FREQUENCY actions (brain queries fire dozens of
+// times per session — a network event per query would be real load and quota
+// burn; a SQLite upsert is microseconds and restart-proof). Totals ride in
+// the daily snapshot; PostHog computes rates from the per-instance deltas.
+const COUNTER_PREFIX = "telemetry:counter:";
+
+export function bumpCounter(name: string, by = 1): void {
+  try {
+    db.prepare(
+      `INSERT INTO config (key, value) VALUES (?, ?)
+       ON CONFLICT(key) DO UPDATE SET value = CAST(CAST(value AS INTEGER) + ? AS TEXT)`
+    ).run(COUNTER_PREFIX + name, String(by), by);
+  } catch {
+    /* counters are never load-bearing */
+  }
+}
+
+export function readCounters(): Record<string, number> {
+  const out: Record<string, number> = {};
+  try {
+    const rows = db
+      .prepare("SELECT key, value FROM config WHERE key LIKE ?")
+      .all(`${COUNTER_PREFIX}%`) as Array<{ key: string; value: string }>;
+    for (const r of rows) out[r.key.slice(COUNTER_PREFIX.length)] = parseInt(r.value, 10) || 0;
+  } catch {
+    /* fresh DB */
+  }
+  return out;
 }
 
 export function telemetryInstanceId(): string {
@@ -117,13 +150,11 @@ function count(sql: string, ...params: unknown[]): number {
 // to seconds in SQL so second-resolution rows (external capture) compare too.
 const CREATED_AT_SEC = "(CASE WHEN created_at > 100000000000 THEN created_at / 1000 ELSE created_at END)";
 
-function sessionsByBackend(): Record<string, number> {
+function countsBy(sql: string): Record<string, number> {
   const out: Record<string, number> = {};
   try {
-    const rows = db
-      .prepare("SELECT backend, count(*) AS c FROM agent_sessions GROUP BY backend")
-      .all() as Array<{ backend: string; c: number }>;
-    for (const r of rows) out[r.backend] = r.c;
+    const rows = db.prepare(sql).all() as Array<{ k: string; c: number }>;
+    for (const r of rows) out[r.k] = r.c;
   } catch {
     /* table absent on ancient DBs — counts stay empty */
   }
@@ -226,11 +257,14 @@ export async function telemetrySnapshot(): Promise<TelemetrySnapshot> {
       `SELECT count(*) AS c FROM agent_sessions WHERE ${CREATED_AT_SEC} >= ?`,
       nowSec - 30 * day
     ),
-    sessions_by_backend: sessionsByBackend(),
+    sessions_by_backend: countsBy("SELECT backend AS k, count(*) AS c FROM agent_sessions GROUP BY backend"),
     jobs_total: count("SELECT count(*) AS c FROM jobs"),
     jobs_done: count("SELECT count(*) AS c FROM jobs WHERE status = 'done'"),
     jobs_failed: count("SELECT count(*) AS c FROM jobs WHERE status = 'failed'"),
+    jobs_by_type: countsBy("SELECT type AS k, count(*) AS c FROM jobs GROUP BY type"),
+    corrections_total: count("SELECT count(*) AS c FROM corrections"),
     errors_since_boot: errorEventCount,
+    counters: readCounters(),
     worktrees_created_total: count(
       "SELECT count(DISTINCT worktree_id) AS c FROM agent_sessions WHERE worktree_id IS NOT NULL"
     ),
@@ -291,9 +325,10 @@ async function capture(event: string, properties: Record<string, unknown>): Prom
 export async function sendTelemetry(): Promise<boolean> {
   try {
     const snap = await telemetrySnapshot();
-    const { instance_id, ...properties } = snap;
+    const { instance_id, counters, ...properties } = snap;
     void instance_id; // identity travels as distinct_id only
-    return await capture("flow_snapshot", properties);
+    // Counters flatten to top-level properties so PostHog can chart them.
+    return await capture("flow_snapshot", { ...properties, ...counters });
   } catch {
     return false;
   }

--- a/orchestrator/src/telemetry.ts
+++ b/orchestrator/src/telemetry.ts
@@ -1,0 +1,315 @@
+// telemetry.ts — anonymous, numbers-only usage snapshot + optional PostHog
+// phone-home.
+//
+// WHAT LEAVES THE MACHINE: counts and booleans only — how many repos are
+// connected, how many nodes the graph has, how many sessions/worktrees exist,
+// whether Slack/Linear/etc. are configured. Never names, paths, repo URLs,
+// code, or message content. GET /v1/telemetry returns the exact payload so a
+// self-hoster can audit what would be sent.
+//
+// TRANSPORT: PostHog's capture API — one plain fetch, no SDK dependency.
+// Off until FLOW_TELEMETRY_POSTHOG_KEY is set (env or dashboard setting);
+// FLOW_TELEMETRY_DISABLE=1 force-disables even with a key. The key is
+// re-read on every tick, so pasting it into the dashboard settings enables
+// reporting without a restart. Sends once shortly after boot, then daily.
+//
+// IDENTITY: a random UUID minted once per deployment and kept in the config
+// table. distinct_id in PostHog = one Flow instance; "how many people use
+// Flow" is a unique-count over it. $process_person_profile:false keeps the
+// events anonymous-tier (no person profiles).
+
+import { randomUUID } from "node:crypto";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { FastifyInstance } from "fastify";
+import db from "./db.js";
+import { listWorkspaceRepos } from "./opencode.js";
+import { managedWorktreesRoot } from "./agents/worktrees.js";
+import { getSetting } from "./settings.js";
+import { getFlowMode } from "./mode.js";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+
+const INSTANCE_ID_KEY = "telemetry:instance_id";
+const DEFAULT_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const FIRST_SEND_DELAY_MS = 2 * 60 * 1000;
+
+// ------------------------------------------------------------------
+// Snapshot
+// ------------------------------------------------------------------
+
+export interface TelemetrySnapshot {
+  instance_id: string;
+  flow_mode: "local" | "prod";
+  version: string;
+  platform: string;
+  node_major: number;
+  sources_total: number;
+  sources_code: number;
+  sources_docs: number;
+  sources_indexed: number;
+  graph_nodes: number | null;
+  graph_edges: number | null;
+  memories: number;
+  observations: number;
+  corpus_events: number;
+  corpus_slack_messages: number;
+  corpus_linear_tickets: number;
+  corpus_meeting_segments: number;
+  sessions_total: number;
+  sessions_via_flow: number;
+  sessions_captured_external: number;
+  sessions_last_7d: number;
+  sessions_last_30d: number;
+  sessions_by_backend: Record<string, number>;
+  worktrees_created_total: number;
+  worktrees_active: number;
+  work_folders_total: number;
+  work_folder_owners: number;
+  connected_slack: boolean;
+  connected_linear: boolean;
+  connected_github: boolean;
+  connected_fireflies: boolean;
+  connected_llm_key: boolean;
+}
+
+export function telemetryInstanceId(): string {
+  const row = db.prepare("SELECT value FROM config WHERE key = ?").get(INSTANCE_ID_KEY) as
+    | { value: string }
+    | undefined;
+  if (row) {
+    try {
+      return JSON.parse(row.value) as string;
+    } catch {
+      return row.value;
+    }
+  }
+  const id = randomUUID();
+  db.prepare("INSERT INTO config (key, value) VALUES (?, ?)").run(INSTANCE_ID_KEY, JSON.stringify(id));
+  return id;
+}
+
+function orchestratorVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(path.resolve(__dirname, "../package.json"), "utf8")) as {
+      version?: string;
+    };
+    return pkg.version ?? "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+}
+
+function count(sql: string, ...params: unknown[]): number {
+  try {
+    return (db.prepare(sql).get(...params) as { c: number } | undefined)?.c ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+// agent_sessions.created_at is Date.now() ms for flow-native rows; normalize
+// to seconds in SQL so second-resolution rows (external capture) compare too.
+const CREATED_AT_SEC = "(CASE WHEN created_at > 100000000000 THEN created_at / 1000 ELSE created_at END)";
+
+function sessionsByBackend(): Record<string, number> {
+  const out: Record<string, number> = {};
+  try {
+    const rows = db
+      .prepare("SELECT backend, count(*) AS c FROM agent_sessions GROUP BY backend")
+      .all() as Array<{ backend: string; c: number }>;
+    for (const r of rows) out[r.backend] = r.c;
+  } catch {
+    /* table absent on ancient DBs — counts stay empty */
+  }
+  return out;
+}
+
+// Live worktree dirs under <workspace>/worktrees/<repo>/<slug>. Filesystem
+// truth (removed copies disappear); the cumulative number comes from
+// agent_sessions.worktree_id instead.
+function activeWorktreeCount(): number {
+  const root = managedWorktreesRoot();
+  if (!root) return 0;
+  let n = 0;
+  try {
+    for (const repo of readdirSync(root, { withFileTypes: true })) {
+      if (!repo.isDirectory()) continue;
+      try {
+        n += readdirSync(path.join(root, repo.name), { withFileTypes: true }).filter((d) =>
+          d.isDirectory()
+        ).length;
+      } catch {
+        /* repo dir raced away */
+      }
+    }
+  } catch {
+    return 0;
+  }
+  return n;
+}
+
+// Node/edge totals via the gateway's read_query verb (same boundary as
+// memory/anchor-provider.ts). null = gateway unreachable, not zero.
+async function graphCounts(): Promise<{ nodes: number | null; edges: number | null }> {
+  const base = process.env.FLOW_GATEWAY_URL || process.env.GRAPH_GATEWAY_URL || "";
+  if (!base) return { nodes: null, edges: null };
+  const url = `${base.replace(/\/$/, "")}/v1/verbs/read_query`;
+  const token = process.env.FLOW_ADMIN_TOKEN || process.env.FLOW_ACTIVITY_TOKEN || "";
+  const run = async (cypher: string): Promise<number | null> => {
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...(token ? { authorization: `Bearer ${token}` } : {}) },
+        body: JSON.stringify({ cypher }),
+        signal: AbortSignal.timeout(4000),
+      });
+      if (!res.ok) return null;
+      const body = (await res.json().catch(() => ({}))) as { rows?: Array<{ c?: number }> };
+      const c = body.rows?.[0]?.c;
+      return typeof c === "number" ? c : null;
+    } catch {
+      return null;
+    }
+  };
+  const [nodes, edges] = await Promise.all([
+    run("MATCH (n) RETURN count(n) AS c"),
+    run("MATCH ()-[r]->() RETURN count(r) AS c"),
+  ]);
+  return { nodes, edges };
+}
+
+export async function telemetrySnapshot(): Promise<TelemetrySnapshot> {
+  let repos: ReturnType<typeof listWorkspaceRepos> = [];
+  try {
+    repos = listWorkspaceRepos();
+  } catch {
+    /* registry unreadable — counts stay 0 */
+  }
+  const docs = repos.filter((r) => r.kind === "docs").length;
+  const graph = await graphCounts();
+  const nowSec = Math.floor(Date.now() / 1000);
+  const day = 86_400;
+  const isSet = (key: string): boolean => Boolean(getSetting(key));
+
+  return {
+    instance_id: telemetryInstanceId(),
+    flow_mode: getFlowMode(),
+    version: orchestratorVersion(),
+    platform: process.platform,
+    node_major: parseInt(process.versions.node.split(".")[0], 10),
+    sources_total: repos.length,
+    sources_code: repos.length - docs,
+    sources_docs: docs,
+    sources_indexed: repos.filter((r) => Boolean(r.lastIndexedCommit)).length,
+    graph_nodes: graph.nodes,
+    graph_edges: graph.edges,
+    memories: count("SELECT count(*) AS c FROM memories"),
+    observations: count("SELECT count(*) AS c FROM observations"),
+    corpus_events: count("SELECT count(*) AS c FROM events"),
+    corpus_slack_messages: count("SELECT count(*) AS c FROM slack_messages"),
+    corpus_linear_tickets: count("SELECT count(*) AS c FROM linear_tickets"),
+    corpus_meeting_segments: count("SELECT count(*) AS c FROM meeting_segments"),
+    sessions_total: count("SELECT count(*) AS c FROM agent_sessions"),
+    sessions_via_flow: count("SELECT count(*) AS c FROM agent_sessions WHERE id NOT LIKE 'ext-%'"),
+    sessions_captured_external: count("SELECT count(*) AS c FROM agent_sessions WHERE id LIKE 'ext-%'"),
+    sessions_last_7d: count(
+      `SELECT count(*) AS c FROM agent_sessions WHERE ${CREATED_AT_SEC} >= ?`,
+      nowSec - 7 * day
+    ),
+    sessions_last_30d: count(
+      `SELECT count(*) AS c FROM agent_sessions WHERE ${CREATED_AT_SEC} >= ?`,
+      nowSec - 30 * day
+    ),
+    sessions_by_backend: sessionsByBackend(),
+    worktrees_created_total: count(
+      "SELECT count(DISTINCT worktree_id) AS c FROM agent_sessions WHERE worktree_id IS NOT NULL"
+    ),
+    worktrees_active: activeWorktreeCount(),
+    work_folders_total: count("SELECT count(*) AS c FROM work_folders"),
+    work_folder_owners: count("SELECT count(DISTINCT owner) AS c FROM work_folders"),
+    connected_slack: isSet("SLACK_BOT_TOKEN") && isSet("SLACK_APP_TOKEN"),
+    connected_linear: isSet("LINEAR_API_KEY"),
+    connected_github: isSet("GITHUB_TOKEN"),
+    connected_fireflies: isSet("FIREFLIES_API_KEY"),
+    connected_llm_key: isSet("LLM_API_KEY") || isSet("OPENROUTER_API_KEY"),
+  };
+}
+
+// ------------------------------------------------------------------
+// PostHog reporter
+// ------------------------------------------------------------------
+
+function posthogTarget(): { url: string; apiKey: string } | null {
+  if (process.env.FLOW_TELEMETRY_DISABLE === "1") return null;
+  const apiKey = getSetting("FLOW_TELEMETRY_POSTHOG_KEY");
+  if (!apiKey) return null;
+  const host = getSetting("FLOW_TELEMETRY_POSTHOG_HOST") || "https://us.i.posthog.com";
+  return { url: `${host.replace(/\/$/, "")}/capture/`, apiKey };
+}
+
+export async function sendTelemetry(): Promise<boolean> {
+  const target = posthogTarget();
+  if (!target) return false;
+  try {
+    const snap = await telemetrySnapshot();
+    const { instance_id, ...properties } = snap;
+    const res = await fetch(target.url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        api_key: target.apiKey,
+        event: "flow_snapshot",
+        distinct_id: instance_id,
+        properties: { ...properties, $process_person_profile: false },
+      }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    return res.ok;
+  } catch {
+    // Best-effort by design: an unreachable PostHog must never affect Flow.
+    return false;
+  }
+}
+
+let firstTimer: NodeJS.Timeout | null = null;
+let intervalTimer: NodeJS.Timeout | null = null;
+
+export function startTelemetryReporter(): void {
+  if (process.env.FLOW_TELEMETRY_DISABLE === "1") {
+    console.log("[telemetry] disabled (FLOW_TELEMETRY_DISABLE=1)");
+    return;
+  }
+  // The key is resolved inside sendTelemetry on every tick, so the timers run
+  // unconditionally — setting the key from the dashboard later just works.
+  if (!posthogTarget()) {
+    console.log("[telemetry] idle — set FLOW_TELEMETRY_POSTHOG_KEY to enable usage reporting");
+  }
+  const interval = parseInt(process.env.FLOW_TELEMETRY_INTERVAL_MS ?? "", 10) || DEFAULT_INTERVAL_MS;
+  firstTimer = setTimeout(() => void sendTelemetry(), FIRST_SEND_DELAY_MS);
+  firstTimer.unref();
+  intervalTimer = setInterval(() => void sendTelemetry(), interval);
+  intervalTimer.unref();
+}
+
+export function stopTelemetryReporter(): void {
+  if (firstTimer) clearTimeout(firstTimer);
+  if (intervalTimer) clearInterval(intervalTimer);
+  firstTimer = null;
+  intervalTimer = null;
+}
+
+// ------------------------------------------------------------------
+// Route — the audit window: exactly what a phone-home would send.
+// ------------------------------------------------------------------
+
+export function registerTelemetryRoutes(app: FastifyInstance): void {
+  app.get("/v1/telemetry", async (_req, reply) => {
+    const snapshot = await telemetrySnapshot();
+    return reply.send({
+      snapshot,
+      reporting: posthogTarget() ? "on" : "off",
+    });
+  });
+}

--- a/orchestrator/test/telemetry.test.ts
+++ b/orchestrator/test/telemetry.test.ts
@@ -35,14 +35,14 @@ let sendTelemetry: () => Promise<boolean>;
 let reportError: (scope: string, err: unknown) => Promise<boolean>;
 let track: (event: string, props: Record<string, number | boolean | string>) => void;
 let sanitizeTrackProps: (raw: unknown) => Record<string, number | boolean>;
+let bumpCounter: (name: string, by?: number) => void;
 let getSetting: (key: string) => string | undefined;
 let putSetting: (key: string, value: string) => void;
 let db: import("better-sqlite3").Database;
 
 before(async () => {
-  ({ telemetryInstanceId, telemetrySnapshot, sendTelemetry, reportError, track, sanitizeTrackProps } = await import(
-    "../src/telemetry.js"
-  ));
+  ({ telemetryInstanceId, telemetrySnapshot, sendTelemetry, reportError, track, sanitizeTrackProps, bumpCounter } =
+    await import("../src/telemetry.js"));
   ({ getSetting, putSetting } = await import("../src/settings.js"));
   ({ default: db } = await import("../src/db.js"));
 
@@ -121,7 +121,7 @@ describe("telemetry snapshot", () => {
     // Every value is a number, boolean, null, or a number-valued map — the
     // payload can never carry repo names, paths, or message content.
     for (const [key, value] of Object.entries(snap)) {
-      if (key === "sessions_by_backend") {
+      if (["sessions_by_backend", "jobs_by_type", "counters"].includes(key)) {
         for (const v of Object.values(value as Record<string, number>)) {
           assert.equal(typeof v, "number");
         }
@@ -151,6 +151,15 @@ describe("telemetry snapshot", () => {
     } finally {
       delete process.env.FLOW_FAKE_OPENCODE;
     }
+  });
+
+  test("bumpCounter accumulates durably and lands in the snapshot", async () => {
+    bumpCounter("brain_search_total", 3);
+    bumpCounter("brain_search_total");
+    bumpCounter("memory_remember_total");
+    const snap = await telemetrySnapshot();
+    assert.equal(snap.counters.brain_search_total, 4);
+    assert.equal(snap.counters.memory_remember_total, 1);
   });
 
   test("sanitizeTrackProps keeps only sane numeric/boolean keys", () => {
@@ -197,6 +206,9 @@ describe("telemetry snapshot", () => {
     assert.equal(props.sessions_total, 3);
     assert.equal(props.$process_person_profile, false); // anonymous-tier events
     assert.equal("instance_id" in props, false); // identity travels as distinct_id only
+    // Counters flatten to top-level chartable properties.
+    assert.equal(props.brain_search_total, 4);
+    assert.equal("counters" in props, false);
   });
 
   test("reportError sends class + Flow frame, never the message", async () => {

--- a/orchestrator/test/telemetry.test.ts
+++ b/orchestrator/test/telemetry.test.ts
@@ -19,6 +19,9 @@ process.env.LINEAR_API_KEY = "lin_api_test";
 delete process.env.SLACK_BOT_TOKEN;
 delete process.env.FLOW_GATEWAY_URL;
 delete process.env.GRAPH_GATEWAY_URL;
+// A default PostHog key ships in the settings registry — point the host at a
+// dead local port so no test can ever reach the real capture endpoint.
+process.env.FLOW_TELEMETRY_POSTHOG_HOST = "http://127.0.0.1:9";
 
 import { test, describe, before, after } from "node:test";
 import assert from "node:assert/strict";
@@ -27,12 +30,14 @@ import type { TelemetrySnapshot } from "../src/telemetry.js";
 let telemetryInstanceId: () => string;
 let telemetrySnapshot: () => Promise<TelemetrySnapshot>;
 let sendTelemetry: () => Promise<boolean>;
+let reportError: (scope: string, err: unknown) => Promise<boolean>;
+let getSetting: (key: string) => string | undefined;
 let putSetting: (key: string, value: string) => void;
 let db: import("better-sqlite3").Database;
 
 before(async () => {
-  ({ telemetryInstanceId, telemetrySnapshot, sendTelemetry } = await import("../src/telemetry.js"));
-  ({ putSetting } = await import("../src/settings.js"));
+  ({ telemetryInstanceId, telemetrySnapshot, sendTelemetry, reportError } = await import("../src/telemetry.js"));
+  ({ getSetting, putSetting } = await import("../src/settings.js"));
   ({ default: db } = await import("../src/db.js"));
 
   // agent_sessions is created by the agents runtime, not db.ts's baseline —
@@ -122,8 +127,15 @@ describe("telemetry snapshot", () => {
     }
   });
 
-  test("sendTelemetry is a no-op without a PostHog key", async () => {
-    assert.equal(await sendTelemetry(), false);
+  test("a default PostHog key ships in the registry; FLOW_TELEMETRY_DISABLE=1 is a hard off", async () => {
+    assert.match(getSetting("FLOW_TELEMETRY_POSTHOG_KEY") ?? "", /^phc_/);
+    process.env.FLOW_TELEMETRY_DISABLE = "1";
+    try {
+      assert.equal(await sendTelemetry(), false);
+      assert.equal(await reportError("test", new Error("nope")), false);
+    } finally {
+      delete process.env.FLOW_TELEMETRY_DISABLE;
+    }
   });
 
   test("sendTelemetry posts a PostHog capture event keyed by instance id", async () => {
@@ -156,5 +168,41 @@ describe("telemetry snapshot", () => {
     assert.equal(props.sessions_total, 3);
     assert.equal(props.$process_person_profile, false); // anonymous-tier events
     assert.equal("instance_id" in props, false); // identity travels as distinct_id only
+  });
+
+  test("reportError sends class + Flow frame, never the message", async () => {
+    let captured: Record<string, unknown> | null = null;
+    const server: Server = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        captured = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
+        res.writeHead(200, { "content-type": "application/json" }).end("{}");
+      });
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+    const port = (server.address() as { port: number }).port;
+    putSetting("FLOW_TELEMETRY_POSTHOG_HOST", `http://127.0.0.1:${port}`);
+
+    const err = new TypeError("secret /Users/someone/private-repo/path leaked");
+    try {
+      assert.equal(await reportError("test-scope", err), true);
+    } finally {
+      server.close();
+    }
+
+    assert.ok(captured, "capture endpoint was hit");
+    const body = captured as Record<string, unknown>;
+    assert.equal(body.event, "flow_error");
+    assert.equal(body.distinct_id, telemetryInstanceId());
+    const props = body.properties as Record<string, unknown>;
+    assert.equal(props.scope, "test-scope");
+    assert.equal(props.error_name, "TypeError");
+    // The message (which can embed user paths) must never travel.
+    assert.equal(JSON.stringify(body).includes("private-repo"), false);
+    // This test file lives under orchestrator/ — the frame is basename:line.
+    if (props.frame !== undefined) {
+      assert.match(String(props.frame), /^[^/\\]+:\d+$/);
+    }
   });
 });

--- a/orchestrator/test/telemetry.test.ts
+++ b/orchestrator/test/telemetry.test.ts
@@ -13,7 +13,9 @@ process.env.OPENCODE_WORKSPACE_DIR = workspace;
 process.env.REPOS_JSON_PATH = join(workspace, "repos.json");
 process.env.DB_PATH = ":memory:";
 process.env.FLOW_ADMIN_TOKEN = "test-token-telemetry";
-process.env.FLOW_FAKE_OPENCODE = "1";
+// Deliberately NOT setting FLOW_FAKE_OPENCODE: that flag hard-disables
+// telemetry (so the rest of the suite can't leak events), and this file needs
+// sends to reach its local capture server.
 process.env.FLOW_DRAIN_DISABLE = "1";
 process.env.LINEAR_API_KEY = "lin_api_test";
 delete process.env.SLACK_BOT_TOKEN;
@@ -31,12 +33,16 @@ let telemetryInstanceId: () => string;
 let telemetrySnapshot: () => Promise<TelemetrySnapshot>;
 let sendTelemetry: () => Promise<boolean>;
 let reportError: (scope: string, err: unknown) => Promise<boolean>;
+let track: (event: string, props: Record<string, number | boolean | string>) => void;
+let sanitizeTrackProps: (raw: unknown) => Record<string, number | boolean>;
 let getSetting: (key: string) => string | undefined;
 let putSetting: (key: string, value: string) => void;
 let db: import("better-sqlite3").Database;
 
 before(async () => {
-  ({ telemetryInstanceId, telemetrySnapshot, sendTelemetry, reportError } = await import("../src/telemetry.js"));
+  ({ telemetryInstanceId, telemetrySnapshot, sendTelemetry, reportError, track, sanitizeTrackProps } = await import(
+    "../src/telemetry.js"
+  ));
   ({ getSetting, putSetting } = await import("../src/settings.js"));
   ({ default: db } = await import("../src/db.js"));
 
@@ -138,6 +144,29 @@ describe("telemetry snapshot", () => {
     }
   });
 
+  test("FLOW_FAKE_OPENCODE=1 (test processes) also hard-disables sends", async () => {
+    process.env.FLOW_FAKE_OPENCODE = "1";
+    try {
+      assert.equal(await sendTelemetry(), false);
+    } finally {
+      delete process.env.FLOW_FAKE_OPENCODE;
+    }
+  });
+
+  test("sanitizeTrackProps keeps only sane numeric/boolean keys", () => {
+    assert.deepEqual(
+      sanitizeTrackProps({
+        harness_claude: true,
+        detected_count: 3,
+        repo_name: "secret-repo", // strings are dropped wholesale
+        "weird key!": 1,
+        nested: { a: 1 },
+      }),
+      { harness_claude: true, detected_count: 3 }
+    );
+    assert.deepEqual(sanitizeTrackProps("junk"), {});
+  });
+
   test("sendTelemetry posts a PostHog capture event keyed by instance id", async () => {
     let captured: Record<string, unknown> | null = null;
     const server: Server = createServer((req, res) => {
@@ -204,5 +233,36 @@ describe("telemetry snapshot", () => {
     if (props.frame !== undefined) {
       assert.match(String(props.frame), /^[^/\\]+:\d+$/);
     }
+  });
+
+  test("track() fires a discrete usage event with enum-shaped props", async () => {
+    let captured: Record<string, unknown> | null = null;
+    const server: Server = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        captured = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
+        res.writeHead(200, { "content-type": "application/json" }).end("{}");
+      });
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+    const port = (server.address() as { port: number }).port;
+    putSetting("FLOW_TELEMETRY_POSTHOG_HOST", `http://127.0.0.1:${port}`);
+
+    track("flow_session_started", { backend: "claude", placement: "separate_copy", native: true });
+    // track() is fire-and-forget — wait for the capture to land.
+    const deadline = Date.now() + 3000;
+    while (!captured && Date.now() < deadline) await new Promise((r) => setTimeout(r, 25));
+    server.close();
+
+    assert.ok(captured, "capture endpoint was hit");
+    const body = captured as Record<string, unknown>;
+    assert.equal(body.event, "flow_session_started");
+    assert.equal(body.distinct_id, telemetryInstanceId());
+    const props = body.properties as Record<string, unknown>;
+    assert.equal(props.backend, "claude");
+    assert.equal(props.placement, "separate_copy");
+    assert.equal(props.native, true);
+    assert.equal(typeof props.version, "string"); // common context rides along
   });
 });

--- a/orchestrator/test/telemetry.test.ts
+++ b/orchestrator/test/telemetry.test.ts
@@ -1,0 +1,160 @@
+// telemetry.test.ts — the usage snapshot is numbers/booleans only, the
+// instance id is stable, reporting stays off without a PostHog key, and the
+// capture payload sends counts under a stable anonymous distinct_id.
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer, type Server } from "node:http";
+
+// Setup: workspace + in-memory DB before any imports that touch db
+const workspace = mkdtempSync(join(tmpdir(), "flow-telemetry-"));
+process.env.OPENCODE_WORKSPACE_DIR = workspace;
+process.env.REPOS_JSON_PATH = join(workspace, "repos.json");
+process.env.DB_PATH = ":memory:";
+process.env.FLOW_ADMIN_TOKEN = "test-token-telemetry";
+process.env.FLOW_FAKE_OPENCODE = "1";
+process.env.FLOW_DRAIN_DISABLE = "1";
+process.env.LINEAR_API_KEY = "lin_api_test";
+delete process.env.SLACK_BOT_TOKEN;
+delete process.env.FLOW_GATEWAY_URL;
+delete process.env.GRAPH_GATEWAY_URL;
+
+import { test, describe, before, after } from "node:test";
+import assert from "node:assert/strict";
+import type { TelemetrySnapshot } from "../src/telemetry.js";
+
+let telemetryInstanceId: () => string;
+let telemetrySnapshot: () => Promise<TelemetrySnapshot>;
+let sendTelemetry: () => Promise<boolean>;
+let putSetting: (key: string, value: string) => void;
+let db: import("better-sqlite3").Database;
+
+before(async () => {
+  ({ telemetryInstanceId, telemetrySnapshot, sendTelemetry } = await import("../src/telemetry.js"));
+  ({ putSetting } = await import("../src/settings.js"));
+  ({ default: db } = await import("../src/db.js"));
+
+  // agent_sessions is created by the agents runtime, not db.ts's baseline —
+  // create the same shape here rather than booting the whole ACP runtime.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS agent_sessions (
+      id TEXT PRIMARY KEY,
+      backend TEXT NOT NULL,
+      repo TEXT NOT NULL,
+      cwd TEXT NOT NULL,
+      title TEXT NOT NULL,
+      status TEXT NOT NULL,
+      worktree_id TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  writeFileSync(
+    process.env.REPOS_JSON_PATH!,
+    JSON.stringify({
+      repos: [
+        { name: "app", url: "https://github.com/acme/app", branch: "main", lastIndexedCommit: "abc123" },
+        { name: "notes", url: "", branch: "main", kind: "docs" },
+      ],
+    })
+  );
+
+  const now = Date.now();
+  const ins = db.prepare(
+    `INSERT INTO agent_sessions (id, backend, repo, cwd, title, status, worktree_id, created_at, updated_at)
+     VALUES (?, ?, 'app', '/tmp/x', 't', 'closed', ?, ?, ?)`
+  );
+  // Two flow-native sessions sharing one worktree, one captured external session.
+  ins.run("s1", "claude", "/wt/a", now, now);
+  ins.run("s2", "claude", "/wt/a", now, now);
+  ins.run("ext-codex-abc", "ext:codex", null, now, now);
+
+  // Two live managed worktrees on disk under <workspace>/worktrees/<repo>/<slug>
+  mkdirSync(join(workspace, "worktrees", "app", "fix-login"), { recursive: true });
+  mkdirSync(join(workspace, "worktrees", "app", "add-tests"), { recursive: true });
+});
+
+after(() => rmSync(workspace, { recursive: true, force: true }));
+
+describe("telemetry snapshot", () => {
+  test("instance id is minted once and stable", () => {
+    const a = telemetryInstanceId();
+    const b = telemetryInstanceId();
+    assert.equal(a, b);
+    assert.match(a, /^[0-9a-f-]{36}$/);
+  });
+
+  test("snapshot reports counts and booleans only — no names, paths, or content", async () => {
+    const snap = await telemetrySnapshot();
+
+    assert.equal(snap.sources_total, 2);
+    assert.equal(snap.sources_code, 1);
+    assert.equal(snap.sources_docs, 1);
+    assert.equal(snap.sources_indexed, 1);
+
+    assert.equal(snap.sessions_total, 3);
+    assert.equal(snap.sessions_via_flow, 2);
+    assert.equal(snap.sessions_captured_external, 1);
+    assert.equal(snap.sessions_last_7d, 3);
+    assert.deepEqual(snap.sessions_by_backend, { claude: 2, "ext:codex": 1 });
+
+    assert.equal(snap.worktrees_created_total, 1); // distinct worktree_id
+    assert.equal(snap.worktrees_active, 2); // dirs on disk
+
+    assert.equal(snap.connected_linear, true); // env key set
+    assert.equal(snap.connected_slack, false);
+    assert.equal(snap.graph_nodes, null); // no gateway configured ≠ zero nodes
+
+    // Every value is a number, boolean, null, or a number-valued map — the
+    // payload can never carry repo names, paths, or message content.
+    for (const [key, value] of Object.entries(snap)) {
+      if (key === "sessions_by_backend") {
+        for (const v of Object.values(value as Record<string, number>)) {
+          assert.equal(typeof v, "number");
+        }
+      } else if (["instance_id", "flow_mode", "version", "platform"].includes(key)) {
+        assert.equal(typeof value, "string");
+      } else {
+        assert.ok(value === null || typeof value === "number" || typeof value === "boolean", key);
+      }
+    }
+  });
+
+  test("sendTelemetry is a no-op without a PostHog key", async () => {
+    assert.equal(await sendTelemetry(), false);
+  });
+
+  test("sendTelemetry posts a PostHog capture event keyed by instance id", async () => {
+    let captured: Record<string, unknown> | null = null;
+    const server: Server = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        captured = JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
+        res.writeHead(200, { "content-type": "application/json" }).end("{}");
+      });
+    });
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+    const port = (server.address() as { port: number }).port;
+
+    putSetting("FLOW_TELEMETRY_POSTHOG_KEY", "phc_test_key");
+    putSetting("FLOW_TELEMETRY_POSTHOG_HOST", `http://127.0.0.1:${port}`);
+    try {
+      assert.equal(await sendTelemetry(), true);
+    } finally {
+      server.close();
+    }
+
+    assert.ok(captured, "capture endpoint was hit");
+    const body = captured as Record<string, unknown>;
+    assert.equal(body.api_key, "phc_test_key");
+    assert.equal(body.event, "flow_snapshot");
+    assert.equal(body.distinct_id, telemetryInstanceId());
+    const props = body.properties as Record<string, unknown>;
+    assert.equal(props.sessions_total, 3);
+    assert.equal(props.$process_person_profile, false); // anonymous-tier events
+    assert.equal("instance_id" in props, false); // identity travels as distinct_id only
+  });
+});


### PR DESCRIPTION
## What

Flow now answers "how many people use it and how" — with a privacy posture that survives open-source scrutiny. Every payload is counts, booleans, and fixed enums; never names, paths, repo URLs, code, or message content. `GET /v1/telemetry` shows any user the exact bytes their instance sends.

### The three layers

**1. Daily `flow_snapshot` (gauges + heartbeat)** — one event per instance per day, keyed by a random per-deployment UUID (`distinct_id` → unique-count = active instances):
- sources (total/code/docs/indexed), graph nodes+edges (via gateway `read_query`; `null` when unreachable, so outages don't read as zero)
- memories, observations, corpus rows (events/slack/linear/meetings)
- sessions (total, via-Flow vs captured-external, 7d/30d, per-backend), jobs (total/done/failed/by-type), corrections
- worktrees (created-ever via `COUNT(DISTINCT worktree_id)`, active from fs), work folders + distinct owners
- connected booleans: Slack, Linear, GitHub, Fireflies, LLM key
- brain-usage counter totals (see layer 3)

**2. Discrete events (verbs — frequency/retention insights)**
- `flow_session_started` {backend, placement, native} — native sessions + first-seen external captures
- `flow_worktree_created`, `flow_source_added` {kind}, `flow_index_completed` {ok, incremental, duration_s}
- `flow_setup_run` {harness_* booleans} — relayed by the CLI through the new authed `POST /v1/telemetry/track` (whitelisted event names, number/boolean props only; the CLI holds no PostHog key)
- `flow_memory_saved` {source, kind} — from `createMemory()`, the single insert point for all new memories
- `flow_error` {scope, error_name, error_code, frame} — frame is basename:line of OUR source files only, **never the message** (messages embed user paths); capped 50/process; `uncaughtExceptionMonitor` observes crashes without altering crash behavior

**3. Durable counters (high-frequency, zero network per call)** — brain queries fire dozens of times per session, so they bump SQLite counters (microsecond upsert, restart-proof) that ride in the snapshot: `brain_search_total`, `brain_hits_total`, `brain_orient_total`, `memory_remember_total`, `memories_created_total`. Standing rule: anything firing more than a few times per session gets a counter, not an event.

### Defaults & opt-out
- On by default: Flow's `phc_` project key ships as the settings-registry default (public **write-only** key — standard client-side analytics practice, safe to commit; reading data requires a private key that is not in the repo)
- Opt-outs converge on one switch: `flow up --no-telemetry` (persists `FLOW_TELEMETRY_DISABLE=1` to the project `.env`; `--telemetry` re-enables), the env var directly, or blanking the key setting
- `$process_person_profile: false` keeps events on PostHog's anonymous tier
- Telemetry is never load-bearing: every send is best-effort with a timeout; PostHog being down cannot affect Flow

### Test safety
`FLOW_FAKE_OPENCODE=1` (the test-process marker) hard-disables all sends — the suite creates sessions/repos under the real baked-in key and must never emit. `test/telemetry.test.ts` (9 tests) asserts against a local capture server, including that a poisoned error message cannot leak.

## Testing
- Full orchestrator suite: **291/291 pass**
- `node --check` on the CLI + behavioral check of the `.env` upsert helper (idempotent, preserves comments/keys)