### PR TITLE
dashboard: remember last-used kickoff config (engine, folder, model/mode)

### DIFF
--- a/dashboard/src/components/AgentTaskComposer.tsx
+++ b/dashboard/src/components/AgentTaskComposer.tsx
@@ -13,6 +13,7 @@ import {
   type AgentModes,
   type ConfigOption,
 } from "@/lib/acpConfig";
+import { loadKickoffPrefs, rememberKickoff } from "@/lib/kickoffPrefs";
 
 export interface Attachment {
   name: string;
@@ -82,7 +83,7 @@ export function AgentTaskComposer({
   onClearWorktreeTarget,
 }: AgentTaskComposerProps) {
   const router = useRouter();
-  const { prefix } = useProject();
+  const { project, prefix } = useProject();
 
   const [agents, setAgents] = useState<DetectedAgent[]>([]);
   const [repos, setRepos] = useState<RepoOption[]>([]);
@@ -144,11 +145,23 @@ export function AgentTaskComposer({
       const folders: WorkFolder[] = data.workFolders ?? [];
       setWorkFolders(folders);
 
-      const defaultBackend = detected.find((x: DetectedAgent) => x.installed)?.id || "";
+      // Last-used choices win over positional defaults — an engine you launched
+      // with yesterday beats "first installed", the folder you launched in
+      // beats "first registered". Falls back when the remembered one is gone.
+      const prefs = loadKickoffPrefs(project);
+      const rememberedBackend = detected.find(
+        (x: DetectedAgent) => x.id === prefs.backend && x.installed
+      )?.id;
+      const defaultBackend =
+        rememberedBackend || detected.find((x: DetectedAgent) => x.installed)?.id || "";
       setBackend((prev) => prev || defaultBackend);
 
       if (!workFolder) {
-        if (folders.length > 0) {
+        const rememberedFolder = folders.find((f) => f.path === prefs.workFolder);
+        if (rememberedFolder) {
+          setWorkFolder(rememberedFolder.path);
+          setRepo(rememberedFolder.repo || allRepos[0]?.name || "default");
+        } else if (folders.length > 0) {
           setWorkFolder(folders[0].path);
           setRepo(folders[0].repo || allRepos[0]?.name || "default");
         } else {
@@ -164,7 +177,7 @@ export function AgentTaskComposer({
     } catch {
       // swallow
     }
-  }, [prefix, workFolder]);
+  }, [prefix, project, workFolder]);
 
   useEffect(() => {
     refresh();
@@ -195,8 +208,27 @@ export function AgentTaskComposer({
         for (const o of opts) {
           if (o.currentValue !== undefined) seed[o.id] = o.currentValue;
         }
-        setConfigValues(seed);
-        setModeId(m?.currentModeId);
+        // Overlay what this engine last launched with — but only options the
+        // agent still advertises, with still-valid select values, and only
+        // where it differs from the agent's own default (equal values would
+        // just be redundant explicit config on session create).
+        const saved = loadKickoffPrefs(project).byBackend?.[backend];
+        const overlay: Record<string, string | boolean> = {};
+        for (const o of opts) {
+          const v = saved?.config?.[o.id];
+          if (v === undefined || v === o.currentValue) continue;
+          if (o.options && o.options.length > 0 && !o.options.some((s) => s.value === v)) {
+            continue;
+          }
+          overlay[o.id] = v;
+        }
+        setConfigValues({ ...seed, ...overlay });
+        setConfig(overlay);
+        const savedMode = m?.availableModes?.some((x) => x.id === saved?.modeId)
+          ? saved?.modeId
+          : undefined;
+        setModeId(savedMode ?? m?.currentModeId);
+        setModeChanged(Boolean(savedMode && savedMode !== m?.currentModeId));
       })
       .catch(() => {
         /* leave controls empty — the session page still shows them live */
@@ -207,7 +239,7 @@ export function AgentTaskComposer({
     return () => {
       cancelled = true;
     };
-  }, [backend, prefix]);
+  }, [backend, prefix, project]);
 
   const handleConfigChange = useCallback((configId: string, value: string | boolean) => {
     setConfigValues((v) => ({ ...v, [configId]: value }));
@@ -357,6 +389,15 @@ export function AgentTaskComposer({
         setCollision(data.active);
         return;
       }
+
+      // The launch succeeded — remember every choice it was made with so the
+      // next kickoff starts from here instead of the hardcoded defaults.
+      rememberKickoff(project, {
+        backend,
+        workFolder: worktreeTarget ? undefined : workFolder,
+        config,
+        modeId,
+      });
 
       setPrompt("");
       setAttachments([]);

--- a/dashboard/src/lib/kickoffPrefs.ts
+++ b/dashboard/src/lib/kickoffPrefs.ts
@@ -1,0 +1,71 @@
+// Remembered kickoff configuration — the composer's answer to "I always pick
+// the same model/mode/folder, stop resetting me to the agent defaults".
+// Last-used wins: every successful session start records the choices made
+// (engine, work folder, and per-engine config/mode), and the next composer
+// mount seeds from them. Values are validated against what the agent
+// currently advertises before being applied, so a stale model or mode id
+// silently falls back to the agent's own default.
+//
+// Stored client-side in localStorage, keyed per project — kickoff choices are
+// a per-person, per-browser concern, same as the flow_last_project cookie.
+
+export interface BackendKickoffPrefs {
+  /** Explicit config values (model selector, thought toggles) last launched with. */
+  config?: Record<string, string | boolean>;
+  /** Mode id last launched with. */
+  modeId?: string;
+}
+
+export interface KickoffPrefs {
+  /** Last-used engine id (claude/codex/opencode). */
+  backend?: string;
+  /** Last-used work folder path. */
+  workFolder?: string;
+  /** Per-engine config memory — switching engines keeps each one's choices. */
+  byBackend?: Record<string, BackendKickoffPrefs>;
+}
+
+function storageKey(project: string | null): string {
+  return `flow.kickoff.${project ?? "@none"}`;
+}
+
+export function loadKickoffPrefs(project: string | null): KickoffPrefs {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(storageKey(project));
+    const parsed = raw ? (JSON.parse(raw) as unknown) : null;
+    return parsed && typeof parsed === "object" ? (parsed as KickoffPrefs) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function rememberKickoff(
+  project: string | null,
+  used: {
+    backend: string;
+    workFolder?: string;
+    config?: Record<string, string | boolean>;
+    modeId?: string;
+  }
+): void {
+  if (typeof window === "undefined" || !used.backend) return;
+  try {
+    const prefs = loadKickoffPrefs(project);
+    prefs.backend = used.backend;
+    if (used.workFolder) prefs.workFolder = used.workFolder;
+    prefs.byBackend = {
+      ...(prefs.byBackend ?? {}),
+      [used.backend]: {
+        // An empty config means "launched on agent defaults" — store nothing
+        // so a deliberate revert to defaults is also remembered.
+        config:
+          used.config && Object.keys(used.config).length > 0 ? used.config : undefined,
+        modeId: used.modeId,
+      },
+    };
+    window.localStorage.setItem(storageKey(project), JSON.stringify(prefs));
+  } catch {
+    // Best-effort — blocked or full storage must never break kickoff.
+  }
+}


### PR DESCRIPTION
## Problem

The agent-task composer resets to hardcoded defaults on every mount: first installed engine, first registered work folder, and whatever the agent advertises as current model/mode. Repeatedly picking the same setup (e.g. **Auto mode on Fable**) means re-picking it on every single kickoff — it always comes back as Manual/default.

## Change

- **New `dashboard/src/lib/kickoffPrefs.ts`** — localStorage-backed store of last-used kickoff choices, keyed per project. Records engine, work folder, and per-engine config (model/mode/effort) + modeId on every successful session start. Per-engine, so Claude/Codex/OpenCode each keep their own remembered setup.
- **`AgentTaskComposer.tsx`** — three seeding points now prefer remembered values over positional defaults:
  - engine: last-used wins over first-installed (falls back if uninstalled)
  - work folder: last-launched wins over first-registered (falls back if unregistered)
  - config/mode: overlaid onto the probed agent options, validated against what the agent currently advertises — stale model ids or removed modes silently fall back to the agent default. Overlaid values are put into the explicit `config`/`modeId` sent on session create, so the session actually starts with them.

Last-used-wins (not frequency counting): converges to the same result for a stable habit, adapts instantly on deliberate change, and remembers a revert-to-defaults as "no overrides".

## Verification

Ran the changed code on a dev server against the live orchestrator: with recorded prefs, the composer opens with the remembered folder, remembered model (Sonnet shown instead of advertised Fable default), Auto mode icon instead of Manual, and the remembered engine chip selected; with no/invalid prefs it behaves exactly as before. `tsc --noEmit` exits clean on this branch; the 4 eslint findings in the composer pre-date this change (present on `dev` HEAD).