### PR TITLE
Add GitHub Copilot CLI and VS Code integration installation

### DIFF
--- a/bin/flow.mjs
+++ b/bin/flow.mjs
@@ -1368,6 +1368,7 @@ async function cmdSetup(rest) {
     Codex        → run ${c.cyan("/hooks")} once in codex here and trust the flow hooks.
     Cursor       → Settings → MCP: approve "flow-graph" when prompted.
     Gemini CLI   → shows "hooks will be executed" notice on first run.
+    Copilot      → trust this folder and approve "flow-graph" in Copilot CLI / VS Code.
 `);
 }
 

--- a/bin/harness/flow-hook.mjs
+++ b/bin/harness/flow-hook.mjs
@@ -14,7 +14,7 @@
 //
 // Zero dependencies; stock Node 22.
 
-import { readFileSync, appendFileSync, mkdirSync, statSync, writeFileSync } from "node:fs";
+import { readFileSync, appendFileSync, mkdirSync, statSync, writeFileSync, openSync, readSync, fstatSync, closeSync, constants } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -86,6 +86,45 @@ function redactDeep(v) {
   return v;
 }
 
+// Copilot CLI and VS Code Stop hooks carry a path, not the final answer.
+// Read only a bounded tail of that supplied JSONL file; never scan session
+// directories or upload tool output/reasoning. Unknown formats degrade quietly.
+function copilotTranscriptLines(payload, tail = true) {
+  const path = payload.transcript_path ?? payload.transcriptPath;
+  if (typeof path !== "string" || !path) return [];
+  let fd;
+  try {
+    fd = openSync(path, constants.O_RDONLY | constants.O_NONBLOCK);
+    const stat = fstatSync(fd);
+    if (!stat.isFile()) return [];
+    const length = Math.min(stat.size, tail ? 256 * 1024 : 8192);
+    const offset = tail ? stat.size - length : 0;
+    const buf = Buffer.alloc(length);
+    const count = readSync(fd, buf, 0, length, offset);
+    const lines = buf.subarray(0, count).toString("utf8").split("\n");
+    if (offset) lines.shift(); // first line may start mid-record
+    return lines.flatMap((line) => {
+      try { return [JSON.parse(line)]; } catch { return []; }
+    });
+  } catch {
+    return [];
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+}
+
+function copilotAnswer(payload) {
+  let answer = null;
+  for (const entry of copilotTranscriptLines(payload)) {
+    if (!entry || entry.agentId || entry.data?.parentToolCallId) continue;
+    if (entry.type === "user.message") answer = null;
+    if (entry.type === "assistant.message" && typeof entry.data?.content === "string") {
+      answer = entry.data.content.trim() ? entry.data.content.slice(-16000) : null;
+    }
+  }
+  return answer;
+}
+
 // ---------------------------------------------------------------------------
 async function main() {
   // Sessions Flow itself runs are already captured by the ACP runtime —
@@ -101,6 +140,12 @@ async function main() {
     return;
   }
 
+  // Copilot also executes .claude/settings.json hooks. Its session.start
+  // transcript header distinguishes these from actual Claude sessions.
+  if (args.harness === "claude" && copilotTranscriptLines(payload, false).some(
+    (entry) => entry?.type === "session.start" && typeof entry.data?.sessionId === "string"
+  )) return;
+
   // The binding (--project) resolves to a machine-level config entry written
   // by `flow setup` — never resolved from the payload at capture time.
   const remoteName = args.remote ?? "local";
@@ -113,6 +158,13 @@ async function main() {
   if (!remote?.url) {
     logLine(`no binding for project "${args.project}" / remote "${remoteName}" in ~/.flow/config.json, dropped`);
     return;
+  }
+
+  if (args.harness === "copilot" && ["Stop", "agentStop"].includes(payload?.hook_event_name ?? payload?.hookEventName)) {
+    if (!payload.last_assistant_message) {
+      const answer = copilotAnswer(payload);
+      if (answer) payload.last_assistant_message = answer;
+    }
   }
 
   const body = JSON.stringify({

--- a/bin/lib/materialize.mjs
+++ b/bin/lib/materialize.mjs
@@ -22,10 +22,12 @@ import {
   copyFileSync,
   rmSync,
   rmdirSync,
+  readdirSync,
 } from "node:fs";
 import { homedir } from "node:os";
 import { join, dirname } from "node:path";
 import { execFileSync } from "node:child_process";
+import { parse as parseJsonc, modify, applyEdits } from "jsonc-parser";
 
 export const FLOW_DIR = join(homedir(), ".flow");
 export const SHIM_PATH = join(FLOW_DIR, "bin", "flow-hook");
@@ -56,6 +58,24 @@ function readJson(p, fallback) {
 function writeJson(p, obj) {
   mkdirSync(dirname(p), { recursive: true });
   writeFileSync(p, JSON.stringify(obj, null, 2) + "\n", "utf-8");
+}
+
+// Copilot's VS Code config accepts comments and trailing commas. Preserve
+// those and unrelated settings; malformed config must never be overwritten.
+function editCopilotJson(file, edit) {
+  let text = existsSync(file) ? readFileSync(file, "utf-8") : "{}\n";
+  const errors = [];
+  const value = parseJsonc(text, errors, { allowTrailingComma: true });
+  if (errors.length || !value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Invalid Copilot configuration: ${file}`);
+  }
+  for (const [path, next] of edit(value)) {
+    text = applyEdits(text, modify(text, path, next, {
+      formattingOptions: { insertSpaces: true, tabSize: 2, eol: "\n" },
+    }));
+  }
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, text, "utf-8");
 }
 
 // Splice a marker-delimited block into a text file: replace ours if present,
@@ -91,7 +111,7 @@ function unspliceBlock(file, begin = BLOCK_BEGIN, end = BLOCK_END) {
 
 // Our entries are recognizable forever by the shim path inside the command.
 function isFlowHook(entry) {
-  return JSON.stringify(entry).includes(".flow/bin/flow-hook");
+  return JSON.stringify(entry).replace(/\\+/g, "/").includes(".flow/bin/flow-hook");
 }
 
 // events: [{name, extra?}] — extra merges into the hook object (e.g. Gemini's
@@ -618,6 +638,44 @@ function renderAntigravity(ctx) {
   return { owned: [], merged: [".agents/hooks.json", ".agents/mcp_config.json"] };
 }
 
+const COPILOT_JSON_FILES = [".github/hooks/flow.json", ".github/mcp.json", ".vscode/mcp.json"];
+
+function renderCopilot(ctx) {
+  const { repoDir, project, repo } = ctx;
+  const argv = [NODE_BIN, SHIM_PATH, "--harness", "copilot", "--project", project, "--repo", repo, "--remote", "local"];
+  const command = process.platform === "win32"
+    ? "& " + argv.map((arg) => `'${arg.replaceAll("'", "''")}'`).join(" ")
+    : argv.map((arg) => `'${arg.replaceAll("'", "'\\''")}'`).join(" ");
+  // PascalCase selects the VS Code-compatible payload dialect in Copilot CLI.
+  // SessionEnd is CLI-only; VS Code sessions are distilled by the idle sweep.
+  editCopilotJson(join(repoDir, COPILOT_JSON_FILES[0]), (file) => [
+    [["version"], 1],
+    ...HOOK_EVENTS.map(({ name }) => [["hooks", name], [
+      ...(file.hooks?.[name] ?? []).filter((entry) => !isFlowHook(entry)),
+      { type: "command", command, timeout: 5 },
+    ]]),
+  ]);
+
+  for (const rel of COPILOT_JSON_FILES.slice(1)) {
+    editCopilotJson(join(repoDir, rel), (file) => {
+      const key = rel.startsWith(".vscode") ? "servers" : "mcpServers";
+      // CLI also accepts a bare map of server names.
+      const path = key === "mcpServers" && !file.mcpServers && Object.keys(file).some((k) => k !== "$schema")
+        ? ["flow-graph"] : [key, "flow-graph"];
+      return [[path, { type: "stdio", command: NODE_BIN, args: [MCP_PATH, "--project", project, "--repo", repo] }]];
+    });
+  }
+
+  const skillPath = join(repoDir, ".github/skills/flow/SKILL.md");
+  mkdirSync(dirname(skillPath), { recursive: true });
+  writeFileSync(skillPath, skillMd(project), "utf-8");
+  spliceBlock(join(repoDir, ".github/copilot-instructions.md"), instructionBlock(project));
+  return {
+    owned: [".github/skills/flow/SKILL.md"],
+    merged: [...COPILOT_JSON_FILES, ".github/copilot-instructions.md"],
+  };
+}
+
 const RENDERERS = {
   claude: renderClaude,
   codex: renderCodex,
@@ -625,6 +683,7 @@ const RENDERERS = {
   gemini: renderGemini,
   cursor: renderCursor,
   antigravity: renderAntigravity,
+  copilot: renderCopilot,
 };
 
 export const ALL_HARNESSES = Object.keys(RENDERERS);
@@ -655,6 +714,12 @@ export function detectHarnesses() {
       existsSync("/Applications/Antigravity.app") ||
       existsSync("/Applications/Antigravity IDE.app") ||
       existsSync(join(home, ".gemini", "antigravity")),
+    copilot: () => onPath("copilot") || existsSync(process.env.COPILOT_HOME || join(home, ".copilot")) ||
+      [".vscode", ".vscode-insiders", ".vscode-server"].some((dir) => {
+        try {
+          return readdirSync(join(home, dir, "extensions")).some((name) => /^github\.copilot(?:-chat)?-/i.test(name));
+        } catch { return false; }
+      }),
   };
   return ALL_HARNESSES.filter((h) => {
     try {
@@ -715,6 +780,9 @@ const CANDIDATE_FILES = [
   ".cursor/hooks.json",
   ".cursor/mcp.json",
   ".cursor/rules/flow.mdc",
+  ...COPILOT_JSON_FILES,
+  ".github/skills/flow/SKILL.md",
+  ".github/copilot-instructions.md",
 ];
 const ORIGINAL_CAP = 256 * 1024;
 
@@ -793,8 +861,37 @@ export function removeRepo(repoDir) {
     ".agents/skills/flow/SKILL.md",
     ".opencode/plugins/flow.ts",
     ".cursor/rules/flow.mdc",
+    ".github/skills/flow/SKILL.md",
   ];
-  for (const rel of owned) rmSync(join(repoDir, rel), { force: true });
+  for (const rel of owned) {
+    if (rel === ".github/skills/flow/SKILL.md" && originals[rel]?.data) {
+      writeFileSync(join(repoDir, rel), Buffer.from(originals[rel].data, "base64"));
+    } else rmSync(join(repoDir, rel), { force: true });
+  }
+
+  for (const rel of COPILOT_JSON_FILES) {
+    if (entry && !entry.merged?.includes(rel)) continue;
+    const p = join(repoDir, rel);
+    if (!existsSync(p)) continue;
+    const original = originals[rel]?.data
+      ? parseJsonc(Buffer.from(originals[rel].data, "base64").toString("utf8"), [], { allowTrailingComma: true }) : {};
+    editCopilotJson(p, (file) => {
+      if (rel.endsWith("hooks/flow.json")) {
+        const hooks = removeFlowHooks(file.hooks);
+        return hooks ? [
+          [["hooks"], Object.keys(hooks).length || original.hooks ? hooks : undefined],
+          [["version"], original.version ?? (originals[rel]?.existed ? undefined : file.version)],
+        ] : [];
+      }
+      const key = rel.startsWith(".vscode") ? "servers" : "mcpServers";
+      if (file[key]?.["flow-graph"]) {
+        const servers = { ...file[key] };
+        delete servers["flow-graph"];
+        return Object.keys(servers).length || original[key] ? [[[key, "flow-graph"], undefined]] : [[[key], undefined]];
+      }
+      return file["flow-graph"] ? [[["flow-graph"], undefined]] : [];
+    });
+  }
 
   // Merged JSON files: strip our entries; marked text files: unsplice.
   for (const rel of [".claude/settings.json", ".gemini/settings.json"]) {
@@ -848,7 +945,7 @@ export function removeRepo(repoDir) {
     delete agHooks["flow-capture"];
     writeJson(agHooksPath, agHooks);
   }
-  for (const f of ["CLAUDE.md", "AGENTS.md", "GEMINI.md"]) unspliceBlock(join(repoDir, f));
+  for (const f of ["CLAUDE.md", "AGENTS.md", "GEMINI.md", ".github/copilot-instructions.md"]) unspliceBlock(join(repoDir, f));
   unspliceBlock(join(repoDir, ".codex", "config.toml"), TOML_BEGIN, TOML_END);
   setGitExclude(repoDir, [], true);
 
@@ -864,10 +961,10 @@ export function removeRepo(repoDir) {
       if ((j !== undefined && isEmptyShell(j)) || text.trim() === "") rmSync(p, { force: true });
     } else if (orig.data != null) {
       const originalBuf = Buffer.from(orig.data, "base64");
-      const now = readJson(p, undefined);
+      const now = COPILOT_JSON_FILES.includes(rel) ? parseJsonc(readFileSync(p, "utf-8"), [], { allowTrailingComma: true }) : readJson(p, undefined);
       const then = (() => {
         try {
-          return JSON.parse(originalBuf.toString("utf-8"));
+          return COPILOT_JSON_FILES.includes(rel) ? parseJsonc(originalBuf.toString("utf-8"), [], { allowTrailingComma: true }) : JSON.parse(originalBuf.toString("utf-8"));
         } catch {
           return undefined;
         }
@@ -878,7 +975,7 @@ export function removeRepo(repoDir) {
     }
   }
   // Empty scaffolding dirs left behind are noise — prune best-effort.
-  for (const dir of [".claude/skills/flow", ".claude/skills", ".claude", ".codex", ".agents/skills/flow", ".agents/skills", ".agents", ".opencode/plugins", ".opencode", ".gemini", ".cursor/rules", ".cursor"]) {
+  for (const dir of [".claude/skills/flow", ".claude/skills", ".claude", ".codex", ".agents/skills/flow", ".agents/skills", ".agents", ".opencode/plugins", ".opencode", ".gemini", ".cursor/rules", ".cursor", ".github/skills/flow", ".github/skills", ".github/hooks", ".github", ".vscode"]) {
     try {
       rmdirSync(join(repoDir, dir)); // only succeeds when empty
     } catch {

--- a/docs/harness-integrations.md
+++ b/docs/harness-integrations.md
@@ -4,6 +4,59 @@ _Research + design doc, 2026-08-05. Findings verified against official vendor do
 by parallel research agents; sources linked per section. Decisions in this doc were settled in
 discussion with Samyak and are also filed in Flow memory._
 
+## Copilot installation (2026-09-05)
+
+The materializer supports GitHub Copilot CLI and VS Code Copilot as the
+`copilot` harness. This installs Flow into the external coding tool; it does
+not add an ACP backend or an agent-picker option in Flow.
+
+Run `flow setup <project> --harness copilot` inside a checkout, or rerun
+`flow setup <project>` for automatic detection. Detection checks `copilot` on
+PATH, `COPILOT_HOME` / `~/.copilot`, and installed GitHub Copilot extensions in
+standard VS Code extension directories. `--all` includes Copilot too.
+
+| Artifact | Purpose |
+|---|---|
+| `.github/hooks/flow.json` | SessionStart, UserPromptSubmit, Stop, SessionEnd capture hooks |
+| `.github/mcp.json` | Copilot CLI project MCP registration (`mcpServers`) |
+| `.vscode/mcp.json` | VS Code MCP registration (`servers`) |
+| `.github/skills/flow/SKILL.md` | Flow memory skill |
+| `.github/copilot-instructions.md` | Managed instruction block |
+
+The CLI and VS Code use separate MCP configurations. PascalCase hook names
+select Copilot CLI's VS Code-compatible payload dialect. Stop supplies a
+transcript path; the shim reads at most the last 256 KiB of that JSONL file,
+extracts the latest parent assistant message, and redacts it before upload.
+Missing files and unknown records are ignored. Recognized Copilot transcript
+headers suppress inherited Claude hooks to avoid duplicate session capture.
+VS Code has no SessionEnd hook, so the existing idle distiller handles closure.
+
+Setup preserves existing MCP servers, hooks, instructions, and JSONC comments.
+Personal mode excludes the generated artifacts from git; `--share` exposes
+them, and `flow setup --remove` removes Flow's entries. Credentials continue
+to live in the machine's Flow config. Trust the folder and approve the
+`flow-graph` MCP server in each client; organization policies may restrict
+MCP or hooks. Remote VS Code extension hosts need Flow installed on that host.
+
+Validation covers setup/removal, JSONC preservation, transcript redaction,
+duplicate capture, and ingestion on Node 22. A live authenticated Copilot
+session was not available for verification. Transcript formats are not a
+stable vendor API. GitHub's hosted Copilot cloud agent requires separate
+sandbox setup, credentials, MCP configuration, and firewall access; the local
+installer does not provision that environment.
+
+Primary sources checked on 2026-09-05:
+
+- [Copilot CLI MCP configuration and project discovery](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-mcp-servers)
+- [Copilot hook configuration and payloads](https://docs.github.com/en/copilot/reference/hooks-reference)
+- [VS Code hooks](https://code.visualstudio.com/docs/agent-customization/hooks)
+- [VS Code transcript producer](https://github.com/microsoft/vscode-copilot-chat/blob/main/src/extension/chat/vscode-node/sessionTranscriptService.ts)
+- [Copilot CLI plugins](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference)
+
+Copilot also supports packaged plugins. Flow keeps its existing direct config
+installation approach, so no marketplace listing or plugin publication is
+required.
+
 ## 1. Goal & framing
 
 Flow today only captures transcripts of sessions **Flow itself runs** (ACP runtime →
@@ -52,7 +105,7 @@ Headline findings:
 | Codex (CLI/IDE/desktop app) | ✅ hooks **GA, on by default** (opt-out `[features] hooks=false`) + `transcript_path`; fire on all local surfaces incl. ChatGPT desktop app's Codex view; rollouts in `~/.codex/sessions/` | 🟡 hooks also run in Codex cloud ("wherever Codex runs") | ✅ MCP (stdio+HTTP+OAuth), skills (`.agents/skills`), AGENTS.md, MCP `instructions` field | ✅ `.codex/` (trust-gated) |
 | Cursor | ✅ hooks (`stop`/`afterAgentResponse`) + `transcript_path`, `workspace_roots`, `conversation_id`, `user_email` | 🟡 cloud agents run repo hooks in Cursor's cloud; v1 API streams transcripts | ✅ MCP (⚠️ ~40-tool cap), skills, rules, `sessionStart` `additional_context` injection | ✅ `.cursor/` (`hooks.json` needs `"version": 1`) |
 | VS Code Copilot | ✅ hooks (Preview) + `transcript_path`; also reads `.claude/settings.json` hooks | 🟡 Copilot coding agent runs repo `.github/hooks/` in cloud sandbox (egress unverified) | ✅ MCP (gallery+OAuth), copilot-instructions.md, AGENTS.md, skills, custom agents pinning `flow/*` | ✅ `.vscode/mcp.json`, `.github/hooks/` |
-| Copilot CLI | ✅ 14 hook events + `transcriptPath`; sessions in SQLite+JSONL under `~/.copilot/` | 🟡 "chronicle" syncs to GitHub cloud, no public read API | ✅ MCP via `~/.copilot/mcp-config.json` (shared with VS Code), skills | ✅ repo `.github/hooks/` |
+| Copilot CLI | ✅ lifecycle hooks + `transcriptPath`; sessions in SQLite+JSONL under `~/.copilot/` | 🟡 "chronicle" syncs to GitHub cloud, no public read API | ✅ MCP via `.github/mcp.json` or `~/.copilot/mcp-config.json`, skills; separate from VS Code config | ✅ repo `.github/hooks/` |
 | Gemini CLI | ✅ hooks (v0.26.0+, Jan 2026): every event has `transcript_path`+`cwd`; `AfterModel` carries full request/response; OTEL bonus channel | ❌ | ✅ MCP (OAuth), GEMINI.md/AGENTS.md, skills | ✅ `.gemini/settings.json` (trusted-folder gated) |
 | Antigravity | ✅ hooks (5 events) + `transcriptPath`+`workspacePaths`; brain dirs (`~/.gemini/antigravity*/brain/`) as fallback | ❌ | ✅ MCP (remote+OAuth), skills, AGENTS.md/rules | ✅ `.agents/` dir |
 | opencode | ✅ JS plugin: `session.idle` → `client.session.messages()` → POST; `worktree` provided | 🟡 `opencode serve` SSE `/event` streams everything (needs a running server) | ✅ remote MCP (OAuth+DCR), custom tools, skills (reads `.claude/skills`), AGENTS.md; `instructions` accepts remote URLs | ✅ `.opencode/` (weak trust model) |
@@ -144,8 +197,9 @@ Headline findings:
 - Coding agent (cloud): runs repo `.github/hooks/*.json` inside its sandbox (`transcriptPath`
   available; egress for POSTs unverified). MCP config lives in repo Settings (admin-only, no
   OAuth, `COPILOT_MCP_*` secrets). No public API for session logs.
-- Serve: MCP in VS Code (`.vscode/mcp.json` + user `~/.copilot/mcp-config.json` shared with
-  CLI; gallery; `code --add-mcp`; `vscode:mcp/install` deep links exist);
+- Serve: MCP in VS Code (`.vscode/mcp.json`, with a `servers` map; gallery;
+  `code --add-mcp`; `vscode:mcp/install` deep links exist). Copilot CLI separately
+  loads `.mcp.json`, `.github/mcp.json`, or user `~/.copilot/mcp-config.json`;
   `.github/copilot-instructions.md`; AGENTS.md; skills (`.github/skills`, also reads
   `.claude/skills` and `.agents/skills`); custom agents can pin `server/tool` in frontmatter.
 - Enterprise: MCP registry allowlists (VS Code enforces at runtime), `ChatMCP` device policy.
@@ -286,7 +340,7 @@ Per-tool rendering:
 | Tool | Files written | Atoms |
 |---|---|---|
 | Claude Code | `.claude/settings.json` hooks → shim; `.mcp.json`; `.claude/skills/flow/` | 1,2,3,4 |
-| VS Code + Copilot CLI | mostly inherited from Claude files; `~/.copilot/mcp-config.json`; instructions block | 2,4 (1,3 inherited) |
+| VS Code + Copilot CLI | `.github/hooks/flow.json`; separate `.github/mcp.json` and `.vscode/mcp.json`; `.github/skills/flow`; instructions block | 1,2,3,4 |
 | Codex | `.codex/hooks.json` + `[features] hooks`; `config.toml` MCP; `.agents/skills/flow/`; AGENTS.md block | 1,2,3,4 |
 | Cursor | `.cursor/hooks.json` (`"version":1`); `.cursor/mcp.json`; skill/rule | 1,2,3,4 |
 | Gemini CLI | `.gemini/settings.json` (hooks + mcpServers); GEMINI.md block; skills | 1,2,3,4 |

--- a/orchestrator/package.json
+++ b/orchestrator/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts",
-"test": "node --import tsx/esm --test test/fake-opencode.ts test/orchestrator.test.ts test/adapters.test.ts test/outbox-approve.test.ts test/llmlog.test.ts test/smoke.ts test/notify.test.ts test/pollers.test.ts test/poller.test.ts test/settings.test.ts test/sources.test.ts test/agent-diff.test.ts test/agent-runtime.test.ts test/worktrees.test.ts test/memory.test.ts test/llm.test.ts test/indexer-runtime.test.ts test/index-queue.test.ts test/change-branch.test.ts test/repo-removed.test.ts test/index-incremental.test.ts test/work-folders.test.ts test/ingest.test.ts test/flow-hook.test.ts test/session-search.test.ts test/telemetry.test.ts test/slack-agent.test.ts",
+    "test": "node --import tsx/esm --test test/fake-opencode.ts test/orchestrator.test.ts test/adapters.test.ts test/outbox-approve.test.ts test/llmlog.test.ts test/smoke.ts test/notify.test.ts test/pollers.test.ts test/poller.test.ts test/settings.test.ts test/sources.test.ts test/agent-diff.test.ts test/agent-runtime.test.ts test/worktrees.test.ts test/memory.test.ts test/llm.test.ts test/indexer-runtime.test.ts test/index-queue.test.ts test/change-branch.test.ts test/repo-removed.test.ts test/index-incremental.test.ts test/work-folders.test.ts test/ingest.test.ts test/flow-hook.test.ts test/materialize.test.mjs test/session-search.test.ts test/telemetry.test.ts test/slack-agent.test.ts",
     "verify": "npm test",
     "verify:real": "tsx test/real-integrations.ts",
     "verify:session": "tsx test/real-session.ts"

--- a/orchestrator/src/ingest/adapters.ts
+++ b/orchestrator/src/ingest/adapters.ts
@@ -87,7 +87,7 @@ function extractAssistant(p: Record<string, unknown>): string | null {
 const START_EVENTS = new Set(["SessionStart", "sessionStart"]);
 const END_EVENTS = new Set(["SessionEnd", "sessionEnd"]);
 // Turn-conclusion events that carry the assistant's final message.
-const STOP_EVENTS = new Set(["Stop", "stop", "afterAgentResponse", "AfterAgent"]);
+const STOP_EVENTS = new Set(["Stop", "stop", "agentStop", "afterAgentResponse", "AfterAgent"]);
 
 export function normalizeHook(
   harness: string,
@@ -105,7 +105,7 @@ export function normalizeHook(
     events.push(created(harness, repo, cwd));
   } else if (END_EVENTS.has(eventName)) {
     closed = true;
-  } else if (eventName === "UserPromptSubmit" || eventName === "beforeSubmitPrompt") {
+  } else if (eventName === "UserPromptSubmit" || eventName === "userPromptSubmitted" || eventName === "beforeSubmitPrompt") {
     const prompt = extractPrompt(payload);
     if (prompt) {
       events.push(userPrompt(prompt));

--- a/orchestrator/test/flow-hook.test.ts
+++ b/orchestrator/test/flow-hook.test.ts
@@ -116,6 +116,58 @@ describe("flow-hook shim", () => {
     assert.equal(received.length, count);
   });
 
+  test("Copilot Stop reads only the final parent response and redacts it before upload", async () => {
+    const transcript = join(home, "copilot-events.jsonl");
+    const entries = [
+      { type: "user.message", data: { content: "Fix the bug" } },
+      { type: "tool.execution_complete", data: { result: { content: "DO-NOT-UPLOAD-TOOL-OUTPUT" } } },
+      { type: "assistant.message", data: { content: "Fixed it. Token ghp_1234567890123456789012345", reasoningText: "DO-NOT-UPLOAD-REASONING" } },
+      { type: "assistant.message", agentId: "child", data: { content: "DO-NOT-UPLOAD-SUBAGENT" } },
+    ];
+    writeFileSync(transcript, entries.map((e) => JSON.stringify(e)).join("\n") + "\n{partial");
+    const payload = { session_id: "copilot-1", cwd: home, hook_event_name: "Stop", transcript_path: transcript };
+    const { code } = await runShim(["--harness", "copilot"], JSON.stringify(payload));
+    assert.equal(code, 0);
+    const event = received.at(-1)!.body.event as Record<string, string>;
+    assert.equal(event.last_assistant_message, "Fixed it. Token [redacted]");
+    assert.ok(!JSON.stringify(event).includes("DO-NOT-UPLOAD"));
+  });
+
+  test("Copilot's inherited Claude hook does not upload a second session", async () => {
+    const transcript = join(home, "copilot-inherited.jsonl");
+    writeFileSync(transcript, JSON.stringify({ type: "session.start", data: { sessionId: "copilot-shared" } }) + '\n');
+    const payload = { session_id: "copilot-shared", hook_event_name: "UserPromptSubmit", prompt: "Hello", transcript_path: transcript };
+    const count = received.length;
+    assert.equal((await runShim(["--harness", "claude"], JSON.stringify(payload))).code, 0);
+    assert.equal(received.length, count);
+    assert.equal((await runShim(["--harness", "copilot"], JSON.stringify(payload))).code, 0);
+    assert.equal(received.length, count + 1);
+  });
+
+  test("Copilot capture skips stale answers and tolerates missing or unknown transcripts", async () => {
+    const transcript = join(home, "copilot-stale.jsonl");
+    writeFileSync(transcript, [
+      { type: "assistant.message", data: { content: "Old answer" } },
+      { type: "user.message", data: { content: "New turn" } },
+    ].map((e) => JSON.stringify(e)).join("\n"));
+    for (const path of [transcript, join(home, "missing.jsonl"), home]) {
+      const payload = { sessionId: "copilot-2", hookEventName: "agentStop", transcriptPath: path };
+      assert.equal((await runShim(["--harness", "copilot"], JSON.stringify(payload))).code, 0);
+      assert.equal((received.at(-1)!.body.event as Record<string, unknown>).last_assistant_message, undefined);
+    }
+  });
+
+  test("Copilot reads a bounded transcript tail and preserves a supplied final answer", async () => {
+    const transcript = join(home, "copilot-large.jsonl");
+    writeFileSync(transcript, JSON.stringify({ type: "tool.execution_complete", data: "x".repeat(512 * 1024) }) +
+      '\n' + JSON.stringify({ type: "assistant.message", data: { content: "Latest answer" } }) + '\n');
+    const payload = { sessionId: "copilot-3", hookEventName: "agentStop", transcriptPath: transcript };
+    await runShim(["--harness", "copilot"], JSON.stringify(payload));
+    assert.equal((received.at(-1)!.body.event as Record<string, unknown>).last_assistant_message, "Latest answer");
+    await runShim(["--harness", "copilot"], JSON.stringify({ ...payload, last_assistant_message: "Direct answer" }));
+    assert.equal((received.at(-1)!.body.event as Record<string, unknown>).last_assistant_message, "Direct answer");
+  });
+
   test("missing remote config: silent success, nothing sent", async () => {
     const count = received.length;
     const { code } = await runShim(

--- a/orchestrator/test/ingest.test.ts
+++ b/orchestrator/test/ingest.test.ts
@@ -121,6 +121,33 @@ describe("gemini dialect", () => {
   });
 });
 
+// Copilot PascalCase hooks use the documented VS Code-compatible dialect.
+// The client shim adds last_assistant_message from the Stop transcript path.
+describe("Copilot capture", () => {
+  test("two turns are captured once and SessionEnd closes the session", async () => {
+    const session_id = "copilot-session";
+    const events = [
+      { hook_event_name: "SessionStart" },
+      { hook_event_name: "UserPromptSubmit", prompt: "Fix the Copilot integration" },
+      { hook_event_name: "Stop", last_assistant_message: "Installed Flow", timestamp: "2026-09-05T10:00:00Z" },
+      { hook_event_name: "UserPromptSubmit", prompt: "Check it" },
+      { hook_event_name: "Stop", last_assistant_message: "Checks passed", timestamp: "2026-09-05T10:01:00Z" },
+      { hook_event_name: "SessionEnd" },
+    ];
+    for (const event of events) {
+      const payload = { ...event, session_id, cwd: "/work/copilot" };
+      const first = await postHook("copilot", payload);
+      assert.equal(first.statusCode, 200);
+      assert.equal((await postHook("copilot", payload)).json().appended, 0);
+    }
+    const transcript = readTranscript(extRowId("copilot", session_id));
+    assert.deepEqual(transcript.map((e) => e.kind), ["created", "user_prompt", "update", "user_prompt", "update"]);
+    assert.match(JSON.stringify(transcript), /Checks passed/);
+    const result = await app.inject({ method: "GET", url: "/v1/ingest/sessions?harness=copilot" });
+    assert.equal(result.json().sessions[0].status, "closed");
+  });
+});
+
 describe("version tolerance", () => {
   test("unknown event names are acknowledged, never errors", async () => {
     const res = await postHook("claude", {

--- a/orchestrator/test/materialize.test.mjs
+++ b/orchestrator/test/materialize.test.mjs
@@ -1,0 +1,134 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { parse } from "jsonc-parser";
+
+const materializer = new URL("../../bin/lib/materialize.mjs", import.meta.url).href;
+
+function fixture(run) {
+  const home = mkdtempSync(join(tmpdir(), "flow-materialize-"));
+  const repoDir = join(home, "repo with spaces");
+  mkdirSync(repoDir);
+  const git = spawnSync("git", ["init", "-q", repoDir]);
+  assert.equal(git.status, 0);
+  const ctx = { repoDir, project: "test-project", repo: "test-repo", harnesses: ["copilot"] };
+  function invoke(code) {
+    const result = spawnSync(process.execPath, ["--input-type=module", "-e", `
+      import * as m from ${JSON.stringify(materializer)};
+      const ctx = ${JSON.stringify(ctx)};
+      ${code}
+    `], { env: { ...process.env, HOME: home, COPILOT_HOME: "" }, encoding: "utf8" });
+    assert.equal(result.status, 0, result.stderr);
+    return result.stdout;
+  }
+  try { run({ home, repoDir, invoke }); }
+  finally { rmSync(home, { recursive: true, force: true }); }
+}
+
+test("Copilot setup, repeated setup, and removal preserve user configuration", () => fixture(({ repoDir, invoke }) => {
+  const originals = {
+    ".vscode/mcp.json": '{\n  // My existing server\n  "servers": { "mine": { "command": "my-server" }, },\n  "inputs": [],\n}\n',
+    ".github/mcp.json": '{"mcpServers":{"mine":{"command":"my-cli-server"}}}\n',
+    ".github/hooks/flow.json": '{"version":1,"hooks":{"Stop":[{"type":"command","command":"my-hook"}]}}\n',
+    ".github/copilot-instructions.md": "# Team rules\n\nKeep public APIs stable.\n",
+    ".github/skills/flow/SKILL.md": "An existing personal skill.\n",
+  };
+  for (const [rel, content] of Object.entries(originals)) {
+    const p = join(repoDir, rel);
+    mkdirSync(join(p, ".."), { recursive: true });
+    writeFileSync(p, content);
+  }
+  invoke("m.materializeRepo(ctx)");
+  const installed = Object.fromEntries(Object.keys(originals).map((rel) => [rel, readFileSync(join(repoDir, rel), "utf8")]));
+  const vscode = parse(installed[".vscode/mcp.json"]);
+  assert.equal(vscode.servers.mine.command, "my-server");
+  assert.equal(vscode.servers["flow-graph"].command, process.execPath);
+  assert.equal(vscode.servers["flow-graph"].type, "stdio");
+  assert.ok(installed[".vscode/mcp.json"].includes("// My existing server"));
+  const cli = parse(installed[".github/mcp.json"]);
+  assert.deepEqual(cli.mcpServers["flow-graph"], vscode.servers["flow-graph"]);
+  const hooks = parse(installed[".github/hooks/flow.json"]);
+  assert.deepEqual(Object.keys(hooks.hooks).sort(), ["SessionEnd", "SessionStart", "Stop", "UserPromptSubmit"]);
+  assert.equal(hooks.hooks.Stop.length, 2);
+  assert.match(hooks.hooks.Stop[1].command, /'--harness' 'copilot'/);
+  assert.ok(!existsSync(join(repoDir, ".claude")), "Copilot installs independently of Claude");
+  assert.match(readFileSync(join(repoDir, ".git/info/exclude"), "utf8"), /\.github\/hooks\/flow.json/);
+  invoke("m.materializeRepo(ctx)");
+  for (const [rel, text] of Object.entries(installed)) assert.equal(readFileSync(join(repoDir, rel), "utf8"), text);
+  invoke("m.removeRepo(ctx.repoDir)");
+  for (const [rel, text] of Object.entries(originals)) assert.equal(readFileSync(join(repoDir, rel), "utf8"), text, rel);
+}));
+
+test("removal keeps servers added after setup and deletes empty generated files", () => fixture(({ repoDir, invoke }) => {
+  invoke("m.materializeRepo(ctx)");
+  const path = join(repoDir, ".vscode/mcp.json");
+  const file = parse(readFileSync(path, "utf8"));
+  file.servers.later = { command: "later-server" };
+  writeFileSync(path, JSON.stringify(file));
+  invoke("m.removeRepo(ctx.repoDir)");
+  assert.deepEqual(parse(readFileSync(path, "utf8")), { servers: { later: { command: "later-server" } } });
+  assert.ok(!existsSync(join(repoDir, ".github")));
+}));
+
+test("bare CLI server maps and shared mode are supported", () => fixture(({ repoDir, invoke }) => {
+  mkdirSync(join(repoDir, ".github"));
+  const path = join(repoDir, ".github/mcp.json");
+  const original = '{"mine":{"command":"server"}}\n';
+  writeFileSync(path, original);
+  invoke("m.materializeRepo({ ...ctx, share: true })");
+  assert.ok(parse(readFileSync(path, "utf8"))["flow-graph"]);
+  assert.ok(!readFileSync(join(repoDir, ".git/info/exclude"), "utf8").includes("flow:begin"));
+  invoke("m.removeRepo(ctx.repoDir)");
+  assert.equal(readFileSync(path, "utf8"), original);
+}));
+
+test("malformed Copilot config is reported without overwriting it", () => fixture(({ repoDir, invoke }) => {
+  mkdirSync(join(repoDir, ".github/hooks"), { recursive: true });
+  const path = join(repoDir, ".github/hooks/flow.json");
+  writeFileSync(path, "{ broken");
+  invoke(`
+    import assert from "node:assert/strict";
+    assert.throws(() => m.materializeRepo(ctx), /Invalid Copilot configuration/);
+  `);
+  assert.equal(readFileSync(path, "utf8"), "{ broken");
+}));
+
+test("Copilot detection recognizes an installed VS Code extension", () => fixture(({ home, invoke }) => {
+  mkdirSync(join(home, ".vscode/extensions/github.copilot-chat-1.0.0"), { recursive: true });
+  assert.ok(JSON.parse(invoke("console.log(JSON.stringify(m.detectHarnesses()))")).includes("copilot"));
+}));
+
+test("removal restores pre-existing empty config maps", () => fixture(({ repoDir, invoke }) => {
+  const originals = {
+    ".vscode/mcp.json": '{ "servers": {} }\n',
+    ".github/mcp.json": '{ "mcpServers": {} }\n',
+    ".github/hooks/flow.json": '{ "hooks": {} }\n',
+  };
+  for (const [rel, content] of Object.entries(originals)) {
+    mkdirSync(join(repoDir, rel, ".."), { recursive: true });
+    writeFileSync(join(repoDir, rel), content);
+  }
+  invoke("m.materializeRepo(ctx); m.removeRepo(ctx.repoDir)");
+  for (const [rel, content] of Object.entries(originals)) assert.equal(readFileSync(join(repoDir, rel), "utf8"), content);
+}));
+
+test("rendered hook commands preserve spaces and shell metacharacters in bindings", () => fixture(({ home, repoDir, invoke }) => {
+  invoke(`m.materializeRepo({ ...ctx, project: "project with spaces", repo: "repo's $literal" })`);
+  mkdirSync(join(home, ".flow/bin"), { recursive: true });
+  writeFileSync(join(home, ".flow/bin/flow-hook"), "console.log(JSON.stringify(process.argv.slice(2)))");
+  const hooks = parse(readFileSync(join(repoDir, ".github/hooks/flow.json"), "utf8"));
+  const result = spawnSync(hooks.hooks.Stop[0].command, { shell: true, encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), ["--harness", "copilot", "--project", "project with spaces", "--repo", "repo's $literal", "--remote", "local"]);
+}));
+
+test("removing another tool's integration leaves unrelated Copilot config alone", () => fixture(({ repoDir, invoke }) => {
+  mkdirSync(join(repoDir, ".vscode"));
+  const path = join(repoDir, ".vscode/mcp.json");
+  writeFileSync(path, "{ unfinished user config");
+  invoke('m.materializeRepo({ ...ctx, harnesses: ["gemini"] }); m.removeRepo(ctx.repoDir)');
+  assert.equal(readFileSync(path, "utf8"), "{ unfinished user config");
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "dashboard"
       ],
       "dependencies": {
-        "falkordb": "^6.2.0"
+        "falkordb": "^6.2.0",
+        "jsonc-parser": "^3.3.1"
       },
       "bin": {
         "flow": "bin/flow.mjs"
@@ -8732,6 +8733,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "license": "MIT"
     },
     "node_modules/jsonfile": {
       "version": "6.2.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "npm": ">=9"
   },
   "dependencies": {
-    "falkordb": "^6.2.0"
+    "falkordb": "^6.2.0",
+    "jsonc-parser": "^3.3.1"
   }
 }


### PR DESCRIPTION
Flow's installer previously supported six coding tools but had no Copilot target. This adds `flow setup <project> --harness copilot` for Copilot CLI and VS Code Copilot, with automatic detection and inclusion in `--all`.

The integration installs separate CLI and VS Code MCP configurations, lifecycle capture hooks, the Flow skill, and a managed instruction block. Setup and removal preserve existing configuration, including JSONC comments. Capture reads a bounded transcript tail, redacts the final assistant response before upload, and suppresses recognized Copilot sessions in inherited Claude hooks to avoid duplicate capture.

This covers installation into external coding tools. It does not add a Flow ACP backend or agent-picker UI, and it does not provision GitHub's hosted Copilot cloud agent. Research sources and operational limits are documented in `docs/harness-integrations.md`.

Validation after rebasing onto current `main`:

- All 328 orchestrator tests pass on Node 22.22.3, including setup/removal, config preservation, shell quoting, capture/redaction, and ingestion tests.
- `git diff --check origin/main...HEAD` passes.
- Orchestrator type-checking still reports errors in unchanged `src/corpus.ts`, `src/index.ts`, `src/pollers/engine.ts`, and `test/memory.test.ts`.
- A live authenticated Copilot session was not available for verification; transcript formats remain a vendor compatibility risk.
