### PR TITLE
Change yellow accent color to blue throughout design system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,7 +151,7 @@ The repo told people to run Flow **three** contradictory ways — a root `docker
 - Every live classifier call (full prompt, raw response, model, latency, per-attempt retries, errors) and every opencode job (summary row + complete JSONL transcript at `data/.../job-logs/<job>.jsonl`, stderr on failure) is recorded. Query via `GET /v1/llmlog?kind=&ref=`. Joined with the audit log, events table, gateway journal, and per-service logs, every decision is traceable end to end.
 
 ### Added — UX & design system
-- **Design system** (`docs/DESIGN.md`) — warm editorial language (cream paper, single yellow accent, Lora serif, Space Mono labels) with shared primitives; applied across the dashboard.
+- **Design system** (`docs/DESIGN.md`) — warm editorial language (cream paper, single blue accent, Lora serif, Space Mono labels) with shared primitives; applied across the dashboard.
 - **UX spec** (`docs/UX.md`, user-approved) — the dashboard as a guided state machine: key gate → connect sources → watch the brain build → alive; floating Ask bar; humanized activity.
 - **State 0 "Flow needs a brain"** — first-run OpenRouter key gate with live validation; nothing else is reachable until the brain works.
 

--- a/bin/flow.mjs
+++ b/bin/flow.mjs
@@ -76,7 +76,7 @@ const c = {
   dim: paint("2"),
   green: paint("32"),
   red: paint("31"),
-  yellow: paint("33"),
+  blue: paint("34"),
   cyan: paint("36"),
 };
 const OK = c.green("✓");
@@ -945,7 +945,7 @@ async function upProject(name, { rebuilt = false } = {}) {
     const executable = projectEnv[overrideName] || process.env[overrideName] || discoverExecutable(backend);
     const check = executable ? spawnSync(executable, ["--version"], { encoding: "utf8", timeout: 5000 }) : null;
     if (!check || check.status !== 0) {
-      finish(`${OK} ${c.dim("services up")} — ${c.yellow(`${backend} unavailable; coding jobs are not ready. Install or repair ${backend}, then run flow up ${name}.`)}`);
+      finish(`${OK} ${c.dim("services up")} — ${c.blue(`${backend} unavailable; coding jobs are not ready. Install or repair ${backend}, then run flow up ${name}.`)}`);
     } else {
       finish(`${OK} ${c.dim("services up")} — ${backend} executable ready`);
     }
@@ -1464,11 +1464,11 @@ async function cmdSetup(rest) {
 
   console.log(`
   ${OK} ${c.bold(repoDir)}
-    → project ${c.bold(name)} (${isRemote ? "remote" : "local"}), repo ${c.bold(repoName)}${registered || isRemote ? "" : c.yellow(" (not a registered source — capture works; graph context limited)")}
+    → project ${c.bold(name)} (${isRemote ? "remote" : "local"}), repo ${c.bold(repoName)}${registered || isRemote ? "" : c.blue(" (not a registered source — capture works; graph context limited)")}
     tools: ${harnesses.join(", ")}${skipped.length ? c.dim(`  (not detected, skipped: ${skipped.join(", ")} — use --all to pre-wire)`) : ""}
     mode:  ${values.share ? "shared (files visible to git — commit them)" : "personal (hidden via .git/info/exclude; use --share for the team)"}
     files: ${[...owned, ...merged].join(", ")}
-    work folder: ${isRemote ? "local checkout connected to remote knowledge" : workFolderOk ? "registered" : c.yellow("not registered (orchestrator not running — will register on next flow up)")}
+    work folder: ${isRemote ? "local checkout connected to remote knowledge" : workFolderOk ? "registered" : c.blue("not registered (orchestrator not running — will register on next flow up)")}
 
   ${c.bold("One-time approvals some tools will ask for:")}
     Claude Code  → first prompt asks to use this repo's .mcp.json — approve.

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -8,7 +8,7 @@
   --ink: rgb(54, 55, 38);
   --text: rgb(73, 73, 57);
   --text-muted: rgb(133, 134, 122);
-  --accent: rgb(255, 247, 129);
+  --accent: rgb(100, 180, 255);
   --line: rgba(0, 0, 0, 0.06);
 
   --ok: rgb(90, 140, 90);

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,6 +1,6 @@
 # Flow — Design System
 
-Warm, editorial, confident. Cream paper, one yellow accent, serif headlines, mono
+Warm, editorial, confident. Cream paper, one blue accent, serif headlines, mono
 labels. Adapted from the Edra reference. Used across the dashboard, the Ask view,
 and the landing page — Flow should feel like one considered product.
 
@@ -19,12 +19,12 @@ are the color; the chrome stays quiet.
 --ink          rgb(54, 55, 38)      near-black, dark surfaces & strong headings
 --text         rgb(73, 73, 57)      body text
 --text-muted   rgb(133, 134, 122)   secondary text, labels
---accent       rgb(255, 247, 129)   THE yellow — primary actions, highlights, live state
+--accent       rgb(100, 180, 255)   THE blue — primary actions, highlights, live state
 --line         rgba(0,0,0,0.06)     hairline borders (border-black/5)
 
 Semantic (used sparingly, muted to fit the palette):
 --ok           rgb(90, 140, 90)     healthy / up-to-date
---busy         the accent yellow    indexing / catching-up / live
+--busy         the accent blue    indexing / catching-up / live
 --warn         rgb(184, 134, 60)    needs attention / propose
 --danger       rgb(168, 80, 70)     error (desaturated brick, not pure red)
 ```


### PR DESCRIPTION
Updates all yellow color references to blue across the design system and CLI.

## Changes
- **CSS colors**: Updated --accent from yellow rgb(255, 247, 129) to blue rgb(100, 180, 255)
- **Design docs**: Updated DESIGN.md to reference blue accent instead of yellow
- **CLI colors**: Changed ANSI color code from yellow (33) to blue (34) and renamed variable
- **CLI messages**: Updated all c.yellow() calls to c.blue() in messages
- **Changelog**: Updated design system reference to mention blue

All accent colors are now consistently blue across the dashboard, documentation, and CLI output.