### PR TITLE
Escape hatch for the native folder picker when the browser isn't on the server's machine

### DIFF
--- a/dashboard/src/app/api/fs/native-pick/cancel/route.ts
+++ b/dashboard/src/app/api/fs/native-pick/cancel/route.ts
@@ -1,0 +1,15 @@
+// /api/fs/native-pick/cancel — dismiss the pending server-side folder dialog.
+// The escape hatch for a browser that isn't on the machine running Flow
+// (tunnel / ssh -L access looks same-machine at the network layer, so the
+// dialog can open on a screen the user can't see): the UI offers "browse from
+// here instead", we kill the osascript child so the dialog doesn't linger on
+// the remote screen until its timeout, and the pending pick request resolves
+// as a cancel.
+import { NextResponse } from "next/server";
+import { requireProject } from "@/lib/projectContext";
+import { cancelNativePick } from "@/lib/nativePick";
+
+export async function POST(): Promise<NextResponse> {
+  await requireProject();
+  return NextResponse.json({ canceled: cancelNativePick() });
+}

--- a/dashboard/src/app/api/fs/native-pick/route.ts
+++ b/dashboard/src/app/api/fs/native-pick/route.ts
@@ -7,6 +7,7 @@
 import { NextResponse } from "next/server";
 import { execFile } from "node:child_process";
 import { requireProject } from "@/lib/projectContext";
