### PR TITLE
Fix past agent session opening and archived transcript replay

### DIFF
--- a/dashboard/src/app/agents/[id]/page.tsx
+++ b/dashboard/src/app/agents/[id]/page.tsx
@@ -11,7 +11,7 @@ export default async function AgentSessionPage({
   const { id } = await params;
   return (
     <Shell>
-      <AgentSession id={id} />
+      <AgentSession key={id} id={id} />
     </Shell>
   );
 }

--- a/dashboard/src/components/AgentSession.tsx
+++ b/dashboard/src/components/AgentSession.tsx
@@ -299,6 +299,14 @@ function reduceEvents(events: SessionEvent[]): {
   };
 }
 
+function mergeEvents(prev: SessionEvent[], incoming: SessionEvent[]): SessionEvent[] {
+  if (incoming.length === 0) return prev;
+  const seen = new Set(prev.map((e) => e.seq));
+  const fresh = incoming.filter((e) => !seen.has(e.seq));
+  if (fresh.length === 0) return prev;
+  return [...prev, ...fresh].sort((a, b) => a.seq - b.seq);
+}
+
 // ---------------------------------------------------------------------------
 
 function statusPill(status: string): { kind: "live" | "ok" | "warn" | "idle"; label: string } {
@@ -311,6 +319,12 @@ function statusPill(status: string): { kind: "live" | "ok" | "warn" | "idle"; la
 
 const AGENT_NAMES: Record<string, string> = { claude: "Claude Code", codex: "Codex", opencode: "OpenCode" };
 
+function agentName(backend?: string): string {
+  if (!backend) return "Agent";
+  const key = backend.startsWith("ext:") ? backend.slice(4) : backend;
+  return AGENT_NAMES[key] ?? backend;
+}
+
 export function AgentSession({ id }: { id: string }) {
   const router = useRouter();
   const { prefix } = useProject();
@@ -321,25 +335,27 @@ export function AgentSession({ id }: { id: string }) {
     repo?: string;
     title?: string;
     cwd?: string;
-	    separateCopy?: boolean;
-	    worktreePath?: string | null;
-	    worktreeGithub?: boolean;
-	    worktreeBase?: string;
-	  } | null>(null);
-	  // Exit banner state (separate-copy sessions). PR result/conflict/server
-	  // errors render inline; dismiss hides it for this pageview only.
-	  const [exitDismissed, setExitDismissed] = useState(false);
-	  const [exitBusy, setExitBusy] = useState(false);
-	  const [exitError, setExitError] = useState("");
-	  const [exitNotice, setExitNotice] = useState("");
-	  const [exitTargetBranch, setExitTargetBranch] = useState("");
-	  const [exitPrUrl, setExitPrUrl] = useState("");
-	  const [exitConflict, setExitConflict] = useState<{ targetBranch: string; files: string[] } | null>(null);
-	  const [openHint, setOpenHint] = useState("");
+    live?: boolean;
+    separateCopy?: boolean;
+    worktreePath?: string | null;
+    worktreeGithub?: boolean;
+    worktreeBase?: string;
+  } | null>(null);
+  // Exit banner state (separate-copy sessions). PR result/conflict/server
+  // errors render inline; dismiss hides it for this pageview only.
+  const [exitDismissed, setExitDismissed] = useState(false);
+  const [exitBusy, setExitBusy] = useState(false);
+  const [exitError, setExitError] = useState("");
+  const [exitNotice, setExitNotice] = useState("");
+  const [exitTargetBranch, setExitTargetBranch] = useState("");
+  const [exitPrUrl, setExitPrUrl] = useState("");
+  const [exitConflict, setExitConflict] = useState<{ targetBranch: string; files: string[] } | null>(null);
+  const [openHint, setOpenHint] = useState("");
   const [input, setInput] = useState("");
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [dragOver, setDragOver] = useState(false);
   const [sendError, setSendError] = useState("");
+  const [loadError, setLoadError] = useState("");
   const [busy, setBusy] = useState(false);
   const [connected, setConnected] = useState(false);
   // Optimistically-shown messages: rendered the instant you hit send, before
@@ -361,30 +377,38 @@ export function AgentSession({ id }: { id: string }) {
 
   // Metadata once
   useEffect(() => {
-    fetch(prefix(`/api/agents/sessions/${id}`))
+    const controller = new AbortController();
+    fetch(prefix(`/api/agents/sessions/${id}`), { signal: controller.signal })
       .then((r) => {
         if (r.status === 401) {
           window.location.href = `/login?from=${encodeURIComponent(`/agents/${id}`)}`;
           return null;
         }
+        if (!r.ok) throw new Error(r.status === 404 ? "This session could not be found." : "Could not load this session. Reload to try again.");
         return r.json();
       })
-	      .then((d) => {
-	        if (!d) return;
-	        setMeta({
-	          backend: d.backend,
-	          repo: d.repo,
-	          title: d.title,
-	          cwd: d.cwd,
-	          separateCopy: d.separateCopy,
-	          worktreePath: d.worktreePath ?? null,
-	          worktreeGithub: Boolean(d.worktreeGithub),
-	          worktreeBase: String(d.worktreeBase ?? "main"),
-	        });
-	        setExitTargetBranch((prev) => prev || String(d.worktreeBase ?? "main"));
-	      })
-      .catch(() => {});
-  }, [id]);
+      .then((d) => {
+        if (!d) return;
+        setMeta({
+          backend: d.backend,
+          repo: d.repo,
+          title: d.title,
+          cwd: d.cwd,
+          live: typeof d.live === "boolean" ? d.live : undefined,
+          separateCopy: d.separateCopy,
+          worktreePath: d.worktreePath ?? null,
+          worktreeGithub: Boolean(d.worktreeGithub),
+          worktreeBase: String(d.worktreeBase ?? "main"),
+        });
+        if (Array.isArray(d.events)) setEvents((prev) => mergeEvents(prev, d.events as SessionEvent[]));
+        if (d.live === false) setArchived(true);
+        setExitTargetBranch((prev) => prev || String(d.worktreeBase ?? "main"));
+      })
+      .catch((err: Error) => {
+        if (!controller.signal.aborted) setLoadError(err.message);
+      });
+    return () => controller.abort();
+  }, [id, prefix]);
 
   // SSE stream (replay + live). Events are buffered and flushed at most every
   // ~90ms — replaying hundreds of chunk events one render at a time froze the
@@ -395,11 +419,7 @@ export function AgentSession({ id }: { id: string }) {
     const flush = () => {
       if (buffer.length === 0) return;
       const batch = buffer.splice(0, buffer.length);
-      setEvents((prev) => {
-        const lastSeq = prev.length ? prev[prev.length - 1].seq : 0;
-        const fresh = batch.filter((e) => e.seq > lastSeq);
-        return fresh.length ? [...prev, ...fresh] : prev;
-      });
+      setEvents((prev) => mergeEvents(prev, batch));
     };
     const iv = setInterval(flush, 90);
     es.onopen = () => setConnected(true);
@@ -424,9 +444,10 @@ export function AgentSession({ id }: { id: string }) {
       clearInterval(iv);
       es.close();
     };
-  }, [id]);
+  }, [id, prefix]);
 
   const view = useMemo(() => reduceEvents(events), [events]);
+  const replayOnly = archived || meta?.live === false;
 
   // OpenCode only advertises custom commands + skills over ACP; its built-in
   // slash commands live in each of its UIs. Of those, /compact is the only one
@@ -505,6 +526,7 @@ export function AgentSession({ id }: { id: string }) {
   // meaningful after the agent commits — whereas the session diff goes empty
   // on a clean working tree, which would otherwise hide the whole panel.
   useEffect(() => {
+    if (!meta || replayOnly) return;
     let cancelled = false;
     fetch(prefix(`/api/agents/sessions/${id}/diff?scope=base`))
       .then((r) => (r.ok ? r.json() : null))
@@ -521,13 +543,13 @@ export function AgentSession({ id }: { id: string }) {
     return () => {
       cancelled = true;
     };
-  }, [id]);
+  }, [id, meta, prefix, replayOnly]);
 
   // Poll the session diff for the selected scope: promptly while the agent
   // works, lazily once idle, never when archived. Cheap for the small diffs
   // these sessions produce.
   useEffect(() => {
-    if (archived) return;
+    if (!meta || replayOnly) return;
     let cancelled = false;
     const load = () => {
       fetch(prefix(`/api/agents/sessions/${id}/diff?scope=${diffScope}`))
@@ -544,7 +566,7 @@ export function AgentSession({ id }: { id: string }) {
       cancelled = true;
       clearInterval(iv);
     };
-  }, [id, archived, view.status, diffScope]);
+  }, [id, meta, prefix, replayOnly, view.status, diffScope]);
 
   const act = useCallback(
     async (action: string, body: unknown = {}) => {
@@ -732,7 +754,7 @@ export function AgentSession({ id }: { id: string }) {
   // The banner appears once a separate-copy session has settled (idle), so the
   // user is prompted to bring the work home rather than leaving it stranded.
   const showExitBanner =
-    !archived && Boolean(meta?.separateCopy) && Boolean(meta?.worktreePath) && view.status === "idle" && !exitDismissed;
+    !replayOnly && Boolean(meta?.separateCopy) && Boolean(meta?.worktreePath) && view.status === "idle" && !exitDismissed;
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const dragDepth = useRef(0); // dragenter/leave fire per child — count to know when we truly left
@@ -740,11 +762,11 @@ export function AgentSession({ id }: { id: string }) {
   // One path for every way a file arrives: picker, paste, or drop. Any file
   // type is accepted — the agent decides what to do with it.
   const addFiles = useCallback(async (files: File[]) => {
-    if (archived || files.length === 0) return;
+    if (replayOnly || files.length === 0) return;
     const read = await Promise.all(files.map((f) => readFileAsAttachment(f)));
     const valid = read.filter((a) => a.data.length > 0);
     if (valid.length > 0) setAttachments((prev) => [...prev, ...valid]);
-  }, [archived]);
+  }, [replayOnly]);
 
   async function handlePaste(e: React.ClipboardEvent<HTMLTextAreaElement>) {
     // Pasted files (screenshots, copied files) arrive as clipboard items with a
@@ -767,13 +789,13 @@ export function AgentSession({ id }: { id: string }) {
   // Drag-and-drop onto the composer. Track a depth counter so the highlight
   // doesn't flicker as the cursor moves between the textarea and its siblings.
   function handleDragEnter(e: React.DragEvent) {
-    if (archived || !Array.from(e.dataTransfer.types).includes("Files")) return;
+    if (replayOnly || !Array.from(e.dataTransfer.types).includes("Files")) return;
     e.preventDefault();
     dragDepth.current += 1;
     setDragOver(true);
   }
   function handleDragOver(e: React.DragEvent) {
-    if (archived || !Array.from(e.dataTransfer.types).includes("Files")) return;
+    if (replayOnly || !Array.from(e.dataTransfer.types).includes("Files")) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = "copy";
   }
@@ -809,8 +831,12 @@ export function AgentSession({ id }: { id: string }) {
     document.addEventListener("mouseup", onMouseUp);
   }, [brainPct]);
 
-  const pill = archived ? { kind: "idle" as const, label: "Archived" } : statusPill(view.status);
-  const running = !archived && (view.status === "running" || view.status === "starting");
+  const pill = replayOnly ? { kind: "idle" as const, label: "Archived" } : statusPill(view.status);
+  const running = !replayOnly && (view.status === "running" || view.status === "starting");
+  const emptyTranscriptText = loadError || (replayOnly
+    ? "No chat transcript was captured for this archived session."
+    : "Waking the agent...");
+  const sessionTitle = meta?.title?.trim() || (meta?.backend ? `${meta.backend.toUpperCase()} session` : "Session");
 
   // Live "what's the agent doing right now" label, derived from the latest
   // activity — so you always know it's alive and whether it's thinking, running
@@ -846,17 +872,17 @@ export function AgentSession({ id }: { id: string }) {
         </button>
         <div className="min-w-0 flex-1">
           <p className="text-ink text-[15px] truncate" style={{ fontFamily: "var(--font-display)" }}>
-            {meta?.title ?? "Session"}
+            {sessionTitle}
           </p>
           <p style={{ fontFamily: "var(--font-mono)" }} className="text-[10px] uppercase tracking-wider text-text-muted">
-            {AGENT_NAMES[meta?.backend ?? ""] ?? meta?.backend} · {meta?.repo}
+            {agentName(meta?.backend)} · {meta?.repo}
             {/* Runs on an isolated copy of the branch, not the user's checkout. */}
             {meta?.separateCopy && (
               <span className="ml-1.5 rounded border border-line bg-cream px-1.5 py-0.5 normal-case tracking-normal text-text-muted">
                 separate copy
               </span>
             )}
-            {!connected && !archived && " · reconnecting…"}
+            {!connected && !replayOnly && " · reconnecting…"}
           </p>
           {/* Where the agent is working — the cloned repo folder — with quick
               openers so you can inspect the changes it's making. */}
@@ -898,7 +924,7 @@ export function AgentSession({ id }: { id: string }) {
           modes={view.modes}
           onChange={(configId, value) => act("config", { configId, value })}
           onModeChange={(modeId) => act("mode", { modeId })}
-          disabled={archived || busy}
+          disabled={replayOnly || busy}
         />
         <StatusPill kind={pill.kind}>{pill.label}</StatusPill>
         {running && (
@@ -921,7 +947,7 @@ export function AgentSession({ id }: { id: string }) {
           >
            <div ref={contentRef} className="flex flex-col gap-3">
             {view.blocks.length === 0 && (
-              <p className="text-text-muted text-[13px]">Waking the agent…</p>
+              <p className="text-text-muted text-[13px]">{emptyTranscriptText}</p>
             )}
             {view.blocks.map((b) => {
               switch (b.type) {
@@ -1266,7 +1292,7 @@ export function AgentSession({ id }: { id: string }) {
               <button
                 type="button"
                 onClick={() => fileInputRef.current?.click()}
-                disabled={archived}
+                disabled={replayOnly}
                 className="flex-shrink-0 h-9 w-9 flex items-center justify-center rounded-lg border border-line hover:bg-paper transition text-text-muted hover:text-ink disabled:opacity-50"
                 title="Attach files"
               >
@@ -1291,7 +1317,7 @@ export function AgentSession({ id }: { id: string }) {
                 fetchFiles={fetchFiles}
                 commands={commands}
                 placeholder={
-                  archived
+                  replayOnly
                     ? "This session ended before the last restart — start a new one to continue."
                     : running
                     ? "Steer the agent — this interrupts and redirects it… (@ to tag a file, / for commands, drop or paste files)"
@@ -1299,10 +1325,10 @@ export function AgentSession({ id }: { id: string }) {
                 }
                 rows={1}
                 autoGrow
-                disabled={archived}
+                disabled={replayOnly}
                 className="block w-full min-h-9 rounded-lg border border-line bg-paper px-3 py-2 text-[13.5px] leading-5 text-ink placeholder:text-text-muted/60 focus:outline-none resize-none disabled:opacity-50"
               />
-              <Button onClick={send} disabled={archived || (!input.trim() && attachments.length === 0) || busy}>
+              <Button onClick={send} disabled={replayOnly || (!input.trim() && attachments.length === 0) || busy}>
                 {running ? "Steer" : "Send"}
               </Button>
             </div>

--- a/dashboard/src/components/AgentsView.tsx
+++ b/dashboard/src/components/AgentsView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useProject } from "@/lib/useProject";
 import { Kicker, Heading, Card, StatusPill } from "@/components/ui";
@@ -51,7 +52,7 @@ const AGENT_BRANDS: Record<string, BrandName> = {
 const ACTIVE_STATUSES = new Set(["starting", "running", "waiting"]);
 
 function AgentBrandIcon({ backend, className }: { backend: string; className?: string }) {
-  const name = AGENT_BRANDS[backend];
+  const name = AGENT_BRANDS[backend.startsWith("ext:") ? backend.slice(4) : backend];
   if (!name) return <span aria-hidden>○</span>;
   return <BrandIcon name={name} size={16} className={className} />;
 }
@@ -176,7 +177,7 @@ export function AgentsView() {
           onNewSession={startInCopy}
           onChanged={refresh}
         />
-        <SessionsColumn sessions={sessions} loading={loading} onNavigate={navigate} />
+        <SessionsColumn sessions={sessions} loading={loading} />
       </div>
     </div>
   );
@@ -196,21 +197,22 @@ interface SessionSearchHit extends Omit<SessionRow, "live"> {
 function SessionCard({
   s,
   snippet,
-  onNavigate,
+  href,
 }: {
   s: Omit<SessionRow, "live">;
   snippet?: string | null;
-  onNavigate: (sid: string) => void;
+  href: string;
 }) {
+  const title = s.title?.trim() || `${s.backend.toUpperCase()} session`;
   return (
-    <button
-      onClick={() => onNavigate(s.id)}
+    <Link
+      href={href}
       className="text-left rounded-lg border border-line bg-paper px-3.5 py-2.5 hover:bg-cream transition flex items-center gap-3 cursor-pointer"
     >
       <AgentBrandIcon backend={s.backend} className="text-ink flex-shrink-0" />
       <div className="min-w-0 flex-1">
         <p className="text-ink text-[13px] truncate font-medium" style={{ fontFamily: "var(--font-display)" }}>
-          {s.title}
+          {title}
         </p>
         <p style={{ fontFamily: "var(--font-mono)" }} className="text-[10px] uppercase tracking-wider text-text-muted mt-0.5 truncate">
           {s.backend} · {timeAgo(s.updated_at)}
@@ -223,18 +225,16 @@ function SessionCard({
         {snippet ? <p className="text-text-muted text-[11.5px] mt-1 line-clamp-2">{snippet}</p> : null}
       </div>
       <StatusPill kind={statusKind(s.status)}>{statusLabel(s.status)}</StatusPill>
-    </button>
+    </Link>
   );
 }
 
 function SessionsColumn({
   sessions,
   loading,
-  onNavigate,
 }: {
   sessions: SessionRow[];
   loading: boolean;
-  onNavigate: (sid: string) => void;
 }) {
   const { prefix } = useProject();
   const [showAll, setShowAll] = useState(false);
@@ -298,7 +298,7 @@ function SessionsColumn({
               <p className="text-text-muted text-[13px]">No sessions match that.</p>
             )}
             {results.map((s) => (
-              <SessionCard key={s.id} s={s} snippet={s.snippet} onNavigate={onNavigate} />
+              <SessionCard key={s.id} s={s} snippet={s.snippet} href={prefix(`/agents/${s.id}`)} />
             ))}
           </>
         ) : (
@@ -307,7 +307,7 @@ function SessionsColumn({
               <p className="text-text-muted text-[13px]">No sessions yet — start one above.</p>
             )}
             {shown.map((s) => (
-              <SessionCard key={s.id} s={s} onNavigate={onNavigate} />
+              <SessionCard key={s.id} s={s} href={prefix(`/agents/${s.id}`)} />
             ))}
           </>
         )}

--- a/orchestrator/src/agents/routes.ts
+++ b/orchestrator/src/agents/routes.ts
@@ -43,6 +43,7 @@ import {
   openWorktreeLocation,
   worktreeDiffAt,
   listSessions,
+  readSessionMetadata,
   readTranscript,
   recordGraphActivity,
   slimEvent,
@@ -203,9 +204,9 @@ export function registerAgentRoutes(app: FastifyInstance): void {
   app.get("/v1/agents/sessions/:id", async (req, reply) => {
     const { id } = req.params as { id: string };
     const live = getSession(id);
-    const rows = listSessions().filter((s) => s.id === id);
-    if (!live && rows.length === 0) return reply.code(404).send({ error: "unknown session" });
-    const meta = rows[0] ?? {};
+    const row = readSessionMetadata(id);
+    if (!live && !row) return reply.code(404).send({ error: "unknown session" });
+    const meta = row ?? {};
     return {
       ...meta,
       // Runs in an isolated "separate copy" (worktree) rather than the user's

--- a/orchestrator/src/agents/runtime.ts
+++ b/orchestrator/src/agents/runtime.ts
@@ -673,10 +673,7 @@ export function getSession(id: string): LiveSession | undefined {
   return liveSession(id);
 }
 
-export function listSessions(): Array<Record<string, unknown>> {
-  const rows = db
-    .prepare(`
-      SELECT
+const SESSION_COLUMNS = `
         id,
         backend,
         repo,
@@ -690,7 +687,19 @@ export function listSessions(): Array<Record<string, unknown>> {
         start_untracked,
         worktree_id,
         created_at,
-        updated_at
+        updated_at`;
+
+export function readSessionMetadata(id: string): Record<string, unknown> | undefined {
+  const row = db.prepare(`SELECT ${SESSION_COLUMNS} FROM agent_sessions WHERE id = ?`).get(id) as Record<string, unknown> | undefined;
+  if (!row) return undefined;
+  const live = sessions.get(id);
+  return { ...row, live: Boolean(live), status: live?.status ?? row.status };
+}
+
+export function listSessions(): Array<Record<string, unknown>> {
+  const rows = db
+    .prepare(`
+      SELECT ${SESSION_COLUMNS}
       FROM agent_sessions
       ORDER BY created_at DESC
       LIMIT 100

--- a/orchestrator/test/ingest.test.ts
+++ b/orchestrator/test/ingest.test.ts
@@ -16,6 +16,7 @@ process.env.FLOW_ADMIN_TOKEN = "test-token-ingest";
 process.env.FLOW_FAKE_OPENCODE = "1";
 process.env.FLOW_DRAIN_DISABLE = "1";
 process.env.FLOW_DISTILLER = "0"; // no LLM in unit tests; trigger wiring asserted via status
+process.env.FLOW_SESSION_SEARCH = "0";
 
 import { test, describe, before, after } from "node:test";
 import assert from "node:assert/strict";
@@ -31,6 +32,8 @@ before(async () => {
   ({ readTranscript } = await import("../src/agents/runtime.js"));
   app = Fastify();
   routes.registerIngestRoutes(app);
+  const { registerAgentRoutes } = await import("../src/agents/routes.js");
+  registerAgentRoutes(app);
   await app.ready();
 });
 
@@ -41,6 +44,37 @@ after(async () => {
 
 const SID = "e3948326-fe79-4a81-95d9-89cd63f1318b";
 const TP = `/Users/u/.claude/projects/-Users-u-spike/${SID}.jsonl`;
+
+test("archived session details replay beyond the newest 100 sessions", async (t) => {
+  const { db } = await import("../src/db.js");
+  const { appendTranscriptEvents } = await import("../src/agents/runtime.js");
+  const insert = db.prepare(`INSERT INTO agent_sessions
+    (id, backend, repo, cwd, title, status, created_at, updated_at)
+    VALUES (?, 'ext:claude', 'spike-repo', '/tmp', 'Archive replay', 'closed', ?, ?)`);
+  const id = "archive-replay-oldest";
+  t.after(() => db.prepare("DELETE FROM agent_sessions WHERE id LIKE 'archive-replay-%'").run());
+  for (let i = 0; i <= 100; i++) {
+    insert.run(i === 0 ? id : `archive-replay-${i}`, i, i);
+  }
+  appendTranscriptEvents(id, [
+    { kind: "user_prompt", data: { text: "Saved prompt" } },
+    { kind: "update", data: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "Saved response" } } },
+  ]);
+
+  const list = await app.inject({ method: "GET", url: "/v1/agents/sessions" });
+  assert.equal(list.json().sessions.length, 100);
+  assert.ok(!list.json().sessions.some((s: { id: string }) => s.id === id));
+
+  const detail = await app.inject({ method: "GET", url: `/v1/agents/sessions/${id}` });
+  assert.equal(detail.statusCode, 200, detail.body);
+  assert.equal(detail.json().id, id);
+  assert.equal(detail.json().live, false);
+  assert.deepEqual(detail.json().events.map((e: { kind: string }) => e.kind), ["user_prompt", "update"]);
+  assert.equal(detail.json().events[1].data.content.text, "Saved response");
+
+  const missing = await app.inject({ method: "GET", url: "/v1/agents/sessions/archive-replay-missing" });
+  assert.equal(missing.statusCode, 404);
+});
 
 const claudeEvents = [
   { session_id: SID, transcript_path: TP, cwd: "/Users/u/spike", hook_event_name: "SessionStart", source: "startup" },


### PR DESCRIPTION
Past sessions could appear stuck on "Waking the agent" when no chat was captured, and sessions older than the newest 100 records could return 404 even though their metadata and transcript still existed.

Look up session metadata by ID, merge metadata replay with SSE events by sequence, and reset the session view when navigating between IDs. Archived sessions now show an explicit empty state and skip live controls and diff polling; failed metadata loads show an error. History entries use links, fallback titles, and external-agent branding.

Validation:
- Dashboard production build passed.
- 13 targeted ingest/runtime tests passed with Node 22, including replay beyond the newest 100 records and a missing-session 404.
- Browser checks confirmed session-link navigation, captured transcript rendering, and the archived empty state on localhost:7600.
- Focused lint still reports pre-existing React purity and set-state-in-effect errors in AgentSession.tsx.

The backend lookup change takes effect after restarting the orchestrator. The local dashboard was refreshed; active orchestrator sessions were preserved.
