### PR TITLE
perf: speed up dashboard startup and full-graph loading

### DIFF
--- a/dashboard/src/app/api/graph/overview/route.ts
+++ b/dashboard/src/app/api/graph/overview/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { getSessionToken } from "@/lib/auth";
 import { requireProject } from "@/lib/projectContext";
 
@@ -8,10 +8,19 @@ import { requireProject } from "@/lib/projectContext";
 // two queries (all nodes, then all relationships). A single joined
 // `MATCH (n) OPTIONAL MATCH (n)-[r]->(m)` query multiplies rows by out-degree,
 // so any row LIMIT silently drops whole subgraphs once the graph grows.
-// We omit `graph` from the body so the gateway uses its configured default graph.
+// By default the gateway uses its configured graph; callers may pass ?graph=
+// for explicit graph selection.
 
 const NODES_CYPHER = `MATCH (n) RETURN n`;
-const EDGES_CYPHER = `MATCH ()-[r]->() RETURN r`;
+const EDGES_CYPHER = `MATCH (a)-[r]->(b) RETURN a, r, b`;
+const NODE_COUNT_CYPHER = `MATCH (n) RETURN count(n) AS count`;
+const EDGE_COUNT_CYPHER = `MATCH ()-[r]->() RETURN count(r) AS count`;
+const DEFAULT_PAGE_LIMIT = 500;
+const MAX_PAGE_LIMIT = 1000;
+
+function pageCypher(base: string, offset: number, limit: number): string {
+  return `${base} SKIP ${offset} LIMIT ${limit}`;
+}
 
 // FalkorDB's native node/edge shape as the gateway returns it: `id` is an
 // INTERNAL integer, the real id + name live in `properties`, the label in
@@ -47,9 +56,79 @@ interface CyEdge {
   label: string;
 }
 
-export async function GET() {
+function intParam(raw: string | null, fallback: number, min: number, max: number): number {
+  const n = Number.parseInt(raw ?? "", 10);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(min, Math.min(max, n));
+}
+
+function countFromRows(rows: Record<string, unknown>[]): number {
+  const row = rows[0] ?? {};
+  const val = row.count ?? row.total ?? Object.values(row)[0] ?? 0;
+  return Number(val) || 0;
+}
+
+function buildGraphRows(nodeRows: Record<string, unknown>[], edgeRows: Record<string, unknown>[]) {
+  const nodesMap = new Map<string, CyNode>();          // display id -> node
+  const internalToDisplay = new Map<number, string>(); // FalkorDB int id -> display id
+
+  const displayId = (nd: GwNode): string =>
+    String(nd.properties?.id ?? nd.properties?.name ?? `node-${nd.id}`);
+
+  const addNode = (nd: GwNode | null | undefined): string | null => {
+    if (!nd) return null;
+    const did = displayId(nd);
+    if (typeof nd.id === "number") internalToDisplay.set(nd.id, did);
+    if (!nodesMap.has(did)) {
+      nodesMap.set(did, {
+        id: did,
+        data: {
+          name: String(nd.properties?.name ?? nd.properties?.title ?? did),
+          type: nd.labels?.[0] ?? "node",
+          description: nd.properties?.description ? String(nd.properties.description) : undefined,
+        },
+      });
+    }
+    return did;
+  };
+
+  for (const row of nodeRows) {
+    addNode(row.n as GwNode | null | undefined);
+  }
+
+  const edgesSet = new Set<string>();
+  const edges: CyEdge[] = [];
+  for (const row of edgeRows) {
+    const sourceFromRow = addNode(row.a as GwNode | null | undefined);
+    const targetFromRow = addNode(row.b as GwNode | null | undefined);
+    const r = row.r as GwRel | null | undefined;
+    if (!r) continue;
+    const s = sourceFromRow ?? internalToDisplay.get(r.sourceId);
+    const t = targetFromRow ?? internalToDisplay.get(r.destinationId);
+    if (!s || !t) continue;
+    const label = r.relationshipType ?? r.type ?? "";
+    const key = `${s}->${label}->${t}`;
+    if (!edgesSet.has(key)) {
+      edgesSet.add(key);
+      edges.push({ source: s, target: t, label });
+    }
+  }
+
+  return {
+    nodes: Array.from(nodesMap.values()),
+    edges,
+  };
+}
+
+export async function GET(req: NextRequest) {
   const token = await getSessionToken();
   if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { searchParams } = new URL(req.url);
+  const part = searchParams.get("part");
+  const graph = searchParams.get("graph") ?? undefined;
+  const offset = intParam(searchParams.get("offset"), 0, 0, Number.MAX_SAFE_INTEGER);
+  const limit = intParam(searchParams.get("limit"), DEFAULT_PAGE_LIMIT, 1, MAX_PAGE_LIMIT);
 
   const project = await requireProject();
   try {
@@ -57,7 +136,7 @@ export async function GET() {
       const res = await fetch(`${project.gatewayUrl}/v1/verbs/read_query`, {
         method: "POST",
         headers: { "Content-Type": "application/json", ...(project.adminToken ? { authorization: `Bearer ${project.adminToken}` } : {}) },
-        body: JSON.stringify({ cypher }),
+        body: JSON.stringify(graph ? { cypher, graph } : { cypher }),
         signal: AbortSignal.timeout(15000),
       });
       if (!res.ok) throw new Error(`Gateway responded ${res.status}`);
@@ -68,57 +147,66 @@ export async function GET() {
       return result.rows ?? [];
     };
 
+    if (part === "summary") {
+      const [nodeCountRows, edgeCountRows] = await Promise.all([
+        runQuery(NODE_COUNT_CYPHER),
+        runQuery(EDGE_COUNT_CYPHER),
+      ]);
+      const nodeTotal = countFromRows(nodeCountRows);
+      const edgeTotal = countFromRows(edgeCountRows);
+      return NextResponse.json({
+        nodes: [],
+        edges: [],
+        total: nodeTotal,
+        nodeTotal,
+        edgeTotal,
+        partial: true,
+      });
+    }
+
+    if (part === "nodes") {
+      const nodeRows = await runQuery(pageCypher("MATCH (n) RETURN n", offset, limit));
+      const data = buildGraphRows(nodeRows, []);
+      return NextResponse.json({
+        ...data,
+        partial: nodeRows.length === limit,
+        page: {
+          part,
+          offset,
+          limit,
+          nextOffset: nodeRows.length === limit ? offset + nodeRows.length : null,
+        },
+      });
+    }
+
+    if (part === "edges") {
+      const edgeRows = await runQuery(pageCypher("MATCH (a)-[r]->(b) RETURN a, r, b", offset, limit));
+      const data = buildGraphRows([], edgeRows);
+      return NextResponse.json({
+        ...data,
+        partial: edgeRows.length === limit,
+        page: {
+          part,
+          offset,
+          limit,
+          nextOffset: edgeRows.length === limit ? offset + edgeRows.length : null,
+        },
+      });
+    }
+
     const [nodeRows, edgeRows] = await Promise.all([
       runQuery(NODES_CYPHER),
       runQuery(EDGES_CYPHER),
     ]);
-
-    const nodesMap = new Map<string, CyNode>();          // display id → node
-    const internalToDisplay = new Map<number, string>(); // FalkorDB int id → display id
-
-    const displayId = (nd: GwNode): string =>
-      String(nd.properties?.id ?? nd.properties?.name ?? `node-${nd.id}`);
-
-    for (const row of nodeRows) {
-      const nd = row.n as GwNode | null | undefined;
-      if (!nd) continue;
-      const did = displayId(nd);
-      internalToDisplay.set(nd.id, did);
-      if (!nodesMap.has(did)) {
-        nodesMap.set(did, {
-          id: did,
-          data: {
-            name: String(nd.properties?.name ?? nd.properties?.title ?? did),
-            type: nd.labels?.[0] ?? "node",
-            description: nd.properties?.description ? String(nd.properties.description) : undefined,
-          },
-        });
-      }
-    }
-
-    const edgesSet = new Set<string>();
-    const edges: CyEdge[] = [];
-    for (const row of edgeRows) {
-      const r = row.r as GwRel | null | undefined;
-      if (!r) continue;
-      const s = internalToDisplay.get(r.sourceId);
-      const t = internalToDisplay.get(r.destinationId);
-      if (!s || !t) continue;
-      const label = r.relationshipType ?? r.type ?? "";
-      const key = `${s}→${label}→${t}`;
-      if (!edgesSet.has(key)) {
-        edgesSet.add(key);
-        edges.push({ source: s, target: t, label });
-      }
-    }
+    const data = buildGraphRows(nodeRows, edgeRows);
 
     return NextResponse.json({
-      nodes: Array.from(nodesMap.values()),
-      edges,
-      total: nodesMap.size,
+      ...data,
+      total: data.nodes.length,
+      nodeTotal: data.nodes.length,
+      edgeTotal: data.edges.length,
     });
   } catch (e) {
-    // Gateway not available — return empty gracefully
-    return NextResponse.json({ error: (e as Error).message, nodes: [], edges: [] });
+    return NextResponse.json({ error: (e as Error).message, nodes: [], edges: [] }, { status: 502 });
   }
 }

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState, useCallback, useMemo } from "react";
 import { Shell } from "@/components/Shell";
 import { KeyGate } from "@/components/KeyGate";
 import { BrainCanvas } from "@/components/BrainCanvas";
 import { AgentPanel } from "@/components/AgentPanel";
 import { IntegrationCatalog } from "@/components/IntegrationCatalog";
 import { CodingToolsPanel } from "@/components/CodingToolsPanel";
-import { SourcesPillStrip, SourceDrawer, type RepoEntry, type SettingItem } from "@/components/SourceDrawer";
+import { SourceDrawer, type RepoEntry, type SettingItem } from "@/components/SourceDrawer";
 import { RecentActivity, type AuditRow } from "@/components/RecentActivity";
 import { Kicker, Heading, StatusPill } from "@/components/ui";
 import { useMode } from "@/lib/useMode";
@@ -22,13 +22,40 @@ interface IngestSource {
   status: string;
 }
 
+type RepoIndexStatus = "never_indexed" | "queued" | "indexing" | "indexed" | "failed";
+
+interface RepoStatusEntry {
+  name: string;
+  branch: string;
+  status: RepoIndexStatus;
+  lastIndexedCommit: string | null;
+  lastIndexedAt: string | null;
+  lastError: string | null;
+  runningJobId: string | null;
+  queuedJobId: string | null;
+}
+
 type HomeState = "loading" | "engine-down" | "no-brain" | "ready";
+
+function hasBrainSettings(settings: SettingItem[]): boolean {
+  return settings.some(
+    (s) => (s.key === "OPENROUTER_API_KEY" || s.key === "LLM_API_KEY" || s.key === "BRAIN_MODE") && s.set
+  );
+}
+
+function statusMap(rows: RepoStatusEntry[]): Record<string, RepoStatusEntry> {
+  const map: Record<string, RepoStatusEntry> = {};
+  for (const row of rows) map[row.name] = row;
+  return map;
+}
 
 export default function HomePage() {
   const [state, setState] = useState<HomeState>("loading");
   const [settings, setSettings] = useState<SettingItem[]>([]);
   const [sources, setSources] = useState<IngestSource[]>([]);
   const [repos, setRepos] = useState<RepoEntry[]>([]);
+  const [repoStatuses, setRepoStatuses] = useState<Record<string, RepoStatusEntry>>({});
+  const [operationalLoaded, setOperationalLoaded] = useState(false);
   const [auditRows, setAuditRows] = useState<AuditRow[]>([]);
   const [graphNodeCount, setGraphNodeCount] = useState(0);
   const [graphEdgeCount, setGraphEdgeCount] = useState(0);
@@ -42,51 +69,67 @@ export default function HomePage() {
   const { mode } = useMode();
   const { prefix } = useProject();
 
-  const hasBrain = settings.some(
-    (s) => (s.key === "OPENROUTER_API_KEY" || s.key === "LLM_API_KEY" || s.key === "BRAIN_MODE") && s.set
+  const hasBrain = hasBrainSettings(settings);
+
+  const reposWithStatus = useMemo<RepoEntry[]>(
+    () =>
+      repos.map((repo) => {
+        const status = repoStatuses[repo.name];
+        if (!status) return repo;
+        return {
+          ...repo,
+          indexStatus: status.status,
+          lastIndexedCommit: status.lastIndexedCommit ?? repo.lastIndexedCommit,
+          lastIndexedAt: status.lastIndexedAt ?? repo.lastIndexedAt,
+          lastError: status.lastError,
+        };
+      }),
+    [repoStatuses, repos]
   );
 
-  const hasSources = repos.length > 0;
-  const isAnyRepoIndexing = repos.some((r) => !r.lastIndexedCommit);
-  const isIndexing = sources.some((s) => s.catching_up) || isAnyRepoIndexing;
+  const hasSources = !operationalLoaded || reposWithStatus.length > 0;
+  const isRepoIndexing = Object.values(repoStatuses).some((r) => r.status === "indexing" || r.status === "queued");
+  const isIndexing = sources.some((s) => s.catching_up || s.status === "catching_up") || isRepoIndexing;
 
-  const loadAll = useCallback(async () => {
+  const refreshOperationalData = useCallback(async () => {
+    const [ingestRes, reposRes, repoStatusRes, auditRes] = await Promise.allSettled([
+      fetch(prefix("/api/ingest/status")).then((r) => (r.ok ? r.json() : { sources: [] })) as Promise<{ sources: IngestSource[] }>,
+      fetch(prefix("/api/repos")).then((r) => (r.ok ? r.json() : { repos: [] })) as Promise<{ repos: RepoEntry[] }>,
+      fetch(prefix("/api/repos/status")).then((r) => (r.ok ? r.json() : { repos: [] })) as Promise<{ repos: RepoStatusEntry[] }>,
+      fetch(prefix("/api/audit?limit=20")).then((r) => (r.ok ? r.json() : { rows: [] })) as Promise<{ rows: AuditRow[] }>,
+    ]);
+
+    if (ingestRes.status === "fulfilled") setSources(ingestRes.value.sources ?? []);
+    if (reposRes.status === "fulfilled") setRepos(reposRes.value.repos ?? []);
+    if (repoStatusRes.status === "fulfilled") setRepoStatuses(statusMap(repoStatusRes.value.repos ?? []));
+    if (auditRes.status === "fulfilled") setAuditRows(auditRes.value.rows ?? []);
+    setOperationalLoaded(true);
+  }, [prefix]);
+
+  const refreshSettings = useCallback(async () => {
     try {
       const settingsResp = await fetch(prefix("/api/settings"));
       if (settingsResp.status === 401) {
         window.location.href = "/login?from=%2F";
         return;
       }
-      if (settingsResp.status >= 500) {
+      if (!settingsResp.ok) {
         setState("engine-down");
         return;
       }
 
-      const [settingsRes, ingestRes, reposRes, auditRes, graphRes] = await Promise.allSettled([
-        settingsResp.json() as Promise<SettingItem[]>,
-        fetch(prefix("/api/ingest/status")).then((r) => r.json()) as Promise<{ sources: IngestSource[] }>,
-        fetch(prefix("/api/repos")).then((r) => r.json()) as Promise<{ repos: RepoEntry[] }>,
-        fetch(prefix("/api/audit?limit=20")).then((r) => r.json()) as Promise<{ rows: AuditRow[] }>,
-        fetch(prefix("/api/graph/overview")).then((r) => r.json()) as Promise<{ nodes: unknown[]; edges: unknown[] }>,
-      ]);
-
-      const s = settingsRes.status === "fulfilled" ? (Array.isArray(settingsRes.value) ? settingsRes.value : []) : [];
-      const ingest = ingestRes.status === "fulfilled" ? (ingestRes.value.sources ?? []) : [];
-      const rps = reposRes.status === "fulfilled" ? (reposRes.value.repos ?? []) : [];
-      const audit = auditRes.status === "fulfilled" ? (auditRes.value.rows ?? []) : [];
-      const graph = graphRes.status === "fulfilled" ? graphRes.value : { nodes: [], edges: [] };
-
+      const s: unknown = await settingsResp.json();
+      if (!Array.isArray(s) || !s.every(
+        (item) => item !== null && typeof item === "object"
+          && typeof item.key === "string" && typeof item.set === "boolean"
+          && (item.value === undefined || item.value === null || typeof item.value === "string")
+      )) {
+        setState("engine-down");
+        return;
+      }
       setSettings(s);
-      setSources(ingest);
-      setRepos(rps);
-      setAuditRows(audit);
-      setGraphNodeCount((graph.nodes ?? []).length);
-      setGraphEdgeCount((graph.edges ?? []).length);
 
-      const brainSet = s.some(
-        (item) => (item.key === "OPENROUTER_API_KEY" || item.key === "LLM_API_KEY" || item.key === "BRAIN_MODE") && item.set
-      );
-      if (!brainSet) {
+      if (!hasBrainSettings(s)) {
         setState("no-brain");
         return;
       }
@@ -97,15 +140,24 @@ export default function HomePage() {
     }
   }, [prefix]);
 
+  const loadAll = useCallback(async () => {
+    const operational = refreshOperationalData();
+    await refreshSettings();
+    await operational;
+  }, [refreshOperationalData, refreshSettings]);
+
   useEffect(() => {
-    loadAll();
+    const timer = setTimeout(() => {
+      void loadAll();
+    }, 0);
+    return () => clearTimeout(timer);
   }, [loadAll]);
 
   // Engine down retry
   useEffect(() => {
     if (state !== "engine-down") return;
     const iv = setInterval(() => {
-      loadAll();
+      void loadAll();
     }, 3000);
     return () => clearInterval(iv);
   }, [state, loadAll]);
@@ -113,22 +165,12 @@ export default function HomePage() {
   // Background refresh poll
   useEffect(() => {
     if (state !== "ready") return;
-    const interval = isIndexing ? 3000 : 10000;
+    const interval = isIndexing ? 5000 : 30000;
     const iv = setInterval(() => {
-      fetch(prefix("/api/graph/overview"))
-        .then((r) => r.json())
-        .then((d: { nodes: unknown[]; edges: unknown[] }) => {
-          setGraphNodeCount((d.nodes ?? []).length);
-          setGraphEdgeCount((d.edges ?? []).length);
-        })
-        .catch(() => {});
-      fetch(prefix("/api/repos"))
-        .then((r) => r.json())
-        .then((d: { repos: RepoEntry[] }) => setRepos(d.repos ?? []))
-        .catch(() => {});
+      void refreshOperationalData();
     }, interval);
     return () => clearInterval(iv);
-  }, [state, isIndexing, prefix]);
+  }, [state, isIndexing, refreshOperationalData]);
 
   const scrollToSources = useCallback(() => {
     const el = document.getElementById("sources-section");
@@ -145,6 +187,11 @@ export default function HomePage() {
     if (agentEl) {
       agentEl.scrollIntoView({ behavior: "smooth" });
     }
+  }, []);
+
+  const handleGraphStats = useCallback(({ nodeCount, edgeCount }: { nodeCount: number; edgeCount: number }) => {
+    setGraphNodeCount(nodeCount);
+    setGraphEdgeCount(edgeCount);
   }, []);
 
   if (state === "loading") {
@@ -172,7 +219,7 @@ export default function HomePage() {
   }
 
   if (state === "no-brain" || !hasBrain) {
-    return <KeyGate onReady={() => loadAll()} />;
+    return <KeyGate onReady={() => void loadAll()} />;
   }
 
   return (
@@ -201,21 +248,23 @@ export default function HomePage() {
             nodeCount={graphNodeCount}
             edgeCount={graphEdgeCount}
             isIndexing={isIndexing}
+            pollInterval={isIndexing ? 15000 : 60000}
             height={hasSources ? 480 : 360}
             onConnectFirstSource={scrollToSources}
             onNodeClick={handleNodeClick}
+            onGraphStats={handleGraphStats}
             sources={sources}
-            repos={repos}
+            repos={reposWithStatus}
           />
         </div>
 
         {/* 2. MIDDLE SECTION: CONNECT SOURCES & INTEGRATIONS */}
         <div id="sources-section" className="w-full">
           <IntegrationCatalog
-            repos={repos}
+            repos={reposWithStatus}
             settings={settings}
             mode={mode}
-            onChanged={() => loadAll()}
+            onChanged={() => void loadAll()}
           />
         </div>
 
@@ -253,10 +302,10 @@ export default function HomePage() {
       <SourceDrawer
         isOpen={isDrawerOpen}
         onClose={() => setIsDrawerOpen(false)}
-        repos={repos}
+        repos={reposWithStatus}
         settings={settings}
         mode={mode}
-        onChanged={() => loadAll()}
+        onChanged={() => void loadAll()}
       />
     </Shell>
   );

--- a/dashboard/src/components/BrainCanvas.tsx
+++ b/dashboard/src/components/BrainCanvas.tsx
@@ -2,7 +2,6 @@
 
 import React, { useEffect, useState } from "react";
 import { BrainGraph } from "@/components/BrainGraph";
-import { Kicker } from "@/components/ui";
 import { useProject } from "@/lib/useProject";
 
 interface ActivityEvent {
@@ -30,18 +29,19 @@ interface BrainCanvasProps {
   height?: number;
   onConnectFirstSource?: () => void;
   onNodeClick?: (nodeName: string) => void;
+  onGraphStats?: (stats: { nodeCount: number; edgeCount: number; error?: string }) => void;
   sources?: Array<{ source: string; catching_up: boolean; last_poll_at: number }>;
   repos?: Array<{ name: string; lastIndexedCommit?: string; kind?: string }>;
 }
 
 export function BrainCanvas({
   nodeCount,
-  edgeCount,
   isIndexing,
-  pollInterval = 5000,
+  pollInterval = 0,
   height = 420,
   onConnectFirstSource,
   onNodeClick,
+  onGraphStats,
   sources = [],
   repos = [],
 }: BrainCanvasProps) {
@@ -96,7 +96,8 @@ export function BrainCanvas({
     return () => clearInterval(iv);
   }, [isIndexing, activeRepo, prefix]);
 
-  const stage = nodeCount === 0 && !isIndexing ? 0 : isIndexing ? 1 : 2;
+  const hasSources = repos.length > 0 || sources.length > 0;
+  const stage = !hasSources && nodeCount === 0 && !isIndexing ? 0 : isIndexing ? 1 : 2;
 
   function handleEmptyClick() {
     if (onConnectFirstSource) {
@@ -170,6 +171,7 @@ export function BrainCanvas({
           height={height}
           isIndexing={isIndexing}
           onNodeClick={onNodeClick}
+          onStats={onGraphStats}
         />
 
         {/* Embedded Ingestion Overlay directly inside Brain Container */}

--- a/dashboard/src/components/BrainGraph.tsx
+++ b/dashboard/src/components/BrainGraph.tsx
@@ -28,6 +28,7 @@ const TYPE_COLORS: Record<string, string> = {
 };
 
 const DEFAULT_NODE_COLOR = "rgb(162, 163, 148)"; // --text-muted adapted
+const GRAPH_PAGE_LIMIT = 500;
 
 function getTypeColor(type: string): string {
   return TYPE_COLORS[type] ?? DEFAULT_NODE_COLOR;
@@ -71,6 +72,21 @@ interface GraphData {
   nodes: CyNode[];
   edges: CyEdge[];
   total?: number;
+  nodeTotal?: number;
+  edgeTotal?: number;
+  partial?: boolean;
+  error?: string;
+}
+
+interface GraphPage extends GraphData {
+  page?: {
+    nextOffset: number | null;
+  };
+}
+
+interface GraphStats {
+  nodeCount: number;
+  edgeCount: number;
   error?: string;
 }
 
@@ -145,59 +161,147 @@ interface BrainGraphProps {
   isIndexing?: boolean;
   // Callback when a node is clicked in the graph
   onNodeClick?: (nodeName: string) => void;
+  // Emits total graph counts as soon as the paged overview reports them.
+  onStats?: (stats: GraphStats) => void;
 }
 
 export function BrainGraph({
   citedNodeIds,
   pollInterval = 0,
   height = 420,
-  fillHeight = false,
   mode = "overview",
   externalData,
   isIndexing = false,
   onNodeClick,
+  onStats,
 }: BrainGraphProps) {
   const { prefix } = useProject();
   const containerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<FalkorDBCanvas | null>(null);
+  const activeFetchRef = useRef<AbortController | null>(null);
+  const hasGraphDataRef = useRef(false);
   // Display id (string) → stable numeric id: @falkordb/canvas addresses nodes
   // by number, and keeping numbers stable across poll refreshes lets
   // setGraphData preserve simulation positions instead of re-randomizing.
   const numericIdsRef = useRef<Map<string, number>>(new Map());
   const dataSignatureRef = useRef<string>("");
+  const topologySignatureRef = useRef<string>("");
   const citedSetRef = useRef<Set<string>>(new Set());
   const [graphData, setGraphData] = useState<GraphData | null>(null);
   const [loading, setLoading] = useState(mode === "overview");
   const [selectedNode, setSelectedNode] = useState<NodeCardData | null>(null);
 
   const fetchOverview = useCallback(async () => {
-    try {
-      const res = await fetch(prefix("/api/graph/overview"));
-      if (!res.ok) throw new Error(`status ${res.status}`);
-      const data = (await res.json()) as GraphData;
+    activeFetchRef.current?.abort();
+    const controller = new AbortController();
+    activeFetchRef.current = controller;
+
+    if (!hasGraphDataRef.current) setLoading(true);
+
+    const fetchPart = async (part: "summary" | "nodes" | "edges", offset = 0): Promise<GraphPage> => {
+      const qs = new URLSearchParams({ part, limit: String(GRAPH_PAGE_LIMIT) });
+      if (part !== "summary") qs.set("offset", String(offset));
+      const res = await fetch(prefix(`/api/graph/overview?${qs.toString()}`), {
+        signal: controller.signal,
+      });
+      const data = (await res.json()) as GraphPage;
+      if (!res.ok) throw new Error(data.error ?? `status ${res.status}`);
+      return data;
+    };
+
+    const nodesById = new Map<string, CyNode>();
+    const edgesByKey = new Map<string, CyEdge>();
+    let nodeTotal = 0;
+    let edgeTotal = 0;
+
+    const publish = (partial: boolean) => {
+      const nodes = Array.from(nodesById.values());
+      const edges = Array.from(edgesByKey.values());
+      const data: GraphData = { nodes, edges, total: nodeTotal || nodes.length, nodeTotal, edgeTotal, partial };
+      hasGraphDataRef.current = true;
       setGraphData(data);
+      onStats?.({ nodeCount: nodeTotal || nodes.length, edgeCount: edgeTotal || edges.length });
+    };
+
+    const merge = (page: GraphData) => {
+      for (const n of page.nodes ?? []) nodesById.set(n.id, n);
+      for (const e of page.edges ?? []) edgesByKey.set(`${e.source}->${e.label}->${e.target}`, e);
+    };
+
+    try {
+      const summary = await fetchPart("summary");
+      nodeTotal = summary.nodeTotal ?? summary.total ?? 0;
+      edgeTotal = summary.edgeTotal ?? 0;
+      onStats?.({ nodeCount: nodeTotal, edgeCount: edgeTotal });
+
+      if (nodeTotal === 0) {
+        publish(false);
+        return;
+      }
+
+      let nodeOffset = 0;
+      for (;;) {
+        const page = await fetchPart("nodes", nodeOffset);
+        merge(page);
+        publish(true);
+        if (page.page?.nextOffset === null || page.page?.nextOffset === undefined) break;
+        nodeOffset = page.page.nextOffset;
+      }
+
+      let edgeOffset = 0;
+      for (;;) {
+        const page = await fetchPart("edges", edgeOffset);
+        merge(page);
+        if (page.page?.nextOffset === null || page.page?.nextOffset === undefined) break;
+        publish(true);
+        edgeOffset = page.page.nextOffset;
+      }
+
+      publish(false);
     } catch {
+      if (controller.signal.aborted) return;
+      hasGraphDataRef.current = true;
       setGraphData({ nodes: [], edges: [], error: "unavailable" });
+      onStats?.({ nodeCount: 0, edgeCount: 0, error: "unavailable" });
     } finally {
-      setLoading(false);
+      if (activeFetchRef.current === controller) {
+        activeFetchRef.current = null;
+        setLoading(false);
+      }
     }
-  }, [prefix]);
+  }, [onStats, prefix]);
 
   // Load data
   useEffect(() => {
     if (mode === "neighborhood" && externalData !== undefined) {
-      setGraphData(externalData);
-      setLoading(false);
-      return;
+      activeFetchRef.current?.abort();
+      const timer = setTimeout(() => {
+        hasGraphDataRef.current = Boolean(externalData);
+        setGraphData(externalData);
+        setLoading(false);
+      }, 0);
+      return () => clearTimeout(timer);
     }
     if (mode === "overview") {
-      setLoading(true);
-      fetchOverview();
+      const timer = setTimeout(() => {
+        void fetchOverview();
+      }, 0);
       if (pollInterval > 0) {
         const iv = setInterval(fetchOverview, pollInterval);
-        return () => clearInterval(iv);
+        return () => {
+          clearTimeout(timer);
+          clearInterval(iv);
+          activeFetchRef.current?.abort();
+        };
       }
+      return () => {
+        clearTimeout(timer);
+        activeFetchRef.current?.abort();
+      };
     }
+    return () => {
+      activeFetchRef.current?.abort();
+    };
   }, [mode, externalData, pollInterval, fetchOverview]);
 
   // Build/update the graph via @falkordb/canvas — the same renderer FalkorDB's
@@ -206,7 +310,9 @@ export function BrainGraph({
   // charge -400, collision = node size + padding, weak centering, and
   // level-of-detail zoom (labels appear as you zoom in — semantic zoom).
   useEffect(() => {
-    if (!graphData || !containerRef.current) return;
+    // Node-only pages would settle and pin nodes before their edges arrive.
+    // Keep pagination progress separate from the complete graph's layout.
+    if (!graphData || graphData.partial || !containerRef.current) return;
 
     const nodes = graphData.nodes ?? [];
     const edges = graphData.edges ?? [];
@@ -219,10 +325,12 @@ export function BrainGraph({
       canvasRef.current?.remove();
       canvasRef.current = null;
       dataSignatureRef.current = "";
+      topologySignatureRef.current = "";
       return;
     }
 
     let cancelled = false;
+    let fitTimer: ReturnType<typeof setTimeout> | undefined;
     import("@falkordb/canvas").then(() => {
       if (cancelled || !containerRef.current) return;
 
@@ -315,14 +423,20 @@ export function BrainGraph({
       // setData re-runs layout + zoomToFit; setGraphData merges and preserves
       // positions. Poll refreshes with identical data are skipped entirely so
       // the constellation never jitters while we watch indexing progress.
-      const signature = `${nodes.map((n) => n.id).sort().join("|")}#${edges.length}#${citedNodeIds?.join(",") ?? ""}`;
+      const topologySignature = JSON.stringify([
+        nodes.map((n) => n.id).sort(),
+        edges.map((e) => JSON.stringify([e.source, e.target, e.label])).sort(),
+      ]);
+      const signature = JSON.stringify([topologySignature, citedNodeIds ?? []]);
       const changed = signature !== dataSignatureRef.current;
-      if (firstPaint) {
+      const topologyChanged = topologySignature !== topologySignatureRef.current;
+      if (firstPaint || topologyChanged) {
         canvas.setData(data);
       } else if (changed) {
         canvas.setGraphData(data);
       }
       dataSignatureRef.current = signature;
+      topologySignatureRef.current = topologySignature;
 
       // Fit the view to the connected constellation: isolated nodes drift to
       // the edges under charge and would otherwise shrink the main cluster to
@@ -335,7 +449,7 @@ export function BrainGraph({
           connected.add(l.target);
         }
         if (connected.size > 0) {
-          setTimeout(() => {
+          fitTimer = setTimeout(() => {
             if (canvasRef.current === canvas) {
               canvas.zoomToFit(1, (n: FalkorGraphNode) => connected.has(n.id as number));
             }
@@ -346,6 +460,7 @@ export function BrainGraph({
 
     return () => {
       cancelled = true;
+      clearTimeout(fitTimer);
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [graphData, citedNodeIds?.join(",")]);
@@ -362,7 +477,14 @@ export function BrainGraph({
   const uniqueTypes = Array.from(new Set((graphData?.nodes ?? []).map((n) => n.data.type))).filter(Boolean);
   const nodeCount = graphData?.nodes?.length ?? 0;
   const edgeCount = graphData?.edges?.length ?? 0;
+  const nodeTotal = graphData?.nodeTotal ?? graphData?.total ?? nodeCount;
+  const edgeTotal = graphData?.edgeTotal ?? edgeCount;
   const isEmpty = !loading && nodeCount === 0;
+  const graphUnavailable = !loading && graphData?.error;
+  const countText =
+    graphData?.partial && nodeTotal > nodeCount
+      ? `${nodeCount}/${nodeTotal} nodes · ${edgeCount}/${edgeTotal} edges`
+      : `${nodeTotal || nodeCount} nodes · ${edgeTotal || edgeCount} edges`;
 
   const headerHeight = 36;
   const canvasHeight = height - headerHeight;
@@ -375,12 +497,12 @@ export function BrainGraph({
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-2 border-b border-white/8 flex-shrink-0" style={{ height: `${headerHeight}px` }}>
         <Kicker>The brain</Kicker>
-        {nodeCount > 0 && (
+        {(nodeCount > 0 || nodeTotal > 0) && (
           <span
             style={{ fontFamily: "var(--font-mono)" }}
             className="text-[10px] uppercase tracking-wider text-white/40"
           >
-            {nodeCount} nodes · {edgeCount} edges
+            {countText}
           </span>
         )}
       </div>
@@ -428,7 +550,9 @@ export function BrainGraph({
                 style={{ fontFamily: "var(--font-display)" }}
                 className="text-white/50 text-sm mb-1"
               >
-                {mode === "neighborhood"
+                {graphUnavailable
+                  ? "Brain gateway unavailable."
+                  : mode === "neighborhood"
                   ? "No graph context for these citations."
                   : isIndexing
                   ? "The brain is being built…"
@@ -438,7 +562,9 @@ export function BrainGraph({
                 style={{ fontFamily: "var(--font-mono)" }}
                 className="text-[10px] uppercase tracking-wider text-white/25"
               >
-                {mode === "overview"
+                {graphUnavailable
+                  ? "Graph data could not be loaded."
+                  : mode === "overview"
                   ? isIndexing
                     ? "Nodes will appear as Flow reads your sources."
                     : "Connect a source to start building."

--- a/dashboard/src/components/SourceDrawer.tsx
+++ b/dashboard/src/components/SourceDrawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, FormEvent, useMemo } from "react";
+import React, { useState, FormEvent } from "react";
 import { useProject } from "@/lib/useProject";
 import { FlowMode } from "@/lib/useMode";
 import { BrandIcon } from "@/components/BrandIcon";
@@ -8,6 +8,8 @@ import { AddFolder } from "@/components/AddFolder";
 import { AddRepoUrl } from "@/components/AddRepoUrl";
 import { RepoPicker } from "@/components/RepoPicker";
 import { Button, Kicker, StatusPill } from "@/components/ui";
+
+export type RepoIndexStatus = "never_indexed" | "queued" | "indexing" | "indexed" | "failed";
 
 export interface RepoEntry {
   name: string;
@@ -18,12 +20,43 @@ export interface RepoEntry {
   addedAt?: string;
   localPath?: string | null;
   kind?: string;
+  indexStatus?: RepoIndexStatus;
+  lastError?: string | null;
 }
 
 export interface SettingItem {
   key: string;
   set: boolean;
   value?: string | null;
+}
+
+function repoIndexStatus(repo: RepoEntry): RepoIndexStatus {
+  return repo.indexStatus ?? (repo.lastIndexedCommit || repo.lastIndexedAt ? "indexed" : "never_indexed");
+}
+
+function repoStatusLabel(status: RepoIndexStatus): string {
+  const labels: Record<RepoIndexStatus, string> = {
+    never_indexed: "Not indexed",
+    queued: "Queued",
+    indexing: "Indexing",
+    indexed: "Indexed",
+    failed: "Failed",
+  };
+  return labels[status];
+}
+
+function repoStatusKind(status: RepoIndexStatus): "live" | "ok" | "warn" | "idle" {
+  if (status === "indexing") return "live";
+  if (status === "indexed") return "ok";
+  if (status === "failed") return "warn";
+  return "idle";
+}
+
+function repoStatusColor(status: RepoIndexStatus): string {
+  if (status === "indexed") return "var(--ok)";
+  if (status === "failed") return "var(--warn)";
+  if (status === "indexing") return "var(--accent)";
+  return "var(--text-muted)";
 }
 
 interface SourcesPillStripProps {
@@ -33,7 +66,7 @@ interface SourcesPillStripProps {
   onOpenDrawer: () => void;
 }
 
-export function SourcesPillStrip({ repos, settings, mode, onOpenDrawer }: SourcesPillStripProps) {
+export function SourcesPillStrip({ repos, settings, onOpenDrawer }: SourcesPillStripProps) {
   const linearSet = settings.some((s) => s.key === "LINEAR_API_KEY" && s.set);
   const firefliesSet = settings.some((s) => s.key === "FIREFLIES_API_KEY" && s.set);
   const [showSlackPopover, setShowSlackPopover] = useState(false);
@@ -52,21 +85,24 @@ export function SourcesPillStrip({ repos, settings, mode, onOpenDrawer }: Source
         </span>
 
         {/* Repos pills */}
-        {repos.map((r) => (
-          <div
-            key={r.name}
-            className="flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-sand border border-line text-[12px] text-ink flex-shrink-0"
-          >
-            <BrandIcon name="opencode" size={14} className="text-ink opacity-70" />
-            <span className="font-medium truncate max-w-[140px]">{r.name}</span>
-            <span className="text-[10px] text-text-muted font-mono">({r.branch})</span>
-            {r.lastIndexedCommit ? (
-              <span className="w-1.5 h-1.5 rounded-full bg-ok" title="Indexed" />
-            ) : (
-              <span className="w-1.5 h-1.5 rounded-full bg-accent animate-pulse" title="Indexing" />
-            )}
-          </div>
-        ))}
+        {repos.map((r) => {
+          const status = repoIndexStatus(r);
+          return (
+            <div
+              key={r.name}
+              className="flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-sand border border-line text-[12px] text-ink flex-shrink-0"
+            >
+              <BrandIcon name="opencode" size={14} className="text-ink opacity-70" />
+              <span className="font-medium truncate max-w-[140px]">{r.name}</span>
+              <span className="text-[10px] text-text-muted font-mono">({r.branch})</span>
+              <span
+                className={`w-1.5 h-1.5 rounded-full ${status === "indexing" ? "animate-pulse" : ""}`}
+                style={{ background: repoStatusColor(status) }}
+                title={repoStatusLabel(status)}
+              />
+            </div>
+          );
+        })}
 
         {/* Linear pill */}
         {linearSet && (
@@ -318,22 +354,25 @@ export function SourceDrawer({
                 <div>
                   <Kicker>Connected Codebases ({repos.length})</Kicker>
                   <div className="mt-2 space-y-2">
-                    {repos.map((r) => (
-                      <div
-                        key={r.name}
-                        className="p-3 rounded-lg border border-line bg-sand flex items-center justify-between gap-3 text-[13px]"
-                      >
-                        <div>
-                          <div className="font-medium text-ink">{r.name}</div>
-                          <div className="text-[11px] font-mono text-text-muted">
-                            Branch: {r.branch} {r.localPath ? `· ${r.localPath}` : ""}
+                    {repos.map((r) => {
+                      const status = repoIndexStatus(r);
+                      return (
+                        <div
+                          key={r.name}
+                          className="p-3 rounded-lg border border-line bg-sand flex items-center justify-between gap-3 text-[13px]"
+                        >
+                          <div>
+                            <div className="font-medium text-ink">{r.name}</div>
+                            <div className="text-[11px] font-mono text-text-muted">
+                              Branch: {r.branch} {r.localPath ? `· ${r.localPath}` : ""}
+                            </div>
                           </div>
+                          <StatusPill kind={repoStatusKind(status)}>
+                            {repoStatusLabel(status)}
+                          </StatusPill>
                         </div>
-                        <StatusPill kind={r.lastIndexedCommit ? "ok" : "live"}>
-                          {r.lastIndexedCommit ? "Indexed" : "Indexing"}
-                        </StatusPill>
-                      </div>
-                    ))}
+                      );
+                    })}
                   </div>
                 </div>
               )}

--- a/orchestrator/src/adapters/github.ts
+++ b/orchestrator/src/adapters/github.ts
@@ -19,7 +19,7 @@
 import type { FastifyInstance } from "fastify";
 import { createHmac } from "node:crypto";
 import { randomUUID } from "node:crypto";
-import { execSync, spawnSync } from "node:child_process";
+import { execSync, spawn, spawnSync } from "node:child_process";
 import { mkdirSync, existsSync } from "node:fs";
 import { processEvent } from "../events.js";
 import type { NormalizedEvent } from "../events.js";
@@ -234,6 +234,90 @@ export function lsRemoteHead(url: string, branch: string, pat?: string): string 
   return line.split("\t")[0].trim();
 }
 
+function redactPat(text: string, pat?: string): string {
+  return pat ? text.replaceAll(pat, "<redacted>") : text;
+}
+
+function githubPollConcurrency(): number {
+  const raw = process.env.FLOW_GITHUB_POLL_CONCURRENCY ?? "6";
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) ? Math.max(1, Math.min(20, n)) : 6;
+}
+
+export function lsRemoteHeadAsync(
+  url: string,
+  branch: string,
+  pat?: string,
+  timeoutMs = 30_000
+): Promise<string> {
+  let cloneUrl = url;
+  if (pat && url.startsWith("https://")) {
+    cloneUrl = url.replace("https://", `https://x-access-token:${pat}@`);
+  }
+
+  return new Promise((resolve, reject) => {
+    const child = spawn("git", ["ls-remote", cloneUrl, `refs/heads/${branch}`], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+
+    const append = (current: string, chunk: Buffer): string =>
+      (current + chunk.toString("utf-8")).slice(-64_000);
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+    }, timeoutMs);
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout = append(stdout, chunk);
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr = append(stderr, chunk);
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on("close", (code, signal) => {
+      clearTimeout(timer);
+      if (timedOut) {
+        reject(new Error(`git ls-remote timed out after ${timeoutMs}ms for ${url}`));
+        return;
+      }
+      if (code !== 0) {
+        const detail = redactPat(stderr.trim() || `exit ${code}${signal ? ` signal ${signal}` : ""}`, pat);
+        reject(new Error(`git ls-remote failed for ${url}: ${detail}`));
+        return;
+      }
+      const line = stdout.trim().split("\n")[0];
+      if (!line) {
+        reject(new Error(`Branch ${branch} not found on ${url}`));
+        return;
+      }
+      resolve(line.split("\t")[0].trim());
+    });
+  });
+}
+
+async function mapWithConcurrency<T>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<void>
+): Promise<void> {
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    for (;;) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      await fn(items[index]);
+    }
+  });
+  await Promise.all(workers);
+}
+
 // ------------------------------------------------------------------
 // Webhook signature validation
 // ------------------------------------------------------------------
@@ -293,9 +377,10 @@ export async function githubFetchSince(cursor: string): Promise<FetchResult> {
 
   const isFirstBoot = !cursor;
 
-  for (const [repo, branch] of registeredRepos) {
+  const repos = Array.from(registeredRepos);
+  await mapWithConcurrency(repos, githubPollConcurrency(), async ([repo, branch]) => {
     try {
-      const sha = lsRemoteHead(repoUrl(repo), branch, pat || undefined);
+      const sha = await lsRemoteHeadAsync(repoUrl(repo), branch, pat || undefined);
       const prev = knownHeads[repo];
 
       if (!isFirstBoot && prev !== undefined && prev !== sha) {
@@ -314,7 +399,7 @@ export async function githubFetchSince(cursor: string): Promise<FetchResult> {
       // Log but don't fail the whole fetch — one repo error should not block others
       console.error(`[github-poller] Error checking ${repo}: ${err}`);
     }
-  }
+  });
 
   return {
     events,

--- a/orchestrator/src/agents/runtime.ts
+++ b/orchestrator/src/agents/runtime.ts
@@ -675,7 +675,26 @@ export function getSession(id: string): LiveSession | undefined {
 
 export function listSessions(): Array<Record<string, unknown>> {
   const rows = db
-    .prepare(`SELECT * FROM agent_sessions ORDER BY created_at DESC LIMIT 100`)
+    .prepare(`
+      SELECT
+        id,
+        backend,
+        repo,
+        cwd,
+        title,
+        status,
+        acp_session_id,
+        stop_reason,
+        error,
+        start_sha,
+        start_untracked,
+        worktree_id,
+        created_at,
+        updated_at
+      FROM agent_sessions
+      ORDER BY created_at DESC
+      LIMIT 100
+    `)
     .all() as Array<Record<string, unknown>>;
   return rows.map((r) => {
     const live = sessions.get(String(r.id));


### PR DESCRIPTION
Dashboard startup no longer waits for the full graph download, and GitHub polling no longer blocks the orchestrator's event loop. The complete graph loads in pages and is laid out once all nodes and edges have arrived, avoiding the dense ball caused by pinning nodes before loading their connections.

Changes:
- Load settings independently, validate settings responses before storing them, and reduce idle polling.
- Use actual repository indexing states for dashboard and source indicators.
- Paginate the full graph, advance cursors by raw row counts, and preserve the layout when background polls return unchanged data.
- Run Git remote checks asynchronously with bounded concurrency and omit search text and embeddings from session list responses.

Validation:
- Dashboard production build, TypeScript check, and ESLint on changed dashboard files passed.
- Session search and agent diff tests: 19 passed on Node 22.
- Browser checks: malformed settings responses recover without crashing; the full Olostep graph renders 770 nodes and 1,759 edges; an unchanged background poll preserves node positions.
- Ad hoc route regression checks passed for duplicate-row pagination, endpoint mapping, final pages, and gateway failures.

Rebased onto current main-dev. No deployment or shared service restart is included.