+import { trackNativePick, untrackNativePick, cancelNativePick } from "@/lib/nativePick";
 
 const SCRIPT = [
   'tell application "System Events" to activate',
@@ -20,8 +21,12 @@ export async function POST(): Promise<NextResponse> {
   if (project.mode !== "local" || process.platform !== "darwin") {
     return NextResponse.json({ unsupported: true });
   }
+  // A new pick supersedes a pending one (another tab, a retry) — dismiss it
+  // so two dialogs never stack on the server's screen.
+  cancelNativePick();
   return new Promise<NextResponse>((resolve) => {
-    execFile("osascript", SCRIPT, { timeout: 5 * 60 * 1000 }, (err, stdout) => {
+    const child = execFile("osascript", SCRIPT, { timeout: 5 * 60 * 1000 }, (err, stdout) => {
+      untrackNativePick(child);
       if (err) {
         // Exit 1 + "User canceled" (-128) is the normal dismiss; a killed
         // process (timeout, shutdown) counts as a dismiss too, not as
@@ -34,5 +39,6 @@ export async function POST(): Promise<NextResponse> {
       const path = stdout.trim().replace(/\/$/, "");
       resolve(NextResponse.json(path ? { path } : { canceled: true }));
     });
+    trackNativePick(child);
   });
 }

--- a/dashboard/src/app/api/fs/pick-folder/route.ts
+++ b/dashboard/src/app/api/fs/pick-folder/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getSessionToken } from "@/lib/auth";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { trackNativePick, untrackNativePick, cancelNativePick } from "@/lib/nativePick";
 
 const execFileAsync = promisify(execFile);
 
@@ -19,20 +20,29 @@ export async function POST(): Promise<NextResponse> {
     return NextResponse.json({ error: "Native picker only available on macOS" }, { status: 400 });
   }
 
+  // A new pick supersedes a pending one so dialogs never stack on-screen.
+  cancelNativePick();
+  const pending = execFileAsync(
+    "osascript",
+    ["-e", 'POSIX path of (choose folder with prompt "Select a project folder")'],
+    { timeout: 120_000 }
+  );
+  trackNativePick(pending.child);
   try {
-    const { stdout } = await execFileAsync(
-      "osascript",
-      ["-e", 'POSIX path of (choose folder with prompt "Select a project folder")'],
-      { timeout: 120_000 }
-    );
+    const { stdout } = await pending;
     const path = stdout.trim().replace(/\/$/, "");
     if (!path) return NextResponse.json({ cancelled: true });
     return NextResponse.json({ path });
   } catch (err: unknown) {
     const msg = (err as Error).message ?? "";
-    if (msg.includes("User canceled") || msg.includes("user canceled")) {
+    const e = err as { killed?: boolean; signal?: string | null };
+    // A killed child is /api/fs/native-pick/cancel dismissing the dialog for
+    // a remote browser — a cancel, not a failure.
+    if (msg.includes("User canceled") || msg.includes("user canceled") || e.killed || e.signal) {
       return NextResponse.json({ cancelled: true });
     }
     return NextResponse.json({ error: msg }, { status: 500 });
+  } finally {
+    untrackNativePick(pending.child);
   }
 }

--- a/dashboard/src/components/AddFolder.tsx
+++ b/dashboard/src/components/AddFolder.tsx
@@ -380,6 +380,7 @@ export function AddFolder({
 
   const { prefix } = useProject();
   const [pickerOpen, setPickerOpen] = useState(false);
+  const [nativePicking, setNativePicking] = useState(false);
   const [inspecting, setInspecting] = useState(false);
   const [inspectError, setInspectError] = useState("");
   const [result, setResult] = useState<Inspect | null>(null);
@@ -426,10 +427,12 @@ export function AddFolder({
 
   async function openNativePicker() {
     setInspecting(true);
+    setNativePicking(true);
     setInspectError("");
     try {
       const res = await fetch(prefix("/api/fs/pick-folder"), { method: "POST" });
       const json = await res.json() as { path?: string; cancelled?: boolean; error?: string };
+      setNativePicking(false);
       if (json.cancelled) {
         setInspecting(false);
         return;
@@ -445,11 +448,20 @@ export function AddFolder({
         return;
       }
     } catch {
+      setNativePicking(false);
       setInspecting(false);
       setPickerOpen(true);
       return;
     }
     setInspecting(false);
+  }
+
+  // The native dialog opened on the SERVER's screen — through a tunnel or
+  // ssh -L that isn't the user's screen, and the network can't tell us.
+  // Escape hatch: dismiss the server-side dialog, browse in-page instead.
+  function browseInstead() {
+    setPickerOpen(true);
+    void fetch(prefix("/api/fs/native-pick/cancel"), { method: "POST" }).catch(() => {});
   }
 
   async function runAdd(sources: AddPayload[]) {
@@ -488,6 +500,18 @@ export function AddFolder({
       >
         {inspecting ? "Inspecting..." : "Choose folder…"}
       </button>
+
+      {nativePicking && !pickerOpen && (
+        <p style={{ margin: "8px 0 0", fontSize: 12, color: "var(--text-muted)", lineHeight: 1.5 }}>
+          A Finder window opened on the machine running Flow.{" "}
+          <button
+            onClick={browseInstead}
+            style={{ background: "none", border: "none", padding: 0, fontSize: 12, color: "var(--ink)", textDecoration: "underline", cursor: "pointer" }}
+          >
+            Don&apos;t see it? Browse from here instead
+          </button>
+        </p>
+      )}
 
       {inspectError && <ErrorBox message={inspectError} />}
 

--- a/dashboard/src/components/CodingToolsPanel.tsx
+++ b/dashboard/src/components/CodingToolsPanel.tsx
@@ -59,6 +59,7 @@ export function CodingToolsPanel() {
   const [msg, setMsg] = useState("");
   const [busy, setBusy] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
+  const [nativePending, setNativePending] = useState(false);
   const [pendingPath, setPendingPath] = useState<string | null>(null);
   const [chosen, setChosen] = useState<Set<string>>(new Set());
   const [openRepo, setOpenRepo] = useState<string | null>(null);
@@ -88,23 +89,31 @@ export function CodingToolsPanel() {
   // real paths from their own pickers); in-page browser as the fallback.
   const pickFolder = async () => {
     setBusy(true);
+    setNativePending(true);
     try {
       const res = await fetch(prefix("/api/fs/native-pick"), { method: "POST" });
       const json = (await res.json()) as { path?: string; canceled?: boolean; unsupported?: boolean };
       if (json.path) {
         openConfirm(json.path);
-        setBusy(false);
         return;
       }
-      if (json.canceled) {
-        setBusy(false);
-        return;
-      }
+      if (json.canceled) return;
+      setPickerOpen(true);
     } catch {
-      /* fall through to in-page picker */
+      setPickerOpen(true);
+    } finally {
+      setNativePending(false);
+      setBusy(false);
     }
-    setBusy(false);
+  };
+
+  // The dialog opened on the SERVER's screen — if the user is reaching this
+  // dashboard through a tunnel or ssh -L, that screen isn't theirs and we
+  // can't tell from the network. Escape hatch: dismiss the server-side dialog
+  // and browse the server's filesystem in-page instead.
+  const browseInstead = () => {
     setPickerOpen(true);
+    void fetch(prefix("/api/fs/native-pick/cancel"), { method: "POST" }).catch(() => {});
   };
 
   const connect = async () => {
@@ -189,6 +198,14 @@ export function CodingToolsPanel() {
         >
           {busy ? "Choosing…" : "+ Connect a workspace"}
         </button>
+        {nativePending && !pickerOpen && (
+          <div className="text-[11px] text-ink/50 leading-snug text-center">
+            A Finder window opened on the machine running Flow.{" "}
+            <button className="underline hover:text-ink" onClick={browseInstead}>
+              Don&apos;t see it? Browse from here instead
+            </button>
+          </div>
+        )}
         <div className="flex items-center gap-2 text-[11px] text-ink/45">
           <span className="h-px bg-line flex-1" />
           or, in any terminal

--- a/dashboard/src/lib/nativePick.ts
+++ b/dashboard/src/lib/nativePick.ts
@@ -1,0 +1,34 @@
+// At most one native folder dialog can sit on the server's screen at a time.
+// The pick routes register their osascript child here so that
+// /api/fs/native-pick/cancel can dismiss it — the escape hatch for a browser
+// that turns out NOT to be on the machine running Flow (a tunnel or ssh -L
+// makes remote access network-indistinguishable from same-machine, so the
+// dialog can open on a screen the user isn't looking at). Kept on globalThis
+// because the pick and cancel route modules are bundled separately and must
+// share one slot.
+import type { ChildProcess } from "node:child_process";
+
+const slot = globalThis as typeof globalThis & {
+  __flowNativePick?: ChildProcess | null;
+};
+
+/** Register the child hosting the currently visible dialog. */
+export function trackNativePick(child: ChildProcess): void {
+  slot.__flowNativePick = child;
+}
+
+/** Clear the slot when a pick settles — only if it still owns the slot
+ * (a superseding pick may have replaced it before its callback ran). */
+export function untrackNativePick(child: ChildProcess): void {
+  if (slot.__flowNativePick === child) slot.__flowNativePick = null;
+}
+
+/** Dismiss the pending dialog, if any. Returns whether one was pending.
+ * The killed child's pick request then resolves as a cancel. */
+export function cancelNativePick(): boolean {
+  const child = slot.__flowNativePick;
+  slot.__flowNativePick = null;
+  if (!child || child.exitCode !== null || child.signalCode !== null) return false;
+  child.kill();
+  return true;
+}


### PR DESCRIPTION
## Problem

The native folder pick routes (`/api/fs/native-pick`, `/api/fs/pick-folder`) open a Finder dialog **on the machine running the dashboard server**. A browser reaching the dashboard through a tunnel (ngrok/cloudflared) or `ssh -L` is network-indistinguishable from same-machine access, so the dialog can open on a screen the user can't see — the flow dead-ends until the osascript timeout (5 min / 2 min).

## Change

**Escape hatch UI** — while a native pick is pending, both picker surfaces (CodingToolsPanel "+ Connect a workspace" and AddFolder "Choose folder…") show:

> A Finder window opened on the machine running Flow. *Don't see it? Browse from here instead*

Clicking it immediately opens the in-page `FolderPickerDialog` (which browses the **server's** filesystem — the correct one, since work folders live where the orchestrator runs) and dismisses the server-side dialog in the background.

**`POST /api/fs/native-pick/cancel`** (new) — kills the pending osascript child so the dialog doesn't linger on the remote screen. The child is registered in a `globalThis` slot (`lib/nativePick.ts`) shared by the pick and cancel route bundles.

**Pick route hardening** — both pick routes now: map a killed child (`err.killed`/`err.signal`) to a cancel rather than a 500, and dismiss any already-pending dialog before opening a new one, so dialogs never stack when the user retries from another tab.

## Verification

- `tsc --noEmit` clean; eslint findings on the touched files are all pre-existing on `dev`.
- Core mechanism tested directly: spawning an osascript `choose folder` child and killing it dismisses the on-screen dialog and yields `{killed: true, signal: SIGTERM}`, which both routes now translate to cancelled.