### PR TITLE
Avoid embedding vectors in dashboard graph responses

### DIFF
--- a/dashboard/src/app/api/graph/overview/route.ts
+++ b/dashboard/src/app/api/graph/overview/route.ts
@@ -11,8 +11,11 @@ import { requireProject } from "@/lib/projectContext";
 // By default the gateway uses its configured graph; callers may pass ?graph=
 // for explicit graph selection.
 
-const NODES_CYPHER = `MATCH (n) RETURN n`;
-const EDGES_CYPHER = `MATCH (a)-[r]->(b) RETURN a, r, b`;
+// Project before the database driver decodes results: whole nodes include
+// embedding vectors, repeated twice per edge, which can exhaust the gateway heap.
+const canvasNode = (alias: string) => `{id: id(${alias}), labels: labels(${alias}), properties: {id: ${alias}.id, name: ${alias}.name, title: ${alias}.title, description: ${alias}.description}}`;
+const NODES_CYPHER = `MATCH (n) RETURN ${canvasNode("n")} AS n`;
+const EDGES_CYPHER = `MATCH (a)-[r]->(b) RETURN ${canvasNode("a")} AS a, {sourceId: id(a), destinationId: id(b), relationshipType: type(r)} AS r, ${canvasNode("b")} AS b`;
 const NODE_COUNT_CYPHER = `MATCH (n) RETURN count(n) AS count`;
 const EDGE_COUNT_CYPHER = `MATCH ()-[r]->() RETURN count(r) AS count`;
 const DEFAULT_PAGE_LIMIT = 500;
@@ -165,7 +168,7 @@ export async function GET(req: NextRequest) {
     }
 
     if (part === "nodes") {
-      const nodeRows = await runQuery(pageCypher("MATCH (n) RETURN n", offset, limit));
+      const nodeRows = await runQuery(pageCypher(NODES_CYPHER, offset, limit));
       const data = buildGraphRows(nodeRows, []);
       return NextResponse.json({
         ...data,
@@ -180,7 +183,7 @@ export async function GET(req: NextRequest) {
     }
 
     if (part === "edges") {
-      const edgeRows = await runQuery(pageCypher("MATCH (a)-[r]->(b) RETURN a, r, b", offset, limit));
+      const edgeRows = await runQuery(pageCypher(EDGES_CYPHER, offset, limit));
       const data = buildGraphRows([], edgeRows);
       return NextResponse.json({
         ...data,


### PR DESCRIPTION
The production Olostep gateway exited with a JavaScript heap-out-of-memory error while the dashboard reported “Brain gateway unavailable.” #76 added pagination, but graph queries still returned complete nodes, including embedding vectors, and repeated both endpoint nodes for every relationship. The legacy unpaged endpoint also retained that payload.

Project only the node identity, labels and display properties plus relationship endpoints/type inside Cypher, before the database driver decodes the result. Apply the same projection to paginated and unpaged responses, preserving the canvas response shape and full graph coverage.

Validation on the affected deployment (2,139 nodes, 5,968 relationships): the old unpaged edge query exhausted an isolated 384 MB Node process. Projected queries completed within a 256 MB process (edge query: 274 ms, approximately 57 MB heap). Production dashboard build passed. After applying the patch and restarting the dashboard and failed gateway, authenticated summary, node-page and edge-page requests returned 200; the complete response returned all 2,139 nodes and 5,968 edges in 0.61 seconds. No graph data or embeddings were deleted or regenerated.

The OOM is confirmed in gateway logs; the oversized query is independently reproducible. Historical request logs do not establish which exact request caused the original process exit. This fixes the dashboard query payload; arbitrary read_query callers can still request large results.
