### PR TITLE
Fix Flow MCP injection in Codex agent sessions

### DIFF
--- a/orchestrator/package.json
+++ b/orchestrator/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts",
-"test": "node --import tsx/esm --test test/fake-opencode.ts test/orchestrator.test.ts test/adapters.test.ts test/outbox-approve.test.ts test/llmlog.test.ts test/smoke.ts test/notify.test.ts test/pollers.test.ts test/poller.test.ts test/settings.test.ts test/sources.test.ts test/agent-diff.test.ts test/worktrees.test.ts test/memory.test.ts test/llm.test.ts test/indexer-runtime.test.ts test/index-queue.test.ts test/change-branch.test.ts test/repo-removed.test.ts test/index-incremental.test.ts test/work-folders.test.ts test/ingest.test.ts test/flow-hook.test.ts test/session-search.test.ts test/telemetry.test.ts test/slack-agent.test.ts",
+"test": "node --import tsx/esm --test test/fake-opencode.ts test/orchestrator.test.ts test/adapters.test.ts test/outbox-approve.test.ts test/llmlog.test.ts test/smoke.ts test/notify.test.ts test/pollers.test.ts test/poller.test.ts test/settings.test.ts test/sources.test.ts test/agent-diff.test.ts test/agent-runtime.test.ts test/worktrees.test.ts test/memory.test.ts test/llm.test.ts test/indexer-runtime.test.ts test/index-queue.test.ts test/change-branch.test.ts test/repo-removed.test.ts test/index-incremental.test.ts test/work-folders.test.ts test/ingest.test.ts test/flow-hook.test.ts test/session-search.test.ts test/telemetry.test.ts test/slack-agent.test.ts",
     "verify": "npm test",
     "verify:real": "tsx test/real-integrations.ts",
     "verify:session": "tsx test/real-session.ts"

--- a/orchestrator/src/agents/runtime.ts
+++ b/orchestrator/src/agents/runtime.ts
@@ -857,7 +857,11 @@ async function startConnectionAttempt(backend: AgentBackend, attempt: SpawnAttem
 
   const proc = spawn(attempt.command, attempt.args, {
     stdio: ["pipe", "pipe", "pipe"],
-    env: attempt.env,
+    // codex-acp otherwise drops session MCPs whose names exist in repo/user
+    // config, losing Flow's project/session context (or using a stale wrapper).
+    env: backend === "codex"
+      ? { ...attempt.env, DISABLE_MCP_CONFIG_FILTERING: "true" }
+      : attempt.env,
   });
   proc.stderr.on("data", (chunk: Buffer) => {
     try {

--- a/orchestrator/test/agent-runtime.test.ts
+++ b/orchestrator/test/agent-runtime.test.ts
@@ -1,0 +1,77 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import childProcess from "node:child_process";
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+import { PassThrough } from "node:stream";
+
+test("Codex adapter launch preserves injected MCPs without changing other backends", async (t) => {
+  const dir = mkdtempSync(join(tmpdir(), "flow-agent-runtime-"));
+  const env = {
+    DB_PATH: join(dir, "flow.db"),
+    FLOW_SESSION_SEARCH: "0",
+    CODEX_PATH: process.execPath,
+    CLAUDE_CODE_EXECUTABLE: process.execPath,
+    DISABLE_MCP_CONFIG_FILTERING: "false",
+  };
+  const saved = Object.fromEntries(Object.keys(env).map((key) => [key, process.env[key]]));
+  Object.assign(process.env, env);
+  t.after(() => {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const launches: NodeJS.ProcessEnv[] = [];
+  // Exercise the real runtime launch and ACP handshake without starting an agent.
+  t.mock.method(childProcess, "spawn", (_command: string, _args: string[], options: childProcess.SpawnOptions) => {
+    launches.push({ ...options.env });
+    const proc = Object.assign(new EventEmitter(), {
+      stdin: new PassThrough(),
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      exitCode: null as number | null,
+    });
+    const input = createInterface({ input: proc.stdin });
+    input.on("line", (line) => {
+      const request = JSON.parse(line);
+      const result = request.method === "initialize"
+        ? { protocolVersion: 1, agentCapabilities: {} }
+        : request.method === "session/new"
+          ? { sessionId: "probe", configOptions: [] }
+          : {};
+      proc.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: request.id, result }) + "\n");
+    });
+    t.after(() => {
+      input.close();
+      proc.stdin.end();
+      proc.stdout.end();
+      proc.stderr.end();
+      proc.exitCode = 0;
+      proc.emit("exit", 0);
+    });
+    return proc;
+  });
+  syncBuiltinESMExports();
+  t.after(() => {
+    t.mock.restoreAll();
+    syncBuiltinESMExports();
+  });
+
+  const { probeAgentOptions } = await import("../src/agents/runtime.js");
+  for (const backend of ["codex", "claude"] as const) {
+    const result = await probeAgentOptions(backend);
+    assert.ok(!("error" in result), JSON.stringify(result));
+  }
+  assert.equal(launches.length, 2);
+  assert.equal(launches[0].DISABLE_MCP_CONFIG_FILTERING, "true");
+  assert.equal(launches[0].CODEX_PATH, process.execPath);
+  assert.equal(launches[1].DISABLE_MCP_CONFIG_FILTERING, "false");
+  assert.equal(process.env.DISABLE_MCP_CONFIG_FILTERING, "false");
+});


### PR DESCRIPTION
Flow-managed Codex sessions can lose `flow-graph` when the checkout already defines an MCP with that name. codex-acp filters out the injected server in favor of the persisted configuration, which may point to a stale registration and lacks Flow's session context.

Set `DISABLE_MCP_CONFIG_FILTERING=true` only when launching the Codex adapter so session injection takes precedence. The shared launch path covers new and resumed sessions, including explicit, local, and bundled CLI selection. Other backends, persisted configuration, and approval policies are unchanged. The flag applies to every injected MCP; Flow currently injects only `flow-graph`.

Validation:
- Added a launch/ACP-handshake regression test that fails before the fix and passes afterward; verifies the Codex subprocess setting and isolation from Claude and the parent environment.
- All 315 orchestrator tests pass.
- Checked installed codex-acp 1.1.0 configuration generation for new/load/resume paths with mocked Codex RPCs: reproduces the collision without the flag and retains injection with it. An isolated real Codex configuration merge preserves an unrelated MCP's command, arguments, and environment.
- TypeScript reports the same 10 pre-existing errors as `main` in corpus.ts, index.ts, pollers/engine.ts, and memory.test.ts; no new errors.

Takes effect on the next adapter launch. Running services were not restarted; no full model turn was used for verification.
