### PR TITLE
Fix merged graph embeddings and missing-repository orientation

### DIFF
--- a/graph-gateway/package.json
+++ b/graph-gateway/package.json
@@ -10,7 +10,7 @@
     "start": "tsx src/server.ts",
     "mcp": "tsx src/mcp.ts",
     "typecheck": "tsc --noEmit",
-    "test": "node --experimental-test-module-mocks --import tsx/esm --test test/verbs-batch.test.ts test/verbs-memory.test.ts test/embed.test.ts test/source.test.ts"
+    "test": "node --experimental-test-module-mocks --import tsx/esm --test test/verbs-batch.test.ts test/verbs-memory.test.ts test/embed.test.ts test/source.test.ts test/vector-repair.test.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",

--- a/graph-gateway/src/reconcile.ts
+++ b/graph-gateway/src/reconcile.ts
@@ -82,7 +82,7 @@ export async function reconcileEmbeddings(
   opts: { force?: boolean; log?: (msg: string) => void } = {},
 ): Promise<{ total: number; embedded: number; failed: number }> {
   const log = opts.log ?? ((m: string) => console.log(m));
-  const filter = opts.force ? "" : "WHERE n.embedding IS NULL";
+  const filter = opts.force ? "" : "WHERE n.embedding IS NULL OR typeOf(n.embedding) <> 'Vectorf32'";
   const rows = await run(
     graph,
     `MATCH (n) ${filter}

--- a/graph-gateway/src/verbs.ts
+++ b/graph-gateway/src/verbs.ts
@@ -138,16 +138,21 @@ async function findByVector(graph: string, q: string, type: string | undefined, 
   const { vec, error } = await embedQuery(q);
   if (!vec) return { rows: [], degraded: error ?? "query could not be embedded" };
   const typeFilter = type ? `AND labels(n)[0] = $type` : "";
-  const rows = await run(
-    graph,
-    `MATCH (n) WHERE n.embedding IS NOT NULL ${typeFilter}
+  let rows;
+  try {
+    rows = await run(
+      graph,
+      `MATCH (n) WHERE typeOf(n.embedding) = 'Vectorf32' ${typeFilter}
      WITH n, vec.cosineDistance(n.embedding, vecf32($vec)) AS d
      WHERE d <= $maxDistance
      RETURN labels(n)[0] AS type, n.id AS id, n.name AS name, n.description AS description, n.evidence AS anchor, d AS distance
      ORDER BY d ASC
      LIMIT ${clampLimit(limit)}`,
-    { vec, maxDistance: VECTOR_MAX_DISTANCE, ...(type ? { type } : {}) },
-  );
+      { vec, maxDistance: VECTOR_MAX_DISTANCE, ...(type ? { type } : {}) },
+    );
+  } catch (err) {
+    return { rows: [], degraded: `vector search failed: ${err instanceof Error ? err.message : String(err)}` };
+  }
   const scored = (rows as unknown as ScoredRow[]).map((r) => ({
     ...r,
     via: "vector" as const,
@@ -570,10 +575,12 @@ async function mergeEntities(input: z.infer<z.ZodObject<typeof mergeEntitiesInpu
     }
   }
 
-  // Fill gaps in keep's props from remove; never overwrite what keep has.
+  // Embeddings are derived, typed data: never round-trip them through generic
+  // property maps (the driver decodes vectors as arrays). Re-embed merged text.
+  // Fill other gaps in keep's props from remove; never overwrite what keep has.
   const fill: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(removeProps)) {
-    if (!(k in keepProps) && !["id", "created_by", "created_at", "updated_by", "updated_at"].includes(k)) fill[k] = v;
+    if (!(k in keepProps) && !["id", "embedding", "created_by", "created_at", "updated_by", "updated_at"].includes(k)) fill[k] = v;
   }
   const mergedAliases = [
     ...String(keepProps.aliases ?? "").split(",").map((s) => s.trim()),
@@ -584,11 +591,12 @@ async function mergeEntities(input: z.infer<z.ZodObject<typeof mergeEntitiesInpu
 
   await run(
     input.graph,
-    `MATCH (n {id: $keep}) SET n += $fill, n.aliases = $aliases, n.merged_from = $remove, n.updated_by = $actor, n.updated_at = $ts`,
+    `MATCH (n {id: $keep}) SET n += $fill, n.embedding = NULL, n.aliases = $aliases, n.merged_from = $remove, n.updated_by = $actor, n.updated_at = $ts`,
     { keep: input.keep, fill, aliases: mergedAliases.join(", "), remove: input.remove, actor: input.provenance.actor, ts: new Date().toISOString() },
   );
   await run(input.graph, `MATCH (n {id: $id}) DETACH DELETE n`, { id: input.remove });
 
+  await embedNode(input.graph, input.keep);
   await record({ graph: input.graph, actor: input.provenance.actor, verb: "merge_entities", input: { keep: input.keep, remove: input.remove }, status: "merged" });
   return { status: "merged", keep: input.keep, removed: input.remove, rewired, skipped };
 }
@@ -849,8 +857,8 @@ async function orient(input: z.infer<z.ZodObject<typeof orientInput>>) {
   // whatever the graph holds (single-repo projects). Missing node ≠ error —
   // the graph may simply not be indexed yet.
   const repoRow =
-    (repoRows as Array<{ id: string; name: string; description: string }>).find((r) => r.name === repo) ??
-    (repoRows as Array<{ id: string; name: string; description: string }>)[0];
+    (repo ? (repoRows as Array<{ id: string; name: string; description: string }>).find((r) => r.name === repo || r.id === `repo:${repo}`) :
+    (repoRows as Array<{ id: string; name: string; description: string }>)[0]);
 
   const countMap = new Map((counts as Array<{ type: string; count: number }>).map((c) => [c.type, c.count]));
   const total = [...countMap.values()].reduce((a, b) => a + b, 0);

--- a/graph-gateway/test/vector-repair.test.ts
+++ b/graph-gateway/test/vector-repair.test.ts
@@ -1,0 +1,47 @@
+import { test, mock } from 'node:test';
+import assert from 'node:assert/strict';
+
+test('merge preserves embedding ownership, reconciliation repairs lists, and missing repos stay missing', async () => {
+  const queries: Array<{ q: string; p: any }> = [];
+  let vectorFailure = false;
+  mock.module('../src/graph.js', { namedExports: {
+    DEFAULT_GRAPH: 'test', deletedGraphError: async () => null, raw: async () => ({}),
+    run: async (_g: string, q: string, p: any = {}) => {
+      queries.push({ q, p });
+      if (q.includes('keepProps')) return [{ keepProps: { id: 'svc:a', name: 'Alpha' }, removeProps: { id: 'svc:b', embedding: [1, 0], description: 'merged description' } }];
+      if (q.includes('MATCH (r:Repository)')) return [{ id: 'repo:engineering-docs', name: 'engineering-docs', description: 'Wrong repository' }];
+      if (q.includes('vec.cosineDistance')) {
+        assert.match(q, /typeOf\(n.embedding\) = 'Vectorf32'/);
+        if (vectorFailure) throw new Error('vector service failed');
+        return [];
+      }
+      if (q.includes('RETURN n.id AS id, labels(n)')) return [{ id: 'svc:a', type: 'Service', name: 'Alpha' }];
+      if (q.includes('RETURN labels(n)[0] AS type, n.name')) return [{ type: 'Service', name: 'Alpha', description: 'merged description' }];
+      return [];
+    },
+  }});
+  mock.module('../src/journal.js', { namedExports: { record: async () => {}, tail: async () => [] } });
+  mock.module('../src/embed.js', { namedExports: {
+    embeddingsEnabled: () => true, entityText: () => 'merged content',
+    embedText: async () => [1, 0], embedQuery: async () => ({ vec: [1, 0] }), embedBatch: async () => [[1, 0]],
+  }});
+  const { callVerb } = await import('../src/verbs.js');
+  await callVerb('merge_entities', { keep: 'svc:a', remove: 'svc:b', provenance: { actor: 'test', source: 'test' } });
+  const fill = queries.find(x => x.q.includes('SET n += $fill'));
+  assert.ok(fill);
+  assert.equal(fill.p.fill.embedding, undefined);
+  assert.equal(fill.p.fill.description, 'merged description');
+  assert.match(fill.q, /n.embedding = NULL/);
+  assert.ok(queries.some(x => x.q.includes('SET n.embedding = vecf32($vec)')));
+  const { reconcileEmbeddings } = await import('../src/reconcile.js');
+  const result = await reconcileEmbeddings('test', { log: () => {} });
+  assert.equal(result.embedded, 1);
+  assert.ok(queries.some(x => x.q.includes("typeOf(n.embedding) <> 'Vectorf32'")));
+  const orient = await callVerb('orient', { repo: 'screenshot-headless' });
+  assert.match(JSON.stringify(orient), /not indexed/);
+  assert.doesNotMatch(JSON.stringify(orient), /Wrong repository/);
+  vectorFailure = true;
+  const search = await callVerb('find_entity', { q: 'some service' });
+  assert.match(JSON.stringify(search), /vector search failed/);
+  assert.notEqual(search.status, 'error');
+});


### PR DESCRIPTION
Entity merges could copy a decoded embedding array into FalkorDB as a List, making all semantic searches fail with a Vectorf32 type error. Exclude derived embeddings from property copying, invalidate the survivor embedding, and regenerate it from merged content. Reconciliation now repairs non-vector embeddings; retrieval filters invalid types and preserves lexical results with an explicit warning on vector-query failure.

Also stop orient from describing an unrelated repository when an explicitly requested repository is absent; allow canonical repo IDs to match display-name variants.

Validation: gateway suite 28 tests passed; TypeScript typecheck passed. On the affected EC2 graph, the guarded cosine query ranks 2,137 valid vectors successfully despite two malformed lists. Regression covers merge copying/invalidation/re-embedding, malformed reconciliation selection, retrieval failure degradation, and absent repo orientation.
