### PR TITLE
flow up: ss fallback for port listener discovery — lsof can be blind

### DIFF
--- a/bin/flow.mjs
+++ b/bin/flow.mjs
@@ -296,25 +296,45 @@ function ensureDashboardBuild() {
   return true; // rebuilt — callers must restart running dashboards (shared .next)
 }
 
+// PIDs listening on a TCP port, from two sources merged. lsof alone is not
+// enough: on a live EC2 (2026-09-03) a long-lived next-server was invisible
+// to lsof — even under sudo — while `ss` (netlink) saw it. That blindness
+// made a self-update believe :7600 was free, kill nothing, and strand the
+// stale dashboard while its freshly-built replacement died on EADDRINUSE.
+// ss ships with iproute2 on Linux and names pids for the caller's own
+// sockets without root — exactly the case that matters (flow kills its own
+// services). macOS has no ss; lsof has not shown this blindness there.
+function portPids(port) {
+  const pids = new Set();
+  try {
+    const out = (spawnSync("lsof", ["-ti", `tcp:${port}`, "-sTCP:LISTEN"], { encoding: "utf8" }).stdout ?? "").trim();
+    for (const p of out.split("\n").filter(Boolean)) pids.add(Number(p));
+  } catch { /* lsof missing */ }
+  if (process.platform === "linux") {
+    try {
+      const out = (spawnSync("ss", ["-tlnp"], { encoding: "utf8" }).stdout ?? "");
+      for (const line of out.split("\n")) {
+        // Match the local-address column (":7600 "); LISTEN rows carry no
+        // real peer ports, so the peer column can't false-positive.
+        if (!line.includes(`:${port} `)) continue;
+        for (const m of line.matchAll(/pid=(\d+)/g)) pids.add(Number(m[1]));
+      }
+    } catch { /* ss missing */ }
+  }
+  return [...pids].filter((p) => Number.isFinite(p) && p > 0);
+}
+
 // Is anything listening on a TCP port? Deterministic (unlike a health probe
 // that can flake and trick us into starting a second process on a used port).
 function portInUse(port) {
-  try {
-    const out = (spawnSync("lsof", ["-ti", `tcp:${port}`, "-sTCP:LISTEN"], { encoding: "utf8" }).stdout ?? "").trim();
-    return out.length > 0;
-  } catch {
-    return false;
-  }
+  return portPids(port).length > 0;
 }
 
 // Kill whatever holds a TCP port (best-effort).
 function killPort(port) {
-  try {
-    const out = (spawnSync("lsof", ["-ti", `tcp:${port}`, "-sTCP:LISTEN"], { encoding: "utf8" }).stdout ?? "").trim();
-    for (const p of out.split("\n").filter(Boolean)) {
-      try { process.kill(Number(p), "SIGKILL"); } catch { /* gone */ }
-    }
-  } catch { /* lsof missing */ }
+  for (const p of portPids(port)) {
+    try { process.kill(p, "SIGKILL"); } catch { /* gone */ }
+  }
 }
 
 // ── Deployment-level state (data/): auth store + the singleton dashboard ────


### PR DESCRIPTION
## Bug

Auto-update on the olostep EC2 left the dashboard on a 4-day-old build. The update pulled and rebuilt correctly, but `flow up`'s kill-the-port-first step found nothing on :7600 — **lsof could not see the long-lived next-server's socket at all (even under sudo), while `ss` (netlink) saw it fine**. So the stale dashboard survived, and the freshly built one died instantly on `EADDRINUSE`. Both `portInUse` and `killPort` trusted lsof alone, so the same blindness could also double-start services.

## Fix

New `portPids(port)` merges two sources: lsof (as before) plus `ss -tlnp` parsing on Linux. ss ships with iproute2 and names pids for the caller's own sockets without root — exactly the case that matters, since flow kills its own services. `portInUse` and `killPort` both use it.

Verified on the affected host: `lsof pids: []` vs `merged pids: [1063834]` for the healthy running dashboard — the blindness is chronic there, so every future update would have failed the same way without this.

## Recovery performed on the box

Killed the stale pid, re-ran `flow up` — dashboard now serves the current build (verified via ss + dashboard.json + HTTP 200).