### PR TITLE
Standardize dashboard title weights and home-page typography

### DIFF
--- a/dashboard/src/app/activity/page.tsx
+++ b/dashboard/src/app/activity/page.tsx
@@ -358,7 +358,7 @@ export default function ActivityPage() {
               <div className="text-center py-6">
                 <p
                   style={{ fontFamily: "var(--font-display)" }}
-                  className="text-ink text-[17px] mb-1"
+                  className="text-ink text-[17px] font-medium mb-1"
                 >
                   Nothing yet.
                 </p>

--- a/dashboard/src/app/connections/page.tsx
+++ b/dashboard/src/app/connections/page.tsx
@@ -63,7 +63,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
         style={{
           margin: "0 0 16px",
           fontSize: 14,
-          fontWeight: 600,
+          fontWeight: 500,
           color: "var(--text-primary)",
           borderBottom: "1px solid var(--border)",
           paddingBottom: 12,
@@ -325,7 +325,7 @@ export default function ConnectionsPage() {
   return (
     <Shell>
       <div style={{ marginBottom: 28 }}>
-        <h1 style={{ margin: 0, fontSize: 22, fontWeight: 700, color: "var(--text-primary)" }}>
+        <h1 style={{ margin: 0, fontSize: 22, fontWeight: 500, color: "var(--text-primary)" }}>
           Connections
         </h1>
         <p style={{ margin: "6px 0 0", fontSize: 13, color: "var(--text-secondary)" }}>
@@ -422,7 +422,7 @@ export default function ConnectionsPage() {
             }}
           >
             <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 4 }}>
-              <span style={{ fontSize: 13, fontWeight: 600, color: "var(--text-primary)" }}>Linear</span>
+              <span style={{ fontSize: 13, fontWeight: 500, color: "var(--text-primary)" }}>Linear</span>
               <StatusBadge on={!!status?.linear_key} />
             </div>
             <div style={{ fontSize: 12, color: "var(--text-muted)" }}>
@@ -440,7 +440,7 @@ export default function ConnectionsPage() {
             }}
           >
             <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 4 }}>
-              <span style={{ fontSize: 13, fontWeight: 600, color: "var(--text-primary)" }}>GitHub</span>
+              <span style={{ fontSize: 13, fontWeight: 500, color: "var(--text-primary)" }}>GitHub</span>
               <span
                 style={{
                   fontSize: 11,
@@ -470,7 +470,7 @@ export default function ConnectionsPage() {
             }}
           >
             <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 4 }}>
-              <span style={{ fontSize: 13, fontWeight: 600, color: "var(--text-primary)" }}>Fireflies</span>
+              <span style={{ fontSize: 13, fontWeight: 500, color: "var(--text-primary)" }}>Fireflies</span>
               <StatusBadge on={!!status?.fireflies_key} />
             </div>
             <div style={{ fontSize: 12, color: "var(--text-muted)" }}>

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -129,7 +129,7 @@ body {
 .markdown-body h6 {
   font-family: var(--font-display);
   color: var(--ink);
-  font-weight: 600;
+  font-weight: 500;
   line-height: 1.3;
   margin: 1.1em 0 0.5em;
 }

--- a/dashboard/src/app/knowledge/page.tsx
+++ b/dashboard/src/app/knowledge/page.tsx
@@ -233,7 +233,7 @@ export default function KnowledgePage() {
   return (
     <Shell>
       <div style={{ marginBottom: 24 }}>
-        <h1 style={{ margin: 0, fontSize: 22, fontWeight: 700, color: "var(--text-primary)" }}>Knowledge Base</h1>
+        <h1 style={{ margin: 0, fontSize: 22, fontWeight: 500, color: "var(--text-primary)" }}>Knowledge Base</h1>
         <p style={{ margin: "6px 0 0", fontSize: 13, color: "var(--text-secondary)" }}>
           Everything Flow has learned — distilled memories with who contributed them, plus raw knowledge from Slack,
           Linear and meetings. Delete anything that&apos;s wrong; agents stop recalling it immediately.
@@ -296,7 +296,7 @@ export default function KnowledgePage() {
         <>
           {/* Distilled memories */}
           <section style={{ marginBottom: 32 }}>
-            <h2 style={{ margin: "0 0 12px", fontSize: 15, fontWeight: 700, color: "var(--text-primary)" }}>
+            <h2 style={{ margin: "0 0 12px", fontSize: 15, fontWeight: 500, color: "var(--text-primary)" }}>
               Memories {memories.length > 0 && <span style={{ color: "var(--text-muted)" }}>({memories.length})</span>}
             </h2>
             {memories.length === 0 ? (
@@ -387,7 +387,7 @@ export default function KnowledgePage() {
 
           {/* Raw corpus knowledge — slack / linear / meetings */}
           <section style={{ marginBottom: 32 }}>
-            <h2 style={{ margin: "0 0 4px", fontSize: 15, fontWeight: 700, color: "var(--text-primary)" }}>
+            <h2 style={{ margin: "0 0 4px", fontSize: 15, fontWeight: 500, color: "var(--text-primary)" }}>
               From Slack, Linear &amp; meetings{" "}
               {corpusTotal > 0 && <span style={{ color: "var(--text-muted)" }}>({corpusTotal})</span>}
             </h2>
@@ -463,7 +463,7 @@ export default function KnowledgePage() {
                 padding: 0,
                 cursor: "pointer",
                 fontSize: 15,
-                fontWeight: 700,
+                fontWeight: 500,
                 color: "var(--text-primary)",
                 marginBottom: 12,
               }}

--- a/dashboard/src/app/login/page.tsx
+++ b/dashboard/src/app/login/page.tsx
@@ -160,14 +160,14 @@ function LoginForm() {
           >
             F
           </div>
-          <span style={{ fontWeight: 700, fontSize: 20, color: "var(--text-primary)" }}>Flow</span>
+          <span style={{ fontWeight: 500, fontSize: 20, color: "var(--text-primary)" }}>Flow</span>
         </div>
 
         <h1
           style={{
             margin: "0 0 6px",
             fontSize: 18,
-            fontWeight: 600,
+            fontWeight: 500,
             color: "var(--text-primary)",
           }}
         >

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -203,7 +203,7 @@ export default function HomePage() {
       <div className="min-h-screen flex items-center justify-center px-6 bg-cream">
         <div className="w-full max-w-lg rise-in text-center">
           <div className="inline-block w-2.5 h-2.5 rounded-full bg-accent animate-pulse mb-6" />
-          <h1 className="font-display text-[32px] leading-tight mb-3">
+          <h1 className="font-display font-medium text-[32px] leading-tight mb-3">
             Flow&apos;s engine isn&apos;t reachable.
           </h1>
           <p className="text-text-muted text-[15px] leading-relaxed mb-6">

--- a/dashboard/src/app/permissions/page.tsx
+++ b/dashboard/src/app/permissions/page.tsx
@@ -166,7 +166,7 @@ export default function PermissionsPage() {
   return (
     <Shell>
       <div style={{ marginBottom: 28 }}>
-        <h1 style={{ margin: 0, fontSize: 22, fontWeight: 700, color: "var(--text-primary)" }}>
+        <h1 style={{ margin: 0, fontSize: 22, fontWeight: 500, color: "var(--text-primary)" }}>
           Permissions
         </h1>
         <p style={{ margin: "6px 0 0", fontSize: 13, color: "var(--text-secondary)" }}>
@@ -251,7 +251,7 @@ export default function PermissionsPage() {
                 padding: "12px 20px",
                 borderBottom: "1px solid var(--border)",
                 fontSize: 12,
-                fontWeight: 700,
+                fontWeight: 500,
                 color: "var(--text-secondary)",
                 textTransform: "uppercase",
                 letterSpacing: "0.06em",

--- a/dashboard/src/app/settings/page.tsx
+++ b/dashboard/src/app/settings/page.tsx
@@ -257,7 +257,7 @@ function Section({
         style={{
           margin: "0 0 18px",
           fontSize: 14,
-          fontWeight: 600,
+          fontWeight: 500,
           color: "var(--text-primary)",
           borderBottom: "1px solid var(--border)",
           paddingBottom: 12,
@@ -469,7 +469,7 @@ export default function SettingsPage() {
           style={{
             margin: 0,
             fontSize: 22,
-            fontWeight: 700,
+            fontWeight: 500,
             color: "var(--text-primary)",
           }}
         >

--- a/dashboard/src/components/AccessSettings.tsx
+++ b/dashboard/src/components/AccessSettings.tsx
@@ -29,7 +29,7 @@ const panel: React.CSSProperties = {
   marginBottom: 20,
 };
 
-const h2: React.CSSProperties = { margin: "0 0 4px", fontSize: 15, fontWeight: 600, color: "var(--text-primary)" };
+const h2: React.CSSProperties = { margin: "0 0 4px", fontSize: 15, fontWeight: 500, color: "var(--text-primary)" };
 const sub: React.CSSProperties = { margin: "0 0 16px", fontSize: 12.5, color: "var(--text-secondary)" };
 const inputStyle: React.CSSProperties = {
   padding: "8px 10px",

--- a/dashboard/src/components/AddFolder.tsx
+++ b/dashboard/src/components/AddFolder.tsx
@@ -265,7 +265,7 @@ function SourceConfigModal({
 
         {own.length > 0 && (
           <div style={{ marginTop: 12 }}>
-            <div style={{ fontSize: 12, fontWeight: 600, color: "var(--ink)", marginBottom: 2 }}>Your repos</div>
+            <div style={{ fontSize: 12, fontWeight: 500, color: "var(--ink)", marginBottom: 2 }}>Your repos</div>
             {own.map(repoRow)}
           </div>
         )}
@@ -338,7 +338,7 @@ function SourceConfigModal({
       >
         {/* Header */}
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "14px 20px", borderBottom: "1px solid var(--line)" }}>
-          <span style={{ fontSize: 14, fontWeight: 600, color: "var(--ink)" }}>
+          <span style={{ fontSize: 14, fontWeight: 500, color: "var(--ink)" }}>
             Configure sources
           </span>
           <button

--- a/dashboard/src/components/AgentPanel.tsx
+++ b/dashboard/src/components/AgentPanel.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { useProject } from "@/lib/useProject";
-import { Kicker, StatusPill } from "@/components/ui";
+import { BodyText, Heading, StatusPill } from "@/components/ui";
 import { BrandIcon, type BrandName } from "@/components/BrandIcon";
 import { AgentTaskComposer } from "@/components/AgentTaskComposer";
 
@@ -87,18 +87,14 @@ export function AgentPanel({ nodeCount, selectedNodeTag, onClearNodeTag }: Agent
       style={{ boxShadow: "0 1px 3px rgba(0,0,0,0.04)" }}
     >
       <div className="flex flex-col gap-4">
-        {/* Header — typography mirrors the "your AI interfaces" card: the two
-            panels are one decision (which interface do you drive Flow from?),
-            so they must read as siblings. */}
         <div className="border-b border-line pb-3">
-          <div className="text-[11px] uppercase tracking-widest text-ink/50">Flow&apos;s interface</div>
-          <h2 className="text-[20px] mt-0.5" style={{ fontFamily: "var(--font-display)" }}>
+          <Heading variant="section">
             Or run agents right here
-          </h2>
-          <p className="text-[12px] text-ink/55 mt-1 leading-snug">
+          </Heading>
+          <BodyText className="mt-1">
             Same brain, your own subscriptions — tasks run on the CLIs already installed on your
             machine. The only difference is which interface you drive from.
-          </p>
+          </BodyText>
         </div>
 
         {/* Task Composer Box */}
@@ -112,8 +108,8 @@ export function AgentPanel({ nodeCount, selectedNodeTag, onClearNodeTag }: Agent
 
       {/* Recent Sessions */}
       <div className="flex flex-col gap-2.5 border-t border-line pt-4 mt-2">
-        <div className="flex items-center justify-between">
-          <Kicker>Recent Sessions</Kicker>
+        <div className="flex items-center justify-between flex-wrap gap-2">
+          <Heading as="h3" variant="card">Recent Sessions</Heading>
           <Link
             href={prefix("/agents")}
             className="text-[10px] text-text-muted hover:text-ink font-mono uppercase tracking-wider transition-colors"
@@ -123,9 +119,9 @@ export function AgentPanel({ nodeCount, selectedNodeTag, onClearNodeTag }: Agent
         </div>
 
         {sessions.length === 0 ? (
-          <p className="text-[11px] text-text-muted italic py-1 text-center font-mono">
+          <BodyText className="py-1 text-center">
             No agent sessions run yet.
-          </p>
+          </BodyText>
         ) : (
           <div className="flex flex-col gap-2 max-h-52 overflow-y-auto pr-1">
             {sessions.slice(0, 4).map((s) => (
@@ -135,10 +131,10 @@ export function AgentPanel({ nodeCount, selectedNodeTag, onClearNodeTag }: Agent
                 className="flex items-center justify-between p-2.5 rounded-lg border border-line bg-cream hover:bg-sand transition-colors text-decoration-none group"
               >
                 <div className="min-w-0 flex-1 mr-2">
-                  <div className="text-[12.5px] font-medium text-ink truncate group-hover:underline">
+                  <div className="text-[12px] leading-relaxed font-medium text-ink truncate group-hover:underline">
                     {s.title || "Untitled task"}
                   </div>
-                  <div className="text-[10px] text-text-muted font-mono truncate flex items-center gap-1.5 mt-0.5">
+                  <div className="text-[11px] text-text-muted truncate flex items-center gap-1.5 mt-0.5">
                     <BrandIcon
                       name={AGENT_BRANDS[s.backend] || "opencode"}
                       size={12}

--- a/dashboard/src/components/AgentSession.tsx
+++ b/dashboard/src/components/AgentSession.tsx
@@ -871,7 +871,7 @@ export function AgentSession({ id }: { id: string }) {
           ←
         </button>
         <div className="min-w-0 flex-1">
-          <p className="text-ink text-[15px] truncate" style={{ fontFamily: "var(--font-display)" }}>
+          <p className="text-ink text-[15px] font-medium truncate" style={{ fontFamily: "var(--font-display)" }}>
             {sessionTitle}
           </p>
           <p style={{ fontFamily: "var(--font-mono)" }} className="text-[10px] uppercase tracking-wider text-text-muted">

--- a/dashboard/src/components/AgentsView.tsx
+++ b/dashboard/src/components/AgentsView.tsx
@@ -152,7 +152,7 @@ export function AgentsView() {
           <div className="mt-2 mb-4">
             <h2
               style={{ fontFamily: "var(--font-display)" }}
-              className="text-base font-semibold text-ink"
+              className="text-base font-medium text-ink"
             >
               Start a new coding task
             </h2>

--- a/dashboard/src/components/BrainGraph.tsx
+++ b/dashboard/src/components/BrainGraph.tsx
@@ -548,7 +548,7 @@ export function BrainGraph({
               </div>
               <p
                 style={{ fontFamily: "var(--font-display)" }}
-                className="text-white/50 text-sm mb-1"
+                className="text-white/50 text-sm font-medium mb-1"
               >
                 {graphUnavailable
                   ? "Brain gateway unavailable."

--- a/dashboard/src/components/CodingToolsPanel.tsx
+++ b/dashboard/src/components/CodingToolsPanel.tsx
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useProject } from "@/lib/useProject";
 import { FolderPickerDialog } from "./FolderPickerDialog";
 import { BrandIcon, type BrandName } from "./BrandIcon";
+import { BodyText, Heading } from "./ui";
 
 interface ConnectedRepo {
   path: string;
@@ -153,14 +154,13 @@ export function CodingToolsPanel() {
     <div className="flex flex-col gap-3.5 p-5 rounded-2xl border border-line bg-paper shadow-xs rise-in h-full">
       {/* Header — value first: your tools, Flow-powered */}
       <div className="border-b border-line pb-3">
-        <div className="text-[11px] uppercase tracking-widest text-ink/50">Your AI interfaces</div>
-        <h2 className="text-[20px] mt-0.5" style={{ fontFamily: "var(--font-display)" }}>
+        <Heading variant="section">
           Use Flow in your own AI tools
-        </h2>
-        <p className="text-[12px] text-ink/55 mt-1 leading-snug">
+        </Heading>
+        <BodyText className="mt-1">
           Keep working where you already work. Connect a workspace and your AI interfaces get this
           project&apos;s memory — and every session they run teaches it.
-        </p>
+        </BodyText>
       </div>
 
       {/* The user's tools, up top: "yes, mine are covered" */}
@@ -282,7 +282,7 @@ export function CodingToolsPanel() {
           })}
         </div>
       ) : (
-        <div className="text-[12px] text-ink/50 py-1">No workspaces connected yet — sessions there aren&apos;t reaching the brain.</div>
+        <BodyText className="py-1">No workspaces connected yet — sessions there aren&apos;t reaching the brain.</BodyText>
       )}
 
       {/* Surfaces Flow can't listen to locally — the honest "later" cards */}
@@ -290,19 +290,19 @@ export function CodingToolsPanel() {
         <div className="flex items-start gap-2 p-2.5 rounded-xl border border-dashed border-line bg-sand/40">
           <span className="text-ink/50 mt-0.5"><BrandIcon name="openai" size={13} /></span>
           <div>
-            <div className="text-[11px] font-medium text-ink/70">ChatGPT chats</div>
-            <div className="text-[10px] text-ink/45 leading-snug">
+            <Heading as="h3" variant="card">ChatGPT chats</Heading>
+            <BodyText>
               Needs a public connector — coming with your team deployment. (The desktop app&apos;s Codex view is already covered above.)
-            </div>
+            </BodyText>
           </div>
         </div>
         <div className="flex items-start gap-2 p-2.5 rounded-xl border border-dashed border-line bg-sand/40">
           <span className="text-ink/50 mt-0.5"><BrandIcon name="anthropic" size={13} /></span>
           <div>
-            <div className="text-[11px] font-medium text-ink/70">claude.ai &amp; Cowork</div>
-            <div className="text-[10px] text-ink/45 leading-snug">
+            <Heading as="h3" variant="card">claude.ai &amp; Cowork</Heading>
+            <BodyText>
               Needs a public connector + skill upload — coming with your team deployment. Works on every plan once live.
-            </div>
+            </BodyText>
           </div>
         </div>
       </div>

--- a/dashboard/src/components/FolderPickerDialog.tsx
+++ b/dashboard/src/components/FolderPickerDialog.tsx
@@ -62,7 +62,7 @@ export function FolderPickerDialog({
       >
         {/* Header */}
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "14px 20px", borderBottom: "1px solid var(--line)" }}>
-          <span style={{ fontSize: 14, fontWeight: 600, color: "var(--ink)" }}>Choose a folder</span>
+          <span style={{ fontSize: 14, fontWeight: 500, color: "var(--ink)" }}>Choose a folder</span>
           <button
             onClick={onClose}
             style={{ background: "none", border: "none", fontSize: 20, cursor: "pointer", color: "var(--text-muted)", lineHeight: 1, padding: "0 2px" }}

--- a/dashboard/src/components/IntegrationCatalog.tsx
+++ b/dashboard/src/components/IntegrationCatalog.tsx
@@ -5,7 +5,7 @@ import { BrandIcon } from "@/components/BrandIcon";
 import { RepoPicker } from "@/components/RepoPicker";
 import { AddFolder } from "@/components/AddFolder";
 import { SlackBotCard } from "@/components/SlackBotCard";
-import { Button, StatusPill, Kicker } from "@/components/ui";
+import { BodyText, Button, Heading } from "@/components/ui";
 import { useProject } from "@/lib/useProject";
 import { FlowMode } from "@/lib/useMode";
 
@@ -111,15 +111,7 @@ export function IntegrationCatalog({
   return (
     <div className="flex flex-col gap-4 p-5 rounded-2xl border border-line bg-paper shadow-xs rise-in">
       <div className="flex items-center justify-between border-b border-line pb-3">
-        <div>
-          <Kicker>Integrations & Sources</Kicker>
-          <h2
-            style={{ fontFamily: "var(--font-display)" }}
-            className="text-lg font-semibold text-ink mt-0.5"
-          >
-            Connect code and business context
-          </h2>
-        </div>
+        <Heading variant="section">Connect code and business context</Heading>
       </div>
 
       {msg && (
@@ -130,7 +122,7 @@ export function IntegrationCatalog({
       )}
 
       {/* Compact Grid of Small Integration Cards: Centered Naked Icon, Name, Description, Connect Button */}
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
+      <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-3">
         {/* 1. GitHub Repositories */}
         <div className="rounded-xl border border-line bg-cream p-4 flex flex-col items-center text-center justify-between hover:border-ink/30 transition-all gap-2 min-h-[195px]">
           <div className="flex items-center justify-center pt-1 text-ink">
@@ -138,12 +130,12 @@ export function IntegrationCatalog({
           </div>
 
           <div className="flex flex-col items-center gap-0.5">
-            <h3 style={{ fontFamily: "var(--font-display)" }} className="text-xs font-semibold text-ink">
+            <Heading as="h3" variant="card">
               GitHub Repos
-            </h3>
-            <p className="text-text-muted text-[10px] leading-tight line-clamp-2">
+            </Heading>
+            <BodyText>
               Sync remote git repos & branches
-            </p>
+            </BodyText>
           </div>
 
           <Button
@@ -164,12 +156,12 @@ export function IntegrationCatalog({
           </div>
 
           <div className="flex flex-col items-center gap-0.5">
-            <h3 style={{ fontFamily: "var(--font-display)" }} className="text-xs font-semibold text-ink">
+            <Heading as="h3" variant="card">
               Local Folder
-            </h3>
-            <p className="text-text-muted text-[10px] leading-tight line-clamp-2">
+            </Heading>
+            <BodyText>
               Connect local folder or checkout
-            </p>
+            </BodyText>
           </div>
 
           <Button
@@ -188,12 +180,12 @@ export function IntegrationCatalog({
           </div>
 
           <div className="flex flex-col items-center gap-0.5">
-            <h3 style={{ fontFamily: "var(--font-display)" }} className="text-xs font-semibold text-ink">
+            <Heading as="h3" variant="card">
               Linear
-            </h3>
-            <p className="text-text-muted text-[10px] leading-tight line-clamp-2">
+            </Heading>
+            <BodyText>
               Sync issues, specs & tickets
-            </p>
+            </BodyText>
           </div>
 
           <Button
@@ -212,12 +204,12 @@ export function IntegrationCatalog({
           </div>
 
           <div className="flex flex-col items-center gap-0.5">
-            <h3 style={{ fontFamily: "var(--font-display)" }} className="text-xs font-semibold text-ink">
+            <Heading as="h3" variant="card">
               Fireflies.ai
-            </h3>
-            <p className="text-text-muted text-[10px] leading-tight line-clamp-2">
+            </Heading>
+            <BodyText>
               Import meeting transcripts
-            </p>
+            </BodyText>
           </div>
 
           <Button
@@ -236,12 +228,12 @@ export function IntegrationCatalog({
           </div>
 
           <div className="flex flex-col items-center gap-0.5">
-            <h3 style={{ fontFamily: "var(--font-display)" }} className="text-xs font-semibold text-ink">
+            <Heading as="h3" variant="card">
               Meeting Notes
-            </h3>
-            <p className="text-text-muted text-[10px] leading-tight line-clamp-2">
+            </Heading>
+            <BodyText>
               Paste raw transcript or notes
-            </p>
+            </BodyText>
           </div>
 
           <Button
@@ -260,12 +252,12 @@ export function IntegrationCatalog({
           </div>
 
           <div className="flex flex-col items-center gap-0.5">
-            <h3 style={{ fontFamily: "var(--font-display)" }} className="text-xs font-semibold text-ink">
+            <Heading as="h3" variant="card">
               Slack Bot
-            </h3>
-            <p className="text-text-muted text-[10px] leading-tight line-clamp-2">
+            </Heading>
+            <BodyText>
               Ask Flow questions in Slack
-            </p>
+            </BodyText>
           </div>
 
           <button

--- a/dashboard/src/components/IntegrationCatalog.tsx
+++ b/dashboard/src/components/IntegrationCatalog.tsx
@@ -278,7 +278,7 @@ export function IntegrationCatalog({
             <div className="p-4 border-b border-line flex items-center justify-between bg-sand">
               <div className="flex items-center gap-2">
                 <BrandIcon name="opencode" size={20} />
-                <span className="font-semibold text-ink text-sm">Connect GitHub Repositories</span>
+                <span className="font-medium text-ink text-sm">Connect GitHub Repositories</span>
               </div>
               <button onClick={() => setActiveModal("none")} className="text-text-muted hover:text-ink text-lg">✕</button>
             </div>
@@ -298,7 +298,7 @@ export function IntegrationCatalog({
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-xs p-4">
           <div className="bg-paper border border-line rounded-2xl w-full max-w-lg p-5 shadow-2xl rise-in flex flex-col gap-4">
             <div className="flex items-center justify-between border-b border-line pb-3">
-              <span className="font-semibold text-ink text-sm">Connect Local Folder</span>
+              <span className="font-medium text-ink text-sm">Connect Local Folder</span>
               <button onClick={() => setActiveModal("none")} className="text-text-muted hover:text-ink text-lg">✕</button>
             </div>
             <AddFolder mode={mode} onAdded={() => { setActiveModal("none"); onChanged(); }} />
@@ -314,7 +314,7 @@ export function IntegrationCatalog({
             <div className="flex items-center justify-between border-b border-line pb-3">
               <div className="flex items-center gap-2">
                 <BrandIcon name="slack" size={20} />
-                <span className="font-semibold text-ink text-sm">Slack bot</span>
+                <span className="font-medium text-ink text-sm">Slack bot</span>
               </div>
               <button
                 onClick={() => {
@@ -337,7 +337,7 @@ export function IntegrationCatalog({
             <div className="flex items-center justify-between border-b border-line pb-3">
               <div className="flex items-center gap-2">
                 <BrandIcon name="linear" size={20} />
-                <span className="font-semibold text-ink text-sm">Connect Linear</span>
+                <span className="font-medium text-ink text-sm">Connect Linear</span>
               </div>
               <button onClick={() => setActiveModal("none")} className="text-text-muted hover:text-ink text-lg">✕</button>
             </div>
@@ -371,7 +371,7 @@ export function IntegrationCatalog({
             <div className="flex items-center justify-between border-b border-line pb-3">
               <div className="flex items-center gap-2">
                 <BrandIcon name="fireflies" size={20} />
-                <span className="font-semibold text-ink text-sm">Connect Fireflies.ai</span>
+                <span className="font-medium text-ink text-sm">Connect Fireflies.ai</span>
               </div>
               <button onClick={() => setActiveModal("none")} className="text-text-muted hover:text-ink text-lg">✕</button>
             </div>
@@ -403,7 +403,7 @@ export function IntegrationCatalog({
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-xs p-4">
           <form onSubmit={handleIngestNotes} className="bg-paper border border-line rounded-2xl w-full max-w-lg p-5 shadow-2xl rise-in flex flex-col gap-4">
             <div className="flex items-center justify-between border-b border-line pb-3">
-              <span className="font-semibold text-ink text-sm">Upload Meeting Notes</span>
+              <span className="font-medium text-ink text-sm">Upload Meeting Notes</span>
               <button type="button" onClick={() => setActiveModal("none")} className="text-text-muted hover:text-ink text-lg">✕</button>
             </div>
             <input

--- a/dashboard/src/components/RecentActivity.tsx
+++ b/dashboard/src/components/RecentActivity.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import Link from "next/link";
 import { useProject } from "@/lib/useProject";
-import { Kicker } from "@/components/ui";
+import { Heading } from "@/components/ui";
 
 export interface AuditRow {
   id: number;
@@ -113,8 +113,8 @@ export function RecentActivity({ rows }: { rows: AuditRow[] }) {
 
   return (
     <div className="flex flex-col gap-2 p-4 rounded-xl border border-line bg-paper">
-      <div className="flex items-center justify-between">
-        <Kicker>Domain Milestones</Kicker>
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <Heading variant="section">Domain Milestones</Heading>
         <Link
           href={prefix("/activity")}
           className="text-[10px] text-text-muted hover:text-ink font-mono uppercase tracking-wider transition-colors"
@@ -125,12 +125,11 @@ export function RecentActivity({ rows }: { rows: AuditRow[] }) {
 
       <div className="space-y-2 mt-1">
         {visible.map((item) => (
-          <div key={item.id} className="flex items-baseline justify-between gap-4 text-[12px] border-b border-line/40 pb-1.5 last:border-0 last:pb-0">
-            <span className="text-ink font-medium">{item.human}</span>
+          <div key={item.id} className="flex items-baseline justify-between gap-4 text-[12px] leading-relaxed border-b border-line/40 pb-1.5 last:border-0 last:pb-0">
+            <span className="text-text">{item.human}</span>
             {item.ts && (
               <span
-                style={{ fontFamily: "var(--font-mono)" }}
-                className="text-[10px] text-text-muted flex-shrink-0"
+                className="text-[11px] text-text-muted flex-shrink-0"
               >
                 {timeAgo(item.ts)}
               </span>

--- a/dashboard/src/components/SlackBotCard.tsx
+++ b/dashboard/src/components/SlackBotCard.tsx
@@ -149,7 +149,7 @@ export function SlackBotCard() {
       }}
     >
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 4 }}>
-        <span style={{ fontSize: 13, fontWeight: 600, color: "var(--text-primary)" }}>Slack bot</span>
+        <span style={{ fontSize: 13, fontWeight: 500, color: "var(--text-primary)" }}>Slack bot</span>
         <span
           style={{
             fontSize: 11,

--- a/dashboard/src/components/SourceIconGrid.tsx
+++ b/dashboard/src/components/SourceIconGrid.tsx
@@ -118,7 +118,7 @@ export function SourceIconGrid({
           <Kicker>Step 1 · Connect Context</Kicker>
           <h2
             style={{ fontFamily: "var(--font-display)" }}
-            className="text-xl font-semibold text-ink mt-0.5"
+            className="text-xl font-medium text-ink mt-0.5"
           >
             Connect your sources to build the Knowledge Graph
           </h2>
@@ -163,7 +163,7 @@ export function SourceIconGrid({
             </div>
 
             <div>
-              <h3 style={{ fontFamily: "var(--font-display)" }} className="text-sm font-semibold text-ink">
+              <h3 style={{ fontFamily: "var(--font-display)" }} className="text-sm font-medium text-ink">
                 Codebase
               </h3>
               <p className="text-text-muted text-[11px] mt-0.5 leading-relaxed">
@@ -226,7 +226,7 @@ export function SourceIconGrid({
             </div>
 
             <div>
-              <h3 style={{ fontFamily: "var(--font-display)" }} className="text-sm font-semibold text-ink">
+              <h3 style={{ fontFamily: "var(--font-display)" }} className="text-sm font-medium text-ink">
                 Linear
               </h3>
               <p className="text-text-muted text-[11px] mt-0.5 leading-relaxed">
@@ -273,7 +273,7 @@ export function SourceIconGrid({
             </div>
 
             <div>
-              <h3 style={{ fontFamily: "var(--font-display)" }} className="text-sm font-semibold text-ink">
+              <h3 style={{ fontFamily: "var(--font-display)" }} className="text-sm font-medium text-ink">
                 Meeting Notes
               </h3>
               <p className="text-text-muted text-[11px] mt-0.5 leading-relaxed">
@@ -318,7 +318,7 @@ export function SourceIconGrid({
             </div>
 
             <div>
-              <h3 style={{ fontFamily: "var(--font-display)" }} className="text-sm font-semibold text-ink">
+              <h3 style={{ fontFamily: "var(--font-display)" }} className="text-sm font-medium text-ink">
                 Slack Bot
               </h3>
               <p className="text-text-muted text-[11px] mt-0.5 leading-relaxed">
@@ -338,7 +338,7 @@ export function SourceIconGrid({
 
           {slackPopover && (
             <div className="absolute bottom-full mb-2 right-0 left-0 p-3 rounded-lg border border-line bg-paper shadow-xl text-[11px] text-ink z-50 rise-in">
-              <div className="font-semibold mb-1">Slack Integration Locked</div>
+              <div className="font-medium mb-1">Slack Integration Locked</div>
               <p className="text-text-muted text-[10px] leading-relaxed mb-2">
                 Slack requires persistent socket connections in production mode (<code className="font-mono text-ink">flow up --mode prod</code>).
               </p>

--- a/dashboard/src/components/SourcesFrontDoor.tsx
+++ b/dashboard/src/components/SourcesFrontDoor.tsx
@@ -581,7 +581,7 @@ function TwoDoors({
       >
         <div
           style={{ fontFamily: "var(--font-mono)" }}
-          className="text-[13px] font-semibold text-ink mb-1"
+          className="text-[13px] font-medium text-ink mb-1"
         >
           GitHub repos
         </div>

--- a/dashboard/src/components/ui.tsx
+++ b/dashboard/src/components/ui.tsx
@@ -19,14 +19,14 @@ export function Heading({
 }) {
   const typography = {
     display: "tracking-tight leading-[1.15]",
-    section: "text-[20px] font-normal leading-normal tracking-normal",
-    card: "text-[16px] font-normal leading-normal tracking-normal",
+    section: "text-[20px] leading-normal tracking-normal",
+    card: "text-[16px] leading-normal tracking-normal",
   };
 
   return (
     <Tag
       style={{ fontFamily: "var(--font-display)" }}
-      className={`text-ink ${typography[variant]} ${className}`}
+      className={`text-ink font-medium ${typography[variant]} ${className}`}
     >
       {children}
     </Tag>

--- a/dashboard/src/components/ui.tsx
+++ b/dashboard/src/components/ui.tsx
@@ -10,18 +10,40 @@ export function Heading({
   children,
   className = "",
   as: Tag = "h2",
+  variant = "display",
 }: {
   children: React.ReactNode;
   className?: string;
   as?: "h1" | "h2" | "h3";
+  variant?: "display" | "section" | "card";
 }) {
+  const typography = {
+    display: "tracking-tight leading-[1.15]",
+    section: "text-[20px] font-normal leading-normal tracking-normal",
+    card: "text-[16px] font-normal leading-normal tracking-normal",
+  };
+
   return (
     <Tag
       style={{ fontFamily: "var(--font-display)" }}
-      className={`text-ink tracking-tight leading-[1.15] ${className}`}
+      className={`text-ink ${typography[variant]} ${className}`}
     >
       {children}
     </Tag>
+  );
+}
+
+export function BodyText({
+  children,
+  className = "",
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <p className={`font-sans text-[12px] font-normal leading-relaxed tracking-normal text-text-muted ${className}`}>
+      {children}
+    </p>
   );
 }
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -34,13 +34,13 @@ with `--paper`/`--cream` text and the accent for emphasis.
 
 ## Type
 
-- **Display / headings** — **Lora** (serif). Tracking-tight, leading ~1.1–1.2. This carries the editorial feel. Sizes: hero 48/37, section 37, card 24, sub 20.
+- **Display / headings** — **Lora** (serif), weight **500** for all page, section, card, and dialog titles. Tracking-tight, leading ~1.1–1.2. This carries the editorial feel. Sizes: hero 48/37, section 37, card 24, sub 20.
 - **Body** — **Inter**. 17px lead, 15px default, relaxed leading. Calm and readable.
 - **Labels / meta / code** — **Space Mono**. UPPERCASE, tracking-widest, ~12–13px, `--text-muted`. Use kickers only when they add context, not to repeat a section heading.
 
 The dashboard home page uses `Heading` variants for a compact, consistent scale:
-`section` is regular 20px Lora with 30px line height; `card` is regular 16px Lora
-with 24px line height. Both use normal letter spacing. `BodyText` is regular
+`section` is 20px Lora with 30px line height; `card` is 16px Lora
+with 24px line height. Both use weight 500 and normal letter spacing. `BodyText` is regular
 12px Inter with relaxed line height and muted color. The main "Flow builds your
 brain" heading keeps its display treatment. Do not add redundant eyebrow labels
 above home section titles (such as "Your AI interfaces" or "Integrations & Sources").

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -36,7 +36,14 @@ with `--paper`/`--cream` text and the accent for emphasis.
 
 - **Display / headings** — **Lora** (serif). Tracking-tight, leading ~1.1–1.2. This carries the editorial feel. Sizes: hero 48/37, section 37, card 24, sub 20.
 - **Body** — **Inter**. 17px lead, 15px default, relaxed leading. Calm and readable.
-- **Labels / meta / code** — **Space Mono**. UPPERCASE, tracking-widest, ~12–13px, `--text-muted`. Every section starts with a mono kicker + a small dot.
+- **Labels / meta / code** — **Space Mono**. UPPERCASE, tracking-widest, ~12–13px, `--text-muted`. Use kickers only when they add context, not to repeat a section heading.
+
+The dashboard home page uses `Heading` variants for a compact, consistent scale:
+`section` is regular 20px Lora with 30px line height; `card` is regular 16px Lora
+with 24px line height. Both use normal letter spacing. `BodyText` is regular
+12px Inter with relaxed line height and muted color. The main "Flow builds your
+brain" heading keeps its display treatment. Do not add redundant eyebrow labels
+above home section titles (such as "Your AI interfaces" or "Integrations & Sources").
 
 Load via Google Fonts (Lora 400/500/600, Inter 400/500, Space Mono 400).
 


### PR DESCRIPTION
Dashboard titles mixed weights of 400, 600, and 700. Standardize page, section, card, dialog, and rendered Markdown headings at weight 500, including the shared Heading component and existing explicit title styles.

Home-page cards also mixed heading sizes, with descriptions ranging from 10px to 12px. Use the "Use Flow in your own AI tools" heading as the shared reference: Lora at 20px for sections and 16px for compact titles, plus 12px Inter descriptions at weight 400. Preserve the main "Flow builds your brain" heading's size and styling.

Remove the redundant "Integrations & Sources", "Your AI interfaces", and "Flow's interface" labels. Apply the same typography to recent sessions, domain milestones, and connector cards; give integration cards three columns at tablet widths. Document the home-page type scale in the design guide.

Validation:
- Production dashboard build and TypeScript check pass.
- Browser checks at desktop and tablet widths confirm matching computed typography, weight 500 on all home-page headings, weight 400 on descriptions, no title/description overflow, and removal of the redundant labels.
- Browser checks also confirm weight 500 on Connections, Settings, Knowledge Base, Permissions, and Activity page headings.
- The existing React effect lint errors in AgentPanel and CodingToolsPanel were reproduced on the original files. The existing fixed-sidebar overflow on mobile is outside this change.
