### PR TITLE
Resolve missing task setup through Slack DMs and browser terminals

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -15,6 +15,8 @@
   "dependencies": {
     "@falkordb/canvas": "^0.2.1",
     "@types/cytoscape": "^3.21.9",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "dompurify": "^3.4.11",
     "marked": "^18.0.5",
     "next": "16.2.10",

--- a/dashboard/src/app/api/cloud/[...path]/route.ts
+++ b/dashboard/src/app/api/cloud/[...path]/route.ts
@@ -7,7 +7,7 @@ async function proxy(req: NextRequest, context: { params: Promise<{ path: string
   if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const { path } = await context.params;
   const route = path.join("/");
-  if (!/^(tasks(?:\/[a-zA-Z0-9-]+(?:\/(?:followup|command|cancel|diff))?)?|repos\/[^/]+\/env)$/.test(route))
+  if (!/^(tasks(?:\/[a-zA-Z0-9-]+(?:\/(?:followup|command|cancel|diff))?)?|setup\/[a-zA-Z0-9-]+|repos\/[^/]+\/env)$/.test(route))
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   try {
     const response = await orcFetch(`/v1/agents/${path.map(encodeURIComponent).join("/")}${req.nextUrl.search}`, token, {

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useState, useCallback, useMemo } from "react";
 import { Shell } from "@/components/Shell";
 import { KeyGate } from "@/components/KeyGate";
 import { BrainCanvas } from "@/components/BrainCanvas";
-import { RepoEnvPanel } from "@/components/CloudAgents";
 import { AgentPanel } from "@/components/AgentPanel";
 import { IntegrationCatalog } from "@/components/IntegrationCatalog";
 import { CodingToolsPanel } from "@/components/CodingToolsPanel";
@@ -267,11 +266,6 @@ export default function HomePage() {
             mode={mode}
             onChanged={() => void loadAll()}
           />
-          {mode === "prod" && reposWithStatus.length > 0 && <section className="mt-5 rounded-xl border border-line bg-paper p-4">
-            <Heading as="h3" variant="card">Repository environments</Heading>
-            <p className="my-2 text-sm text-text-muted">Configure env files for server tasks in each repository.</p>
-            {reposWithStatus.filter(repo => repo.kind !== "docs").map(repo => <div key={repo.name} className="mt-3"><p className="mb-2 text-sm font-medium">{repo.name}</p><RepoEnvPanel repo={repo.name} /></div>)}
-          </section>}
         </div>
 
         {/* 3. THE INTERFACE DECISION: use Flow in your own AI tools (left) —

--- a/dashboard/src/app/setup/[id]/page.tsx
+++ b/dashboard/src/app/setup/[id]/page.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { use, useCallback, useEffect, useRef, useState } from "react";
+import { useProject } from "@/lib/useProject";
+import type { Terminal } from "@xterm/xterm";
+import "@xterm/xterm/css/xterm.css";
+
+type SetupState = { repo: string; environment: string; reason: string; state: string; output: string; cursor: number; active: boolean; reset?: boolean };
+export default function SetupPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const { prefix } = useProject();
+  const url = prefix(`/api/cloud/setup/${id}`);
+  const host = useRef<HTMLDivElement>(null);
+  const term = useRef<Terminal | null>(null);
+  const cursor = useRef(0);
+  const [setup, setSetup] = useState<SetupState | null>(null);
+  const [error, setError] = useState("");
+  const [opening, setOpening] = useState(false);
+  const [queueing, setQueueing] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const inputChain = useRef(Promise.resolve());
+  const post = useCallback(async (body: object) => {
+    const response = await fetch(url, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
+    const result = await response.json();
+    if (!response.ok) throw new Error(result.error ?? "Setup terminal unavailable");
+    return result;
+  }, [url]);
+
+  useEffect(() => {
+    let stopped = false;
+    let terminal: Terminal | undefined;
+    let observer: ResizeObserver | undefined;
+    void (async () => {
+      const [{ Terminal }, { FitAddon }] = await Promise.all([import("@xterm/xterm"), import("@xterm/addon-fit")]);
+      if (stopped || !host.current) return;
+      terminal = new Terminal({ cursorBlink: true, fontSize: 14, scrollback: 1500, theme: { background: "#181b19" } });
+      const fit = new FitAddon(); terminal.loadAddon(fit); terminal.open(host.current); fit.fit();
+      term.current = terminal;
+      terminal.onData(data => {
+        inputChain.current = inputChain.current.then(() => post({ action: "input", data })).then(() => {}).catch(e => setError(e.message));
+      });
+      observer = new ResizeObserver(() => {
+        fit.fit();
+        void post({ action: "input", data: "", cols: terminal!.cols, rows: terminal!.rows }).catch(() => {});
+      });
+      observer.observe(host.current);
+    })().catch(e => setError(e.message));
+    return () => { stopped = true; observer?.disconnect(); terminal?.dispose(); term.current = null; cursor.current = 0; };
+  }, [post]);
+
+  useEffect(() => {
+    let stopped = false;
+    let timer: ReturnType<typeof setTimeout>;
+    async function poll() {
+      try {
+        if (opening) {
+          const result = await post({ action: "open" });
+          if (stopped) return;
+          setQueueing(result.queued);
+          if (!result.queued) { setOpening(false); term.current?.focus(); }
+        }
+        const response = await fetch(`${url}?cursor=${cursor.current}`, { cache: "no-store" });
+        const result = await response.json();
+        if (!response.ok) throw new Error(result.error ?? "Unable to read setup terminal");
+        if (stopped) return;
+        if (term.current) { if (result.reset) term.current.reset(); term.current.write(result.output); cursor.current = result.cursor; }
+        setSetup(result);
+      } catch (e) { if (!stopped) { setError((e as Error).message); setOpening(false); } }
+      finally { if (!stopped) timer = setTimeout(poll, 500); }
+    }
+    void poll();
+    return () => { stopped = true; clearTimeout(timer); };
+  }, [url, post, opening]);
+
+  async function finish(complete: boolean) {
+    setBusy(true); setError("");
+    try { await inputChain.current; await post({ action: complete ? "complete" : "close" }); setOpening(false); setQueueing(false); }
+    catch (e) { setError((e as Error).message); }
+    finally { setBusy(false); }
+  }
+  const waiting = setup?.state === "waiting";
+  return <main className="mx-auto max-w-5xl space-y-5 px-6 py-10">
+    <div><p className="text-sm text-text-muted">Flow needs your help</p><h1 className="mt-2 font-display text-3xl">Set up {setup?.repo ?? "the environment"}</h1></div>
+    {setup && <p>{setup.reason} <span className="text-text-muted">Environment: {setup.environment}.</span></p>}
+    <p className="text-sm text-text-muted">This terminal runs on the Flow server as the same user as your agents. Install a CLI or complete its login here, then resume your task. Saved CLI logins persist; shell-only exports do not. Terminal input and output are not saved to the agent conversation.</p>
+    <div className="flex flex-wrap items-center gap-3">
+      <button className="rounded border border-line bg-paper px-4 py-2 disabled:opacity-50" disabled={!waiting || setup?.active || opening || busy} onClick={() => { setError(""); setOpening(true); }}>Open terminal</button>
+      <button className="rounded border border-line px-4 py-2 disabled:opacity-50" disabled={!waiting || busy} onClick={() => void finish(true)}>Done — resume task</button>
+      <button className="rounded px-3 py-2 text-sm disabled:opacity-50" disabled={(!setup?.active && !opening) || busy} onClick={() => void finish(false)}>Close terminal</button>
+      {queueing && <span className="text-sm text-text-muted">Waiting for the machine. Another coding task is running.</span>}
+      {setup && !waiting && <span className="text-sm">{setup.state === "cancelled" ? "Setup cancelled." : "Setup received. Flow will continue in the original Slack thread."}</span>}
+    </div>
+    <div ref={host} className="h-[480px] overflow-hidden rounded-xl bg-[#181b19] p-3" aria-label="Interactive setup terminal" />
+    {error && <p role="alert" className="text-sm text-red-700">{error}</p>}
+  </main>;
+}

--- a/dashboard/src/components/AgentPanel.tsx
+++ b/dashboard/src/components/AgentPanel.tsx
@@ -35,7 +35,7 @@ const AGENT_BRANDS: Record<string, BrandName> = {
 
 function statusKind(status: string): "live" | "ok" | "warn" | "idle" {
   if (status === "running" || status === "starting") return "live";
-  if (status === "waiting") return "warn";
+  if (status === "waiting" || status === "setup") return "warn";
   if (status === "idle") return "ok";
   if (status === "error") return "warn";
   return "idle";
@@ -47,6 +47,7 @@ function statusLabel(status: string): string {
     starting: "Starting",
     running: "Working",
     waiting: "Needs approval",
+    setup: "Needs setup",
     idle: "Done — steerable",
     error: "Error",
     closed: "Closed",

--- a/dashboard/src/components/AgentSession.tsx
+++ b/dashboard/src/components/AgentSession.tsx
@@ -313,6 +313,7 @@ function mergeEvents(prev: SessionEvent[], incoming: SessionEvent[]): SessionEve
 
 function statusPill(status: string): { kind: "live" | "ok" | "warn" | "idle"; label: string } {
   if (status === "running" || status === "starting") return { kind: "live", label: status === "starting" ? "Starting" : "Working" };
+  if (status === "setup") return { kind: "warn", label: "Needs setup" };
   if (status === "waiting") return { kind: "warn", label: "Needs approval" };
   if (status === "idle") return { kind: "ok", label: "Done — steerable" };
   if (status === "error") return { kind: "warn", label: "Error" };

--- a/dashboard/src/components/AgentsView.tsx
+++ b/dashboard/src/components/AgentsView.tsx
@@ -51,7 +51,7 @@ const AGENT_BRANDS: Record<string, BrandName> = {
   opencode: "opencode",
 };
 
-const ACTIVE_STATUSES = new Set(["starting", "running", "waiting"]);
+const ACTIVE_STATUSES = new Set(["starting", "running", "waiting", "setup"]);
 
 function AgentBrandIcon({ backend, className }: { backend: string; className?: string }) {
   const name = AGENT_BRANDS[backend.startsWith("ext:") ? backend.slice(4) : backend];
@@ -61,7 +61,7 @@ function AgentBrandIcon({ backend, className }: { backend: string; className?: s
 
 function statusKind(status: string): "live" | "ok" | "warn" | "idle" {
   if (status === "running" || status === "starting") return "live";
-  if (status === "waiting" || status === "queued") return "warn";
+  if (status === "waiting" || status === "setup" || status === "queued") return "warn";
   if (status === "idle") return "ok";
   if (status === "error") return "warn";
   return "idle";
@@ -73,6 +73,7 @@ function statusLabel(status: string): string {
     starting: "Starting",
     running: "Working",
     waiting: "Needs approval",
+    setup: "Needs setup",
     idle: "Done — steerable",
     error: "Error",
     closed: "Closed",

--- a/dashboard/src/components/CloudAgents.tsx
+++ b/dashboard/src/components/CloudAgents.tsx
@@ -1,8 +1,7 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useProject } from "@/lib/useProject";
 
-const button = "rounded border border-[var(--line)] px-3 py-2 text-sm disabled:opacity-40";
 async function api(url: string, method = "GET", body?: unknown) {
   const response = await fetch(url, { method, headers: { "Content-Type": "application/json" }, ...(body === undefined ? {} : { body: JSON.stringify(body) }) });
   const data = await response.json();
@@ -16,15 +15,4 @@ export function CloudCommandPanel({ id, repos }: { id: string; repos: { name: st
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
   return <details className="border-t border-line bg-cream px-4 py-2 text-xs"><summary className="cursor-pointer font-mono">Server terminal command</summary><form className="mt-3 flex flex-col gap-2" onSubmit={async e => { e.preventDefault(); setBusy(true); setError(""); try { await api(prefix(`/api/cloud/tasks/${id}/command`), "POST", { repo: repo || repos[0]?.name, command }); setCommand(""); } catch(e) { setError((e as Error).message); } finally { setBusy(false); } }}><p className="text-text-muted">Runs in this task’s worktree under the coding queue. Noninteractive; stops after two minutes. Output appears in the transcript.</p><select aria-label="Command repository" className="rounded border border-line bg-paper p-2" value={repo || repos[0]?.name || ""} onChange={e => setRepo(e.target.value)}>{repos.map(r => <option key={r.name}>{r.name}</option>)}</select><textarea aria-label="Server command" className="rounded border border-line bg-paper p-2 font-mono" value={command} onChange={e => setCommand(e.target.value)} placeholder="npm test" /><button className="self-start rounded border border-line bg-paper px-3 py-1" disabled={busy || !command.trim() || !repos.length}>Run command</button>{error && <p role="alert">{error}</p>}</form></details>;
-}
-export function RepoEnvPanel({ repo }: { repo: string }) {
-  const { prefix } = useProject();
-  const url = prefix(`/api/cloud/repos/${encodeURIComponent(repo)}/env`);
-  const [files, setFiles] = useState<{ filename: string; updatedAt: number }[]>([]);
-  const [error, setError] = useState("");
-  const [busy, setBusy] = useState(false);
-  const [open, setOpen] = useState(false);
-  useEffect(() => { if (open) void api(url).then(d => setFiles(d.files)).catch(e => setError(e.message)); }, [url, open]);
-  async function change(method: string, filename: string, content?: string) { setBusy(true); setError(""); try { setFiles((await api(url, method, { filename, content })).files); } catch(e) { setError((e as Error).message); } finally { setBusy(false); } }
-  return <details className="border-t border-[var(--line)] px-3 py-3" onToggle={e => setOpen(e.currentTarget.open)}><summary className="cursor-pointer text-xs">Environment files</summary><div className="mt-3 space-y-3"><p className="text-xs text-[var(--text-muted)]">Upload .env or .env.local for {repo}. Stored encrypted on this server and copied only into this repo’s task worktrees at the next turn. Values are never displayed here. Applications load these files themselves.</p><label className="block text-xs">Upload or replace an env file<input aria-label={`Upload env file for ${repo}`} type="file" className="mt-2 block text-xs" disabled={busy} onChange={async e => { const file = e.target.files?.[0]; e.target.value = ""; if (!file) return; if (file.size > 256 * 1024) { setError("Maximum file size is 256 KiB"); return; } await change("PUT", file.name, await file.text()); }} /></label>{files.map(file => <div className="flex items-center justify-between text-xs" key={file.filename}><span>{file.filename} · {new Date(file.updatedAt).toLocaleString()}</span><button className={button} disabled={busy} onClick={() => void change("DELETE", file.filename)}>Remove</button></div>)}{error && <p role="alert" className="text-xs">{error}</p>}</div></details>;
 }

--- a/dashboard/src/components/SourcesFrontDoor.tsx
+++ b/dashboard/src/components/SourcesFrontDoor.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { RepoEnvPanel } from "./CloudAgents";
 // SourcesFrontDoor — the "sources front door" on the home page. Two doors,
 // never one ambiguous box: an "Add a folder" input (local mode only — point
 // Flow at a project folder or a folder of docs) stacked above the GitHub
@@ -221,7 +220,7 @@ function IndexLogPanel({ repo }: { repo: string }) {
   );
 }
 
-function SourceRow({ s, st, onChanged, mode }: { mode: FlowMode; s: SourceEntry; st?: RepoStatusEntry; onChanged: () => void }) {
+function SourceRow({ s, st, onChanged }: { s: SourceEntry; st?: RepoStatusEntry; onChanged: () => void }) {
   const { prefix } = useProject();
   const chip = sourceChip(s);
   // Prefer the orchestrator's state machine; fall back to the legacy guess
@@ -479,7 +478,6 @@ function SourceRow({ s, st, onChanged, mode }: { mode: FlowMode; s: SourceEntry;
         </div>
       </div>
 
-      {mode === "prod" && s.kind !== "docs" && <RepoEnvPanel repo={s.name} />}
 
       {/* Live indexer activity — appears while an index job runs */}
       {s.kind !== "docs" && <IndexActivityStrip repo={s.name} active={indexing || watchActivity} />}
@@ -667,7 +665,7 @@ export function SourcesFrontDoor({ variant, repos, mode, onChanged }: Props) {
       {repos.length > 0 && (
         <div className="flex flex-col gap-1.5">
           {repos.map((s, i) => (
-            <SourceRow key={i} s={s} st={statuses[s.name]} onChanged={onChanged} mode={mode} />
+            <SourceRow key={i} s={s} st={statuses[s.name]} onChanged={onChanged} />
           ))}
         </div>
       )}

--- a/dashboard/src/lib/cloudAgentView.ts
+++ b/dashboard/src/lib/cloudAgentView.ts
@@ -1,7 +1,7 @@
 export interface CloudRepo { name: string; baseBranch?: string; worktree?: { path: string; branch: string; archived_at?: number; cleanup_error?: string } }
 export interface CloudTurn { id: string; status: string; phase: string; message: string; created_at?: number; updated_at?: number; repos?: CloudRepo[]; result?: { answer_md?: string; output?: string }; events?: { kind: string; time: number; title: string; output?: string; status?: string }[] }
 export interface CloudRun { turns: CloudTurn[]; repos: CloudRepo[]; slackUrl?: string }
-export const cloudStatus = (turn: CloudTurn) => turn.phase === "waiting" || turn.status === "queued" ? "queued" : turn.status === "done" ? "idle" : turn.status === "failed" ? "error" : "running";
+export const cloudStatus = (turn: CloudTurn) => turn.phase === "setup" ? "setup" : turn.phase === "waiting" || turn.status === "queued" ? "queued" : turn.status === "done" ? "idle" : turn.status === "failed" ? "error" : "running";
 export function cloudSessionRow(turn: CloudTurn) {
   return { id: `cloud-${turn.id}`, backend: "opencode", repo: turn.repos?.map(r => r.name).join(", ") || "server", title: turn.message, status: cloudStatus(turn), live: ["running", "queued"].includes(turn.status), worktree_id: turn.repos?.find(r => r.worktree)?.worktree?.path ?? null, created_at: (turn.created_at ?? 0) * 1000, updated_at: (turn.updated_at ?? 0) * 1000 };
 }

--- a/docs/cloud-task-lifecycle.md
+++ b/docs/cloud-task-lifecycle.md
@@ -91,10 +91,12 @@ blindly force-cleaning. Local checkpoint branches are retained indefinitely.
 `FLOW_TEST_OPENCODE_BIN` to an installed OpenCode binary to include the real
 plugin smoke test. Run on Linux to exercise orphan process-group recovery.
 
-## Repository environment files
+## Legacy repository environment API
 
-In the server dashboard, expand **Environment files** on a repository row.
-Upload `.env`, `.env.local`, or another `.env.*` file (256 KiB maximum).
+The old dashboard upload panel has been removed in favor of conversational setup
+(described below). Existing stored files and `/v1/agents/repos/:repo/env` remain
+supported for compatibility: `.env`, `.env.local`, or another `.env.*` file
+(256 KiB maximum).
 Files are scoped to that repository in that Flow project. The API lists names
 and update times, never values. Uploading the same filename replaces its saved
 version; Remove deletes the saved version. Store development/test credentials.
@@ -105,7 +107,7 @@ migration makes existing encrypted settings and env files unreadable. This is
 protection for stored data, not isolation from administrators or task processes.
 Every authenticated administrator of the project can replace these files.
 
-At the start of a conversation turn, Flow writes uploads into the appropriate
+When a coding turn acquires its workspace, Flow writes uploads into the appropriate
 repo worktree with mode 0600. Uploads override source env copies. Applications
 must load the files as usual; Flow does not execute shell code from env files
 or globally export their contents. Changes during a run apply on a later turn.

--- a/docs/cloud-task-lifecycle.md
+++ b/docs/cloud-task-lifecycle.md
@@ -194,3 +194,48 @@ and twenty stored images per thread. Start a new thread when that storage limit
 is reached. Stored images are retained with the conversation; no automatic image
 retention cleanup is implemented yet. Unsupported attachments and inaccessible
 files produce a visible error rather than a text-only answer pretending to see them.
+
+## Conversational setup
+
+The dashboard no longer has a repository env-upload panel. In cloud Slack tasks,
+`flow_setup` lets the agent list saved setup, register an existing untracked file
+without reading its values, select an environment, or request a missing file,
+variable, or CLI setup from the original requester. Paths can be nested and files
+can have any name; each supplied file is limited to 1 MiB. Tracked files, Git
+metadata, traversal and symlink destinations are refused.
+
+A request opens a dedicated DM thread with the original requester. File/value
+replies are consumed by the setup handler before normal chat/image processing.
+Only the requester in the matching Slack workspace and DM thread can fulfill it.
+Raw values and files do not enter job prompts; files are stored encrypted with the
+project settings key. Slack itself retains the original attachment/message.
+
+The agent turn ends while waiting, releasing the machine coding slot. Requests
+survive restarts. Once fulfilled, a worker takes that slot to register files in
+both the source checkout and the task worktree, then resumes the same conversation
+and delivers the result to the original Slack thread. The resume job is deduplicated
+by request ID. Upload/network failures leave the request pending. Conflicting
+locally changed files are retained instead of overwritten. A requester can reply
+`cancel` in the setup DM thread to cancel a waiting request.
+
+Saved setup is keyed by repository, environment and destination. Environment
+selection sticks to each conversation; a single non-production environment can
+be reused automatically, while production requires explicit selection. Copies
+are mode 0600, excluded in Git's local exclude file, hidden from cloud diffs, and
+restored for future worktrees. This is coordination on a trusted shared host,
+not OS isolation; authenticated terminals and programs can access host files.
+Normal application loaders must load env files; values are not automatically
+exported into every shell. Register only reusable configuration, not databases,
+Terraform state or caches. Modified private setup keeps worktrees from being
+checkpointed automatically.
+
+Terminal requests link to an authenticated project dashboard page backed by
+node-pty and xterm.js. It starts a login shell as the Flow OS user in the source
+checkout and holds the same coding slot as agents. CLI installations and saved
+logins persist; shell-only exports do not. Terminal input/output is held only in
+bounded memory, never stored in the agent transcript. Closing the terminal
+releases its slot; “Done — resume task” also fulfills the setup request. The agent
+must verify the setup after resuming. Disconnected terminals close after five
+minutes without polling/input, and terminals have a one-hour maximum lifetime.
+A restart ends the terminal; the DM link can reopen it. Linux builds need the
+native build prerequisites for node-pty (Python and a C/C++ toolchain).

--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -1,8 +1,7 @@
 FROM node:22-slim
 
-# Fallback build tools only. better-sqlite3 (^12) and opencode-ai ship prebuilt
-# binaries for linux-x64/arm64, so a normal install compiles nothing — these are
-# kept purely as a safety net if a prebuild is ever unavailable for this arch.
+# Build tools for node-pty, plus fallback compilation when other native
+# dependencies do not have a prebuilt binary for this architecture.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 make g++ \
  && rm -rf /var/lib/apt/lists/*

--- a/orchestrator/package.json
+++ b/orchestrator/package.json
@@ -8,22 +8,23 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "tsx src/index.ts",
-    "test": "node --import tsx/esm --test test/fake-opencode.ts test/orchestrator.test.ts test/adapters.test.ts test/outbox-approve.test.ts test/llmlog.test.ts test/smoke.ts test/notify.test.ts test/pollers.test.ts test/poller.test.ts test/settings.test.ts test/sources.test.ts test/agent-diff.test.ts test/agent-runtime.test.ts test/worktrees.test.ts test/cloud-tasks.test.ts test/cloud-opencode-smoke.test.ts test/memory.test.ts test/llm.test.ts test/indexer-runtime.test.ts test/index-queue.test.ts test/change-branch.test.ts test/repo-removed.test.ts test/index-incremental.test.ts test/work-folders.test.ts test/ingest.test.ts test/flow-hook.test.ts test/connector-auth.test.ts test/materialize.test.mjs test/executables.test.mjs test/remote-setup.test.mjs test/session-search.test.ts test/telemetry.test.ts test/slack-agent.test.ts test/slack-images.test.ts",
+    "test": "node --import tsx/esm --test test/fake-opencode.ts test/orchestrator.test.ts test/adapters.test.ts test/outbox-approve.test.ts test/llmlog.test.ts test/smoke.ts test/notify.test.ts test/pollers.test.ts test/poller.test.ts test/settings.test.ts test/sources.test.ts test/agent-diff.test.ts test/agent-runtime.test.ts test/worktrees.test.ts test/cloud-tasks.test.ts test/cloud-opencode-smoke.test.ts test/memory.test.ts test/llm.test.ts test/indexer-runtime.test.ts test/index-queue.test.ts test/change-branch.test.ts test/repo-removed.test.ts test/index-incremental.test.ts test/work-folders.test.ts test/ingest.test.ts test/flow-hook.test.ts test/connector-auth.test.ts test/materialize.test.mjs test/executables.test.mjs test/remote-setup.test.mjs test/session-search.test.ts test/telemetry.test.ts test/slack-agent.test.ts test/slack-images.test.ts test/setup.test.ts",
     "verify": "npm test",
     "verify:real": "tsx test/real-integrations.ts",
     "verify:session": "tsx test/real-session.ts"
   },
   "dependencies": {
-    "@opencode-ai/plugin": "1.17.20",
     "@agentclientprotocol/claude-agent-acp": "^0.56.0",
+    "@agentclientprotocol/codex-acp": "^1.1.0",
     "@agentclientprotocol/sdk": "^1.2.0",
     "@fastify/sensible": "^5.6.0",
+    "@opencode-ai/plugin": "1.17.20",
     "@slack/bolt": "^5.1.0",
     "@slack/web-api": "^7.18.0",
-    "@agentclientprotocol/codex-acp": "^1.1.0",
     "better-sqlite3": "^12.11.1",
-    "shell-quote": "^1.10.0",
-    "fastify": "^4.28.0"
+    "fastify": "^4.28.0",
+    "node-pty": "^1.1.0",
+    "shell-quote": "^1.10.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.11",

--- a/orchestrator/src/agents/cloud-cleanup.ts
+++ b/orchestrator/src/agents/cloud-cleanup.ts
@@ -5,6 +5,7 @@ import db from "../db.js";
 import { containsSecret } from "../events.js";
 import { cloudGit, cloudMode, conversationRepos, reconcileWorktree, withConversationTurn, type CloudRepo } from "./cloud-workspaces.js";
 import { requestCodingSlot, releaseCodingSlot } from "./coding-slot.js";
+import { unchangedSetupFile, isSetupFile } from "./setup-files.js";
 import { managedEnvUnchanged, redactCloudText } from "./repo-env.js";
 
 const split = (s: string) => s.split("\0").filter(Boolean);
@@ -17,6 +18,7 @@ async function checkpoint(key: string, repo: CloudRepo): Promise<void> {
   const cwd = tree.path;
   const metadata = tree.git_dir!;
   const unchangedEnv = (name: string) => {
+    if (unchangedSetupFile(repo.name, cwd, name)) return true;
     if (managedEnvUnchanged(metadata, cwd, name)) return true;
     if (!/^\.env(?:\.[^/]+)?$/.test(name)) return false;
     const local = path.join(cwd, name), source = path.join(repo.source, name);
@@ -32,7 +34,7 @@ async function checkpoint(key: string, repo: CloudRepo): Promise<void> {
 
   // Only discard known rebuildable caches and unchanged copies of source env
   // files. Unknown ignored state (local databases, uploads, etc.) keeps the tree.
-  const ignored = split(await cloudGit(cwd, ["ls-files", "--others", "--ignored", "--exclude-standard", "--directory", "-z"]));
+  const ignored = split(await cloudGit(cwd, ["ls-files", "--others", "--ignored", "--exclude-standard", "-z"]));
   for (const name of ignored) {
     if (name.split("/").some((part) => disposable.has(part))) continue;
     if (unchangedEnv(name)) continue;
@@ -47,6 +49,7 @@ async function checkpoint(key: string, repo: CloudRepo): Promise<void> {
     return existsSync(target) ? createHash("sha256").update(readFileSync(target)).digest("hex") : "deleted";
   }).join(":");
   for (const name of changed) {
+    if (isSetupFile(repo.name, name)) throw new Error("Setup file changes require private preservation; retained workspace");
     if (managedEnvUnchanged(metadata, cwd, name)) continue;
     if (unchangedEnv(name) && !(await cloudGit(cwd, ["ls-files", "--", name]))) continue;
     if (sensitiveName(name)) throw new Error("Credential-related changes require manual preservation; retained workspace");

--- a/orchestrator/src/agents/cloud-opencode-plugin.ts
+++ b/orchestrator/src/agents/cloud-opencode-plugin.ts
@@ -44,6 +44,19 @@ const cloudPlugin: Plugin = async ({ directory }) => {
       } };
     },
     tool: {
+      flow_setup: tool({
+        description: "Resolve missing repository configuration or CLI authentication. list shows saved setup paths without values. remember registers an existing untracked file from source/worktree and copies it privately to both and future worktrees. select chooses an environment. request DMs the ORIGINAL Slack requester for a file/value or interactive setup terminal, ends this turn, and resumes automatically when ready. Never pass secret content as arguments.",
+        args: { action: tool.schema.enum(["list", "remember", "select", "request"]), repo: tool.schema.string(), environment: tool.schema.string().optional(), kind: tool.schema.enum(["file", "value", "terminal"]).optional(), destination: tool.schema.string().optional(), variable: tool.schema.string().optional(), reason: tool.schema.string().optional(), from: tool.schema.enum(["source", "worktree"]).optional() },
+        async execute(args) {
+          for (;;) {
+            const response = await fetch(endpoint.replace(/workspace$/, "setup"), { method: "POST", headers: { "content-type": "application/json", authorization: `Bearer ${process.env.FLOW_JOB_TOKEN}` }, body: JSON.stringify(args), signal: AbortSignal.timeout(90_000) });
+            const result = await response.json() as { error?: string };
+            if (response.status === 423) { await new Promise(resolve => setTimeout(resolve, 1000)); continue; }
+            if (!response.ok) throw new Error(result.error ?? "Setup request failed");
+            return JSON.stringify(result);
+          }
+        },
+      }),
       flow_workspace: tool({
         description: "List registered repos and this conversation's worktrees. With repo and edit=true, prepare or reuse its worktree for requested edits. Questions do not need one.",
         args: { repo: tool.schema.string().optional(), edit: tool.schema.boolean().optional() },

--- a/orchestrator/src/agents/cloud-routes.ts
+++ b/orchestrator/src/agents/cloud-routes.ts
@@ -1,3 +1,4 @@
+import { requests } from "./setup-requests.js";
 import { timingSafeEqual } from "node:crypto";
 import type { FastifyInstance } from "fastify";
 import { containsSecret } from "../events.js";
@@ -41,16 +42,18 @@ export function registerCloudTaskRoutes(app: FastifyInstance): void {
       if (!job || job.status !== "running" || typeof key !== "string" || !["answer", "continue"].includes(job.type)) {
         return reply.code(403).send({ error: "A running cloud conversation job is required" });
       }
+      if (requests().some(r => r.job === job.id && ["requesting", "waiting", "ready"].includes(r.state))) return reply.code(409).send({ error: "Task is waiting for setup; stop this turn" });
       const { repo, edit, execution } = req.body ?? {};
       if ((repo !== undefined && typeof repo !== "string") || (execution !== undefined && typeof execution !== "boolean") || (edit !== undefined && typeof edit !== "boolean") || (edit && !repo)) {
         return reply.code(400).send({ error: "edit requires a registered repo name" });
       }
       try {
-        if (edit || execution) {
+        const needsRestore = conversationRepos(key).some(r => r.worktree?.archived_at);
+        if (edit || execution || needsRestore) {
           const slot = requestCodingSlot(req.params.id, codingChildPid(req.params.id));
           if (!slot.acquired) return reply.code(423).send({ error: "Waiting for the machine's coding slot", position: slot.position });
         }
-        await restoreConversationWorktrees(key);
+        if (edit || execution || needsRestore) await restoreConversationWorktrees(key, true);
         if (edit) await ensureConversationWorktree(key, repo!);
         return { repos: conversationRepos(key) };
       } catch (err) {

--- a/orchestrator/src/agents/cloud-tool-policy.ts
+++ b/orchestrator/src/agents/cloud-tool-policy.ts
@@ -9,6 +9,7 @@ Use flow_workspace without arguments to discover repositories and this conversat
 Questions need no worktree: use read, grep and glob against the returned source directories. Do not run shell commands to answer simple source questions.
 Only when the user requests changes, call flow_workspace with repo and edit=true. Re-read files in the returned worktree before editing them.
 The same conversation can acquire more worktrees as you discover other repositories to change. Reuse existing worktrees on follow-ups.
+Use flow_setup to resolve missing setup as part of the task. Inspect setup docs and config references first; list saved setup without reading values. Register required existing untracked config files with remember (source or worktree), including nested paths and arbitrary filenames. When a file/value or CLI installation/login is missing, request it from the original Slack requester using flow_setup. Specify the intended environment; never silently choose production. A request ends this turn and releases the coding slot; Flow resumes you after the reply. For shared CLI installs/authentication, request a terminal rather than telling the user to SSH. The terminal runs as your OS user; new processes can use saved CLI login/config, but terminal-only exports do not persist. Use a value/file request for persistent environment values. Verify setup after resuming. Do not treat mutable databases or Terraform state as reusable configuration. Never put credential content in tool arguments.
 All edits and commands must target your conversation's worktrees. Shared clones are read-only evidence. Never change their branches or files.
 Set bash.workdir explicitly to the chosen worktree. Do not use cd or Git directory overrides; Flow has already created your branch.
 Use the bash tool result and its exit metadata as execution evidence. A new shell cannot retrieve the previous shell exit status; do not run echo $? to check it. Once the requested check succeeds, report the result without rerunning it unless a new change or failure requires another check.
@@ -40,7 +41,7 @@ export function cloudGitIdentity(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
 
 export const CLOUD_PERMISSIONS = {
   "*": "deny", read: "allow", glob: "allow", grep: "allow", edit: "allow", bash: "allow",
-  flow_workspace: "allow", todowrite: "allow", todoread: "allow", external_directory: "allow",
+  flow_setup: "allow", flow_workspace: "allow", todowrite: "allow", todoread: "allow", external_directory: "allow",
   "graph_*": "allow",
 } as const;
 
@@ -160,18 +161,24 @@ export function createCloudToolPolicy(options: {
   };
 
   return async (tool: string, args: Record<string, unknown>): Promise<void> => {
-    if (GRAPH_TOOLS.has(tool) || tool === "flow_workspace" || tool === "todowrite" || tool === "todoread") return;
+    if (GRAPH_TOOLS.has(tool) || tool === "flow_setup" || tool === "flow_workspace" || tool === "todowrite" || tool === "todoread") return;
     if (!["read", "glob", "grep", "write", "edit", "apply_patch", "bash"].includes(tool)) {
       throw new Error(`Tool "${tool}" is not enabled for cloud tasks`);
     }
     if (["write", "edit", "apply_patch", "bash"].includes(tool)) await options.acquire?.();
     const repos = await options.repos();
     for (const repo of repos) if (repo.worktree) assertWorktree(repo.worktree.path);
+    const assertNotSetup = (target: string) => {
+      for (const repo of repos) for (const root of [repo.source, repo.worktree?.path].filter(Boolean) as string[]) {
+        if (repo.setupPaths?.some(file => canonicalPath(path.join(root, file)) === canonicalPath(target))) throw new Error("Setup file contents are private; use flow_setup without reading values");
+      }
+    };
 
     if (tool === "read" || tool === "glob" || tool === "grep") {
       const field = tool === "read" ? "filePath" : "path";
       const target = absolute(args[field]);
       assertCodePath(target);
+      assertNotSetup(target);
       for (const repo of repos) {
         if (within(repo.source, target)) {
           args[field] = repo.worktree
@@ -224,6 +231,7 @@ export function createCloudToolPolicy(options: {
     const redirects: string[] = [];
     for (const target of targets) {
       assertCodePath(target);
+      assertNotSetup(target);
       const own = repos.find((r) => r.worktree && within(r.worktree.path, target));
       if (own) continue;
       const source = repos.find((r) => within(r.source, target));

--- a/orchestrator/src/agents/cloud-view-routes.ts
+++ b/orchestrator/src/agents/cloud-view-routes.ts
@@ -4,6 +4,8 @@ import { enqueueJob, getJob, cancelCloudJob } from "../opencode.js";
 import { cloudMode, conversationRepos, type ConversationRef } from "./cloud-workspaces.js";
 import { cloudEvents } from "./cloud-events.js";
 import { codingSlotStatus } from "./coding-slot.js";
+import { requests } from "./setup-requests.js";
+import { isSetupFile } from "./setup-files.js";
 import { redactCloudText } from "./repo-env.js";
 import { containsSecret } from "../events.js";
 
@@ -13,7 +15,8 @@ function summarize(id: string, includeEvents = true) {
   const result = raw ? { answer_md: redactCloudText(String(raw.answer_md ?? raw.error ?? "")), output: redactCloudText(String(raw.output ?? "")), exit_code: raw.exit_code } : null;
   let message = job.input.display_message ?? (job.input.manual_command ? `Terminal: ${(job.input.manual_command as { command: string }).command}` : job.input.message ?? job.input.question ?? "Task");
   if (!job.input.display_message && typeof message === "string" && message.startsWith("Style:")) message = message.slice(message.lastIndexOf("\n\n") + 2);
-  return { id, status: job.status, phase: ["running", "queued"].includes(job.status) ? codingSlotStatus(id) ?? job.status : job.status,
+  const pendingSetup = requests().some(r => r.job === id && ["requesting", "waiting", "ready"].includes(r.state));
+  return { id, status: job.status, phase: pendingSetup ? "setup" : ["running", "queued"].includes(job.status) ? codingSlotStatus(id) ?? job.status : job.status,
     message: redactCloudText(String(message)).slice(0, 8000), created_at: job.created_at, updated_at: job.updated_at,
     repos: conversationRepos(String(job.input.conversation_key)),
     command: Boolean(job.input.manual_command), session_id: job.session_id, result, events: includeEvents ? cloudEvents(id) : [] };
@@ -53,7 +56,7 @@ export function registerCloudViewRoutes(app: FastifyInstance): void {
     const result = await worktreeDiff(repo.worktree.path, repo.name);
     if ("error" in result) return reply.code(409).send(result);
     const sensitive = /(?:^|\/)(?:\.env(?:\.[^/]*)?|\.npmrc|credentials|id_rsa|id_ed25519)$|\.(?:pem|key)$/i;
-    const files = result.files.filter(f => !sensitive.test(f.path));
+    const files = result.files.filter(f => !sensitive.test(f.path) && !isSetupFile(repo.name, f.path));
     const allowed = new Set(files.map(f => f.path));
     const diff = result.diff.split(/(?=^diff --git )/m).filter(chunk => {
       const name = chunk.split("\n")[0].match(/ b\/(.+)$/)?.[1];

--- a/orchestrator/src/agents/cloud-workspaces.ts
+++ b/orchestrator/src/agents/cloud-workspaces.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import db from "../db.js";
 import { createSessionWorktree, overlayEnvFiles } from "./worktrees.js";
+import { applySetupFiles, setupFiles } from "./setup-files.js";
 import { applyRepoEnv } from "./repo-env.js";
 
 const exec = promisify(execFile);
@@ -20,6 +21,7 @@ export interface CloudRepo {
   name: string;
   source: string;
   baseBranch: string;
+  setupPaths?: string[];
   worktree?: { path: string; branch: string; base_commit: string; git_dir?: string | null; git_identity?: string | null; archived_at?: number | null; checkpoint_commit?: string | null; cleanup_error?: string | null };
 }
 
@@ -81,7 +83,7 @@ export function conversationRepos(key: string): CloudRepo[] {
     const worktree = db.prepare(
       "SELECT path, branch, base_commit, git_dir, git_identity, archived_at, checkpoint_commit, cleanup_error FROM cloud_worktrees WHERE conversation_key = ? AND repo = ?",
     ).get(key, repo.name) as CloudRepo["worktree"];
-    return { name: repo.name, source: path.join(workspace, "repos", repo.name), baseBranch: repo.branch, worktree };
+    return { name: repo.name, source: path.join(workspace, "repos", repo.name), baseBranch: repo.branch, setupPaths: setupFiles(repo.name).map(f => f.destination), worktree };
   });
 }
 
@@ -121,6 +123,7 @@ export async function ensureConversationWorktree(key: string, name: string, refr
       }
       await reconcileWorktree(key, repo);
       if (restored || refreshEnv) applyRepoEnv(name, repo.source, repo.worktree.path, repo.worktree.git_dir!);
+      if (restored || refreshEnv) applySetupFiles(key, name, repo.worktree.path);
       return repo;
     }
     let commit: string | undefined;
@@ -143,6 +146,7 @@ export async function ensureConversationWorktree(key: string, name: string, refr
     db.prepare("INSERT INTO cloud_worktrees (conversation_key, repo, path, branch, base_commit, git_dir, git_identity) VALUES (?, ?, ?, ?, ?, ?, ?)")
       .run(key, name, result.path, result.branch, commit, gitDir, gitIdentity);
     applyRepoEnv(name, repo.source, result.path, gitDir);
+    applySetupFiles(key, name, result.path);
     return { ...repo, worktree: { ...result, base_commit: commit, git_dir: gitDir, git_identity: gitIdentity } };
   }
 }

--- a/orchestrator/src/agents/coding-slot.ts
+++ b/orchestrator/src/agents/coding-slot.ts
@@ -25,7 +25,7 @@ function proc(pid: number) {
   try {
     const raw = readFileSync(`/proc/${pid}/stat`, "utf8");
     const fields = raw.slice(raw.lastIndexOf(")") + 2).split(" ");
-    return { identity: fields[19], group: Number(fields[2]), zombie: fields[0] === "Z" };
+    return { identity: fields[19], group: Number(fields[2]), session: Number(fields[3]), zombie: fields[0] === "Z" };
   } catch { return undefined; }
 }
 function identity(pid: number): string {
@@ -38,7 +38,7 @@ function identity(pid: number): string {
 function groupAlive(pid: number): boolean {
   if (process.platform === "linux") {
     return readdirSync("/proc").some((name) => /^\d+$/.test(name) && (() => {
-      const p = proc(Number(name)); return p?.group === pid && !p.zombie;
+      const p = proc(Number(name)); return Boolean(p && (p.group === pid || p.session === pid) && !p.zombie);
     })());
   }
   try { process.kill(-pid, 0); return true; } catch { return false; }
@@ -48,6 +48,15 @@ function stopOrphan(row: Request): boolean {
   const now = identity(row.child);
   if (now !== "gone" && now !== row.child_identity) {
     throw new Error("Coding worker PID changed; inspect the machine before clearing its queue entry");
+  }
+  if (process.platform === "linux") {
+    // Interactive terminals put foreground jobs into separate process groups
+    // within the same session. Stop those too before admitting another writer.
+    for (const name of readdirSync("/proc")) {
+      if (!/^\d+$/.test(name)) continue;
+      const p = proc(Number(name));
+      if (p?.session === row.child) { try { process.kill(-p.group, "SIGKILL"); } catch {} }
+    }
   }
   try { process.kill(-row.child, "SIGKILL"); } catch { /* recheck below */ }
   return !groupAlive(row.child);

--- a/orchestrator/src/agents/repo-env.ts
+++ b/orchestrator/src/agents/repo-env.ts
@@ -3,6 +3,7 @@ import { existsSync, lstatSync, readFileSync, writeFileSync, renameSync, unlinkS
 import path from "node:path";
 import db from "../db.js";
 import { encrypt, decrypt, getSetting, SETTINGS } from "../settings.js";
+import { setupFiles } from "./setup-files.js";
 import { containsSecret } from "../events.js";
 
 const prefix = (repo: string) => `repo-env:${repo}:`;
@@ -83,6 +84,20 @@ export function redactCloudText(text: string): string {
       const match = /^\s*(?:export\s+)?[A-Za-z_][A-Za-z0-9_]*\s*=\s*(.*)$/.exec(line);
       if (match) values.push(match[1].replace(/^['"]|['"]$/g, ""));
     }
+  }
+  for (const file of setupFiles()) {
+    const decoded = decrypt(file.encrypted);
+    if (!decoded) continue;
+    const raw = Buffer.from(decoded, "base64").toString("utf8");
+    values.push(raw.trim());
+    for (const line of raw.split(/\r?\n/)) {
+      const match = /^\s*(?:export\s+)?[A-Za-z_][A-Za-z0-9_]*\s*=\s*(.*)$/.exec(line);
+      if (match) values.push(match[1].replace(/^['"]|['"]$/g, ""));
+    }
+    try {
+      const collect = (value: unknown): void => { if (typeof value === "string") values.push(value); else if (value && typeof value === "object") Object.values(value).forEach(collect); };
+      collect(JSON.parse(raw));
+    } catch { /* non-JSON setup file */ }
   }
   for (const value of values.filter((v) => v.length >= 4).sort((a, b) => b.length - a.length)) text = text.replaceAll(value, "[redacted]");
   return text;

--- a/orchestrator/src/agents/setup-files.ts
+++ b/orchestrator/src/agents/setup-files.ts
@@ -1,0 +1,145 @@
+import { createHash, randomUUID } from "node:crypto";
+import { existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import db from "../db.js";
+import { encrypt, decrypt } from "../settings.js";
+
+export const MAX_SETUP_BYTES = 1024 * 1024;
+interface SetupFile { repo: string; environment: string; destination: string; encrypted: string; digest: string }
+const hash = (data: Buffer) => createHash("sha256").update(data).digest("hex");
+const key = (...parts: string[]) => `setup-file:${JSON.stringify(parts)}`;
+export function setupFiles(repo?: string): SetupFile[] {
+  const rows = db.prepare("SELECT value FROM config WHERE key LIKE 'setup-file:%'").all() as { value: string }[];
+  return rows.map(row => JSON.parse(row.value) as SetupFile).filter(file => !repo || file.repo === repo);
+}
+export function validateSetupPath(destination: string): void {
+  if (!destination || destination.length > 500 || destination.includes("\\") || destination.split("/").some(p => !p || p === "." || p === ".." || p === ".git") || /[\x00-\x1f\x7f]/.test(destination) || path.isAbsolute(destination)) {
+    throw new Error("Use a repository-relative file path without traversal or Git metadata");
+  }
+}
+function safeTarget(root: string, destination: string): string {
+  validateSetupPath(destination);
+  const base = realpathSync(root);
+  let current = base;
+  for (const part of destination.split("/")) {
+    current = path.join(current, part);
+    try { if (lstatSync(current).isSymbolicLink()) throw new Error("Setup paths cannot contain symlinks"); }
+    catch (error) { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error; }
+  }
+  return current;
+}
+function git(root: string, args: string[]): string {
+  return execFileSync("git", ["-C", root, "--literal-pathspecs", ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+}
+function manifest(root: string): Record<string, string> {
+  const metadata = git(root, ["rev-parse", "--absolute-git-dir"]);
+  const file = path.join(metadata, "flow-setup-files.json");
+  return existsSync(file) ? JSON.parse(readFileSync(file, "utf8")) : {};
+}
+export function isSetupFile(repo: string, destination: string): boolean {
+  return setupFiles(repo).some(file => file.destination === destination);
+}
+export function unchangedSetupFile(repo: string, root: string, destination: string): boolean {
+  if (!isSetupFile(repo, destination)) return false;
+  const target = safeTarget(root, destination);
+  return existsSync(target) && lstatSync(target).isFile() && manifest(root)[destination] === hash(readFileSync(target));
+}
+export function setupEnvironment(conversation: string, repo: string, select?: string): string | undefined {
+  const selection = `setup-selection:${JSON.stringify([conversation, repo])}`;
+  if (select !== undefined) {
+    if (!/^[A-Za-z0-9_-]{1,64}$/.test(select)) throw new Error("Use a short environment name such as staging or production");
+    db.prepare("INSERT OR REPLACE INTO config (key,value) VALUES (?,?)").run(selection, select);
+  }
+  const pinned = db.prepare("SELECT value FROM config WHERE key = ?").get(selection) as { value: string } | undefined;
+  if (pinned) return pinned.value;
+  const environments = [...new Set(setupFiles(repo).map(file => file.environment))];
+  // Production never becomes an implicit default just because it is the only profile.
+  const candidates = environments.filter(e => !/^(prod|production|live)$/i.test(e));
+  if (candidates.length === 1) return setupEnvironment(conversation, repo, candidates[0]);
+  if (environments.length) throw new Error(`Choose a setup environment for ${repo}: ${environments.join(", ")}. Ask the requester if it is unclear.`);
+}
+function checkTarget(root: string, file: SetupFile, data: Buffer): void {
+  const target = safeTarget(root, file.destination);
+  if (git(root, ["ls-files", "--", file.destination])) throw new Error("Setup files must not overwrite files tracked by Git; choose a local config path");
+  if (existsSync(target)) {
+    if (!lstatSync(target).isFile()) throw new Error("Setup destination must be a regular file");
+    const current = hash(readFileSync(target));
+    const previous = manifest(root)[file.destination];
+    if (current !== hash(data) && current !== previous && !setupFiles(file.repo).some(saved => saved.destination === file.destination && saved.digest === current)) throw new Error("Existing setup file changed locally; retained it instead of overwriting");
+  } else if (manifest(root)[file.destination]) throw new Error("Setup file was deleted locally; retained that deletion instead of overwriting");
+}
+function place(root: string, file: SetupFile, data: Buffer): void {
+  const target = safeTarget(root, file.destination);
+  mkdirSync(path.dirname(target), { recursive: true, mode: 0o700 });
+  const metadata = git(root, ["rev-parse", "--absolute-git-dir"]);
+  const exclude = git(root, ["rev-parse", "--git-path", "info/exclude"]);
+  const excludePath = path.resolve(root, exclude);
+  mkdirSync(path.dirname(excludePath), { recursive: true });
+  // Escape Git ignore metacharacters and anchor the exact repository path.
+  const pattern = "/" + file.destination.replace(/[\\*?!\[\] #]/g, "\\$&");
+  const old = existsSync(excludePath) ? readFileSync(excludePath, "utf8") : "";
+  if (!old.split("\n").includes(pattern)) writeFileSync(excludePath, old + "\n" + pattern + "\n", { mode: 0o600 });
+  const tmp = path.join(path.dirname(target), `.flow-setup-${randomUUID()}`);
+  writeFileSync(tmp, data, { mode: 0o600, flag: "wx" }); renameSync(tmp, target);
+  writeFileSync(path.join(metadata, "flow-setup-files.json"), JSON.stringify({ ...manifest(root), [file.destination]: hash(data) }), { mode: 0o600 });
+}
+/** Called only while holding the machine coding slot. Validate both destinations before changing either. */
+export function registerSetupFile(options: { repo: string; environment: string; destination: string; data: Buffer; source: string; worktree: string; conversation: string }): void {
+  const { repo, environment, destination, data, source, worktree, conversation } = options;
+  validateSetupPath(destination);
+  if (data.length > MAX_SETUP_BYTES) throw new Error("Setup files must be at most 1 MiB");
+  if (!/^[A-Za-z0-9_-]{1,64}$/.test(environment)) throw new Error("Invalid environment name");
+  const file = { repo, environment, destination, encrypted: encrypt(data.toString("base64")), digest: hash(data) };
+  checkTarget(source, file, data); checkTarget(worktree, file, data);
+  // Store before applying: a crash can retry the same content without losing the supplied file.
+  db.prepare("INSERT OR REPLACE INTO config (key,value) VALUES (?,?)").run(key(repo, environment, destination), JSON.stringify(file));
+  setupEnvironment(conversation, repo, environment);
+  place(source, file, data); place(worktree, file, data);
+}
+export function rememberExistingSetup(options: { repo: string; environment: string; destination: string; source: string; worktree: string; conversation: string; from: "source" | "worktree" }): void {
+  const target = safeTarget(options[options.from], options.destination);
+  if (!lstatSync(target).isFile() || lstatSync(target).size > MAX_SETUP_BYTES) throw new Error("Select a regular setup file at most 1 MiB");
+  registerSetupFile({ ...options, data: readFileSync(target) });
+}
+export function applySetupFiles(conversation: string, repo: string, worktree: string): void {
+  const files = setupFiles(repo);
+  if (!files.length) return;
+  const environment = setupEnvironment(conversation, repo);
+  const selected = files.filter(file => file.environment === environment);
+  const selectedPaths = new Set(selected.map(file => file.destination));
+  const removals = [...new Set(files.map(file => file.destination))].filter(destination => !selectedPaths.has(destination)).flatMap(destination => {
+    const target = safeTarget(worktree, destination);
+    if (!existsSync(target)) return [];
+    if (!lstatSync(target).isFile() || git(worktree, ["ls-files", "--", destination]) || !files.some(file => file.destination === destination && file.digest === hash(readFileSync(target)))) throw new Error("Another environment's setup file was changed locally; retained it instead of removing");
+    return [{ destination, target }];
+  });
+  const planned = selected.map(file => {
+    const plaintext = decrypt(file.encrypted);
+    if (plaintext === null) throw new Error("Cannot decrypt saved setup file");
+    const data = Buffer.from(plaintext, "base64");
+    checkTarget(worktree, file, data);
+    return { file, data };
+  });
+  for (const { destination, target } of removals) {
+    unlinkSync(target);
+    const previous = manifest(worktree); delete previous[destination];
+    writeFileSync(path.join(git(worktree, ["rev-parse", "--absolute-git-dir"]), "flow-setup-files.json"), JSON.stringify(previous), { mode: 0o600 });
+  }
+  for (const { file, data } of planned) place(worktree, file, data);
+}
+
+/** Preserve unrelated entries when the requester supplies a single missing variable. */
+export function mergeSetupValue(source: string, destination: string, variable: string, assignment: Buffer): Buffer {
+  const target = safeTarget(source, destination);
+  if (!existsSync(target)) return assignment;
+  if (!lstatSync(target).isFile() || lstatSync(target).size > MAX_SETUP_BYTES) throw new Error("Existing env file cannot be safely updated");
+  const content = readFileSync(target, "utf8");
+  if (content.includes("\0")) throw new Error("Variable destination is not a text env file");
+  const pattern = new RegExp(`^\\s*(?:export\\s+)?${variable}\\s*=`);
+  const lines = content.split(/\r?\n/);
+  // Do not guess where a multiline assignment ends.
+  if (lines.some(line => line.trim() === assignment.toString("utf8").trim())) return Buffer.from(content);
+  if (lines.some(line => pattern.test(line))) throw new Error("Variable already exists; upload the complete replacement file instead");
+  return Buffer.from(content.replace(/\n?$/, "\n") + assignment.toString("utf8"));
+}

--- a/orchestrator/src/agents/setup-requests.ts
+++ b/orchestrator/src/agents/setup-requests.ts
@@ -9,7 +9,7 @@ export interface SetupRequest {
   repo: string; environment: string; destination?: string; variable?: string;
   kind: "file" | "value" | "terminal"; reason: string;
   state: "requesting" | "waiting" | "ready" | "resumed" | "cancelled";
-  encrypted?: string; resumeJob?: string; notice?: string; createdAt: number;
+  encrypted?: string; resumeJob?: string; notice?: string; delivered?: boolean; createdAt: number;
 }
 db.exec(`CREATE TABLE IF NOT EXISTS setup_requests (id TEXT PRIMARY KEY, value TEXT NOT NULL)`);
 export function requests(): SetupRequest[] {

--- a/orchestrator/src/agents/setup-requests.ts
+++ b/orchestrator/src/agents/setup-requests.ts
@@ -25,7 +25,10 @@ export function saveSetupRequest(request: SetupRequest): void {
 export async function slackCall(method: string, args: Record<string, unknown>): Promise<Record<string, any>> {
   const token = getSetting("SLACK_BOT_TOKEN");
   if (!token) throw new Error("Slack is not connected");
-  const response = await fetch(`https://slack.com/api/${method}`, { method: "POST", headers: { authorization: `Bearer ${token}`, "content-type": "application/json; charset=utf-8" }, body: JSON.stringify(args), signal: AbortSignal.timeout(30_000) });
+  // files.info uses query/form parameters; unlike chat.postMessage it does not accept JSON bodies.
+  const info = method === "files.info";
+  const query = info ? `?${new URLSearchParams(Object.entries(args).map(([key, value]) => [key, String(value)]))}` : "";
+  const response = await fetch(`https://slack.com/api/${method}${query}`, { method: info ? "GET" : "POST", headers: { authorization: `Bearer ${token}`, "content-type": "application/json; charset=utf-8" }, ...(info ? {} : { body: JSON.stringify(args) }), signal: AbortSignal.timeout(30_000) });
   const body = await response.json() as Record<string, any>;
   if (!response.ok || !body.ok) throw new Error(`Slack ${method} failed (${String(body.error ?? response.status).replace(/[^a-zA-Z0-9_:-]/g, "")})`);
   return body;

--- a/orchestrator/src/agents/setup-requests.ts
+++ b/orchestrator/src/agents/setup-requests.ts
@@ -1,0 +1,115 @@
+import { randomUUID } from "node:crypto";
+import db from "../db.js";
+import { encrypt, decrypt, getSetting } from "../settings.js";
+import { MAX_SETUP_BYTES, validateSetupPath } from "./setup-files.js";
+
+export interface SetupRequest {
+  id: string; job: string; conversation: string; requester: string; team: string;
+  channel: string; thread: string; dm?: string; dmThread?: string;
+  repo: string; environment: string; destination?: string; variable?: string;
+  kind: "file" | "value" | "terminal"; reason: string;
+  state: "requesting" | "waiting" | "ready" | "resumed" | "cancelled";
+  encrypted?: string; resumeJob?: string; notice?: string; createdAt: number;
+}
+db.exec(`CREATE TABLE IF NOT EXISTS setup_requests (id TEXT PRIMARY KEY, value TEXT NOT NULL)`);
+export function requests(): SetupRequest[] {
+  return (db.prepare("SELECT value FROM setup_requests").all() as { value: string }[]).map(r => JSON.parse(r.value));
+}
+export function getSetupRequest(id: string): SetupRequest | undefined {
+  const row = db.prepare("SELECT value FROM setup_requests WHERE id = ?").get(id) as { value: string } | undefined;
+  return row ? JSON.parse(row.value) : undefined;
+}
+export function saveSetupRequest(request: SetupRequest): void {
+  db.prepare("INSERT OR REPLACE INTO setup_requests (id,value) VALUES (?,?)").run(request.id, JSON.stringify(request));
+}
+export async function slackCall(method: string, args: Record<string, unknown>): Promise<Record<string, any>> {
+  const token = getSetting("SLACK_BOT_TOKEN");
+  if (!token) throw new Error("Slack is not connected");
+  const response = await fetch(`https://slack.com/api/${method}`, { method: "POST", headers: { authorization: `Bearer ${token}`, "content-type": "application/json; charset=utf-8" }, body: JSON.stringify(args), signal: AbortSignal.timeout(30_000) });
+  const body = await response.json() as Record<string, any>;
+  if (!response.ok || !body.ok) throw new Error(`Slack ${method} failed (${String(body.error ?? response.status).replace(/[^a-zA-Z0-9_:-]/g, "")})`);
+  return body;
+}
+export function setupUrl(id: string): string {
+  const base = process.env.FLOW_PUBLIC_URL;
+  if (!base) throw new Error("FLOW_PUBLIC_URL must be configured for setup terminals");
+  const url = new URL(base);
+  if (!["http:", "https:"].includes(url.protocol) || url.username || url.password) throw new Error("Invalid public dashboard URL");
+  url.pathname = `${url.pathname.replace(/\/$/, "")}/setup/${id}`; url.search = ""; url.hash = "";
+  return url.toString();
+}
+export async function createSetupRequest(input: Omit<SetupRequest, "id" | "state" | "createdAt">): Promise<SetupRequest> {
+  const existing = requests().find(r => r.job === input.job && ["requesting", "waiting", "ready"].includes(r.state));
+  if (existing) { if (existing.state === "requesting") await deliverSetupRequest(existing); return getSetupRequest(existing.id)!; }
+  if (!["file", "value", "terminal"].includes(input.kind)) throw new Error("Choose file, value, or terminal setup");
+  if (!input.requester || !input.channel || !input.thread) throw new Error("Setup requests need an originating Slack requester and thread");
+  if (input.kind !== "terminal") validateSetupPath(input.destination ?? "");
+  if (input.kind === "value" && !/^[A-Za-z_][A-Za-z0-9_]*$/.test(input.variable ?? "")) throw new Error("A value request needs an environment variable name");
+  if (input.kind === "terminal") setupUrl("check");
+  const request: SetupRequest = { ...input, id: randomUUID(), state: "requesting", createdAt: Date.now() };
+  saveSetupRequest(request);
+  await deliverSetupRequest(request);
+  return getSetupRequest(request.id)!;
+}
+export async function deliverSetupRequest(request: SetupRequest): Promise<void> {
+  if (!request.dm) {
+    const result = await slackCall("conversations.open", { users: request.requester });
+    request.dm = result.channel.id; saveSetupRequest(request);
+  }
+  const threadUrl = `https://app.slack.com/client/${encodeURIComponent(request.team)}/${request.channel}/thread/${request.channel}-${request.thread}`;
+  const instruction = request.kind === "terminal"
+    ? `<${setupUrl(request.id)}|Open setup terminal>, complete the installation or login, then click “Done — resume task”.`
+    : request.kind === "file" ? `Reply in this DM thread with the file for \`${request.destination}\`.`
+    : `Reply in this DM thread with the value for \`${request.variable}\`. I will write it to \`${request.destination}\`.`;
+  const result = await slackCall("chat.postMessage", { channel: request.dm, client_msg_id: request.id,
+    text: `I need some setup for ${request.repo} (${request.environment}): ${request.reason}\n\n${instruction}\nI’ll remember this setup for future tasks in this environment. Reply “cancel” to cancel this setup request.\n<${threadUrl}|Original task>` });
+  request.dmThread = String(result.ts); request.state = "waiting"; saveSetupRequest(request);
+}
+export async function receiveSetupReply(input: { team?: string; channel: string; thread: string; user: string; text: string; files?: { id?: string }[] }): Promise<boolean> {
+  const request = requests().find(r => r.dm === input.channel && r.dmThread === input.thread && r.team === (input.team ?? ""));
+  if (!request) return false;
+  // A DM thread is bound to one requester. Never pass rejected/raw replies to the LLM.
+  if (input.user !== request.requester) return true;
+  const reply = (text: string) => slackCall("chat.postMessage", { channel: request.dm, thread_ts: request.dmThread, text });
+  if (input.text.trim().toLowerCase() === "cancel" && ["waiting", "ready"].includes(request.state)) {
+    request.state = "cancelled"; saveSetupRequest(request); await reply("Setup request cancelled. I’ve kept the task’s work."); return true;
+  }
+  if (request.state !== "waiting") return true;
+  try {
+    if (request.kind === "terminal") {
+      await reply(`Please use <${setupUrl(request.id)}|the setup terminal> and click “Done — resume task” when ready.`); return true;
+    }
+    let data: Buffer;
+    if (request.kind === "value") {
+      if (input.files?.length || !input.text.trim()) throw new Error("Reply with the requested value, or cancel this request");
+      data = Buffer.from(`${request.variable}=${JSON.stringify(input.text.trim())}\n`);
+    } else {
+      if (input.files?.length !== 1 || !/^F[A-Z0-9]+$/.test(input.files[0].id ?? "")) throw new Error("Please attach exactly one file in this DM thread");
+      const result = await slackCall("files.info", { file: input.files[0].id });
+      const file = result.file;
+      if (!file || file.size > MAX_SETUP_BYTES) throw new Error("Please upload a file no larger than 1 MiB");
+      const url = new URL(file.url_private_download || file.url_private || "https://invalid.invalid");
+      if (url.protocol !== "https:" || url.hostname !== "files.slack.com" || url.username || url.password) throw new Error("Unsupported Slack download URL");
+      const response = await fetch(url, { headers: { authorization: `Bearer ${getSetting("SLACK_BOT_TOKEN")}` }, redirect: "error", signal: AbortSignal.timeout(30_000) });
+      if (!response.ok || !response.body) throw new Error("Could not download the setup file; please retry");
+      const chunks: Uint8Array[] = []; let bytes = 0;
+      for await (const chunk of response.body) { bytes += chunk.length; if (bytes > MAX_SETUP_BYTES) throw new Error("Please upload a file no larger than 1 MiB"); chunks.push(chunk); }
+      data = Buffer.concat(chunks);
+    }
+    if (data.length > MAX_SETUP_BYTES) throw new Error("Setup value is too large");
+    // Re-read after network waits: duplicate deliveries or cancellation may have won.
+    if (getSetupRequest(request.id)?.state !== "waiting") return true;
+    request.encrypted = encrypt(data.toString("base64")); request.state = "ready"; saveSetupRequest(request);
+    await reply("Received. I’ll apply it when the machine is available and resume the original task there.");
+  } catch (error) {
+    // Only our fixed diagnostics are safe here; transport errors can contain URLs.
+    const message = error instanceof Error && !/fetch|URL|network/i.test(error.message) ? error.message : "Could not receive the setup file; please retry.";
+    await reply(message);
+  }
+  return true;
+}
+export function setupData(request: SetupRequest): Buffer {
+  const data = request.encrypted ? decrypt(request.encrypted) : null;
+  if (data === null) throw new Error("Setup file is unavailable");
+  return Buffer.from(data, "base64");
+}

--- a/orchestrator/src/agents/setup-routes.ts
+++ b/orchestrator/src/agents/setup-routes.ts
@@ -1,0 +1,68 @@
+import { timingSafeEqual } from "node:crypto";
+import type { FastifyInstance } from "fastify";
+import db from "../db.js";
+import { getJob, jobScopedToken, codingChildPid, pauseCloudJobForSetup } from "../opencode.js";
+import { cloudMode, conversationRepos, ensureConversationWorktree } from "./cloud-workspaces.js";
+import { requestCodingSlot } from "./coding-slot.js";
+import { createSetupRequest, getSetupRequest, requests } from "./setup-requests.js";
+import { rememberExistingSetup, setupEnvironment, setupFiles } from "./setup-files.js";
+import { redactCloudText } from "./repo-env.js";
+import { openSetupTerminal, readSetupTerminal, writeSetupTerminal, closeSetupTerminal } from "./setup-terminal.js";
+
+export function registerSetupRoutes(app: FastifyInstance): void {
+  app.post<{ Params: { id: string }; Body: { action: string; repo: string; environment?: string; kind?: "file" | "value" | "terminal"; destination?: string; variable?: string; reason?: string; from?: "source" | "worktree" } }>("/v1/agents/tasks/:id/setup", async (req, reply) => {
+    const actual = Buffer.from((req.headers.authorization ?? "").replace(/^Bearer /i, ""));
+    const expected = Buffer.from(jobScopedToken(req.params.id));
+    if (!cloudMode() || actual.length !== expected.length || !timingSafeEqual(actual, expected)) return reply.code(401).send({ error: "Unauthorized" });
+    const job = getJob(req.params.id), body = req.body;
+    const conversation = job?.input.conversation_key;
+    if (!job || job.status !== "running" || typeof conversation !== "string") return reply.code(403).send({ error: "A running cloud task is required" });
+    try {
+      const repo = conversationRepos(conversation).find(r => r.name === body?.repo);
+      if (!repo) throw new Error("Select a registered repository");
+      if (body.action === "list") return { files: setupFiles(repo.name).map(({ destination, environment }) => ({ destination, environment })) };
+      if (!body.environment || !/^[A-Za-z0-9_-]{1,64}$/.test(body.environment)) throw new Error("Specify the intended environment; ask the requester if unclear");
+      if (body.action === "request") {
+        const [source, team, ref] = JSON.parse(conversation);
+        if (source !== "slack") throw new Error("Setup requests currently need an originating Slack conversation");
+        const [channel, thread] = JSON.parse(ref);
+        const original = db.prepare("SELECT input FROM jobs WHERE json_extract(input,'$.conversation_key') = ? AND json_extract(input,'$.slack_requester') IS NOT NULL ORDER BY rowid LIMIT 1").get(conversation) as { input: string } | undefined;
+        const requester = original ? JSON.parse(original.input).slack_requester : undefined;
+        if (!requester) throw new Error("The original Slack requester is unknown; start a new Slack task");
+        if (!body.reason?.trim() || body.reason.length > 2000 || redactCloudText(body.reason) !== body.reason) throw new Error("Describe the missing setup without including credentials");
+        const request = await createSetupRequest({ job: job.id, conversation, requester, team, channel, thread, repo: repo.name, environment: body.environment, kind: body.kind!, destination: body.destination, variable: body.variable, reason: body.reason });
+        // Stop even an agent that ignores the returned handoff instruction.
+        setTimeout(() => pauseCloudJobForSetup(job.id, request.id), 100).unref();
+        return { waiting: true, request: request.id, instruction: "Stop this turn. Flow has DMed the requester and will resume the original task after setup." };
+      }
+      if (!["remember", "select"].includes(body.action)) throw new Error("Unknown setup action");
+      if (requests().some(r => r.job === job.id && ["requesting", "waiting", "ready"].includes(r.state))) throw new Error("This task is waiting for setup");
+      if (!requestCodingSlot(job.id, codingChildPid(job.id)).acquired) return reply.code(423).send({ error: "Waiting for the coding slot" });
+      setupEnvironment(conversation, repo.name, body.environment);
+      const owned = await ensureConversationWorktree(conversation, repo.name);
+      if (body.action === "remember") {
+        if (!["source", "worktree"].includes(body.from ?? "")) throw new Error("Choose source or worktree for the existing file");
+        rememberExistingSetup({ repo: repo.name, environment: body.environment, destination: body.destination ?? "", source: repo.source, worktree: owned.worktree!.path, conversation, from: body.from! });
+      } else await ensureConversationWorktree(conversation, repo.name, true);
+      return { configured: true, repo: repo.name, environment: body.environment, destination: body.destination };
+    } catch (error) { return reply.code(409).send({ error: error instanceof Error && !("cmd" in error) ? error.message : "Setup operation failed; existing files were retained" }); }
+  });
+  // These routes use the normal authenticated dashboard/admin middleware, never a job token.
+  app.get<{ Params: { id: string }; Querystring: { cursor?: string } }>("/v1/agents/setup/:id", async (req, reply) => {
+    reply.header("Cache-Control", "no-store");
+    const request = getSetupRequest(req.params.id);
+    if (!cloudMode() || !request || request.kind !== "terminal") return reply.code(404).send({ error: "Setup terminal not found" });
+    return { repo: request.repo, environment: request.environment, reason: request.reason, state: request.state, ...readSetupTerminal(request.id, Number(req.query.cursor) || 0) };
+  });
+  app.post<{ Params: { id: string }; Body: { action?: string; data?: string; cols?: number; rows?: number } }>("/v1/agents/setup/:id", async (req, reply) => {
+    reply.header("Cache-Control", "no-store");
+    if (!cloudMode()) return reply.code(404).send({ error: "Not found" });
+    try {
+      const { action, data, cols, rows } = req.body ?? {};
+      if (action === "open") return await openSetupTerminal(req.params.id);
+      if (action === "input") { writeSetupTerminal(req.params.id, data ?? "", cols, rows); return { ok: true }; }
+      if (action === "close" || action === "complete") { closeSetupTerminal(req.params.id, action === "complete"); return { ok: true }; }
+      return reply.code(400).send({ error: "Unknown terminal action" });
+    } catch (error) { return reply.code(409).send({ error: (error as Error).message }); }
+  });
+}

--- a/orchestrator/src/agents/setup-terminal.ts
+++ b/orchestrator/src/agents/setup-terminal.ts
@@ -1,0 +1,88 @@
+import { chmodSync, existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import type { IPty } from "node-pty";
+import { requestCodingSlot, attachCodingChild, releaseCodingSlot, codingSlotStatus } from "./coding-slot.js";
+import { getSetupRequest, saveSetupRequest } from "./setup-requests.js";
+import { conversationRepos } from "./cloud-workspaces.js";
+import { getJob, codingChildPid } from "../opencode.js";
+
+interface Terminal { pty: IPty; output: string; offset: number; touched: number; started: number; exited: boolean }
+const terminals = new Map<string, Terminal>();
+const lease = (id: string) => `setup-terminal:${id}`;
+const waiting = new Map<string, number>();
+const opening = new Map<string, Promise<{ queued: boolean }>>();
+export async function openSetupTerminal(id: string): Promise<{ queued: boolean }> {
+  const existing = opening.get(id);
+  if (existing) return existing;
+  const promise = openTerminal(id); opening.set(id, promise);
+  try { return await promise; } finally { opening.delete(id); }
+}
+async function openTerminal(id: string): Promise<{ queued: boolean }> {
+  const request = getSetupRequest(id);
+  if (!request || request.kind !== "terminal" || request.state !== "waiting") throw new Error("This setup terminal is no longer waiting");
+  const existing = terminals.get(id);
+  if (existing && !existing.exited) { existing.touched = Date.now(); return { queued: false }; }
+  if (["queued", "running"].includes(getJob(request.job)?.status ?? "") || codingChildPid(request.job)) return { queued: true };
+  waiting.set(id, Date.now());
+  if (!requestCodingSlot(lease(id)).acquired) return { queued: true };
+  let spawned: IPty | undefined;
+  try {
+    const repo = conversationRepos(request.conversation).find(r => r.name === request.repo);
+    if (!repo) throw new Error("Repository is no longer registered");
+    // node-pty 1.1.0 ships its macOS spawn helper without executable mode.
+    if (process.platform === "darwin") {
+      const packageDir = path.dirname(createRequire(import.meta.url).resolve("node-pty/package.json"));
+      const helper = path.join(packageDir, "prebuilds", `darwin-${process.arch}`, "spawn-helper");
+      if (existsSync(helper)) chmodSync(helper, 0o755);
+    }
+    const { spawn } = await import("node-pty");
+    if (codingSlotStatus(lease(id)) !== "coding" || getSetupRequest(id)?.state !== "waiting") throw new Error("Terminal opening was cancelled");
+    // No admin/job tokens in the terminal environment. Login shells read the same user's CLI setup.
+    const env = Object.fromEntries(Object.entries(process.env).filter(([key, value]) => value !== undefined && !/TOKEN|SECRET|PASSWORD|API_KEY/.test(key))) as Record<string, string>;
+    const pty = spawn(process.env.SHELL || "/bin/bash", ["-l"], { name: "xterm-256color", cols: 100, rows: 28, cwd: repo.source, env: { ...env, HISTFILE: "/dev/null", TERM: "xterm-256color" } });
+    spawned = pty;
+    attachCodingChild(lease(id), pty.pid);
+    const terminal: Terminal = { pty, output: "", offset: 0, touched: Date.now(), started: Date.now(), exited: false };
+    terminals.set(id, terminal); waiting.delete(id);
+    pty.onData(data => {
+      terminal.output += data;
+      if (terminal.output.length > 256_000) { const drop = terminal.output.length - 256_000; terminal.output = terminal.output.slice(drop); terminal.offset += drop; }
+    });
+    pty.onExit(() => { terminal.exited = true; releaseCodingSlot(lease(id)); });
+    return { queued: false };
+  } catch { if (spawned) { try { spawned.kill("SIGKILL"); } catch {} } waiting.delete(id); releaseCodingSlot(lease(id)); throw new Error("Could not start a setup terminal on this host"); }
+}
+export function readSetupTerminal(id: string, cursor = 0) {
+  const terminal = terminals.get(id);
+  if (!terminal) return { output: "", cursor: 0, active: false };
+  terminal.touched = Date.now();
+  const reset = cursor < terminal.offset || cursor > terminal.offset + terminal.output.length;
+  return { output: terminal.output.slice(reset ? 0 : Math.max(0, cursor - terminal.offset)), cursor: terminal.offset + terminal.output.length, active: !terminal.exited, reset };
+}
+export function writeSetupTerminal(id: string, data: string, cols?: number, rows?: number): void {
+  const terminal = terminals.get(id);
+  if (!terminal || terminal.exited || getSetupRequest(id)?.state !== "waiting") throw new Error("Open the setup terminal first");
+  if (typeof data !== "string" || data.length > 16_384) throw new Error("Terminal input is too large");
+  terminal.touched = Date.now();
+  if (cols !== undefined && rows !== undefined && Number.isInteger(cols) && Number.isInteger(rows) && cols >= 20 && cols <= 300 && rows >= 5 && rows <= 100) terminal.pty.resize(cols, rows);
+  terminal.pty.write(data);
+}
+export function closeSetupTerminal(id: string, complete = false): void {
+  const terminal = terminals.get(id);
+  if (terminal) { try { terminal.pty.kill("SIGKILL"); } catch {} terminals.delete(id); }
+  waiting.delete(id); releaseCodingSlot(lease(id));
+  if (complete) {
+    const request = getSetupRequest(id);
+    if (!request || request.kind !== "terminal" || request.state !== "waiting") throw new Error("Setup request is not waiting");
+    request.state = "ready"; saveSetupRequest(request);
+  }
+}
+export function sweepSetupTerminals(): void {
+  const cutoff = Date.now() - 5 * 60_000;
+  for (const [id, terminal] of terminals) if (terminal.touched < cutoff || terminal.started < Date.now() - 60 * 60_000 || getSetupRequest(id)?.state !== "waiting") closeSetupTerminal(id);
+  for (const [id, touched] of waiting) if (touched < Date.now() - 30_000) closeSetupTerminal(id);
+}
+export function stopSetupTerminals(): void {
+  for (const id of new Set([...terminals.keys(), ...waiting.keys()])) closeSetupTerminal(id);
+}

--- a/orchestrator/src/agents/setup-worker.ts
+++ b/orchestrator/src/agents/setup-worker.ts
@@ -1,0 +1,80 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import db from "../db.js";
+import { getJob, enqueueJob, codingChildPid, pauseCloudJobForSetup } from "../opencode.js";
+import { codingSlotStatus, requestCodingSlot, releaseCodingSlot } from "./coding-slot.js";
+import { cloudMode, conversationRepos, ensureConversationWorktree } from "./cloud-workspaces.js";
+import { registerSetupFile, setupEnvironment, mergeSetupValue, rememberExistingSetup } from "./setup-files.js";
+import { requests, saveSetupRequest, setupData, slackCall, deliverSetupRequest } from "./setup-requests.js";
+import { cloudRunUrl } from "../slack-agent/runtime.js";
+import { sweepSetupTerminals, stopSetupTerminals } from "./setup-terminal.js";
+
+let sweeping = false;
+export async function sweepSetupRequests(): Promise<void> {
+  if (!cloudMode() || sweeping) return;
+  sweeping = true;
+  try {
+    sweepSetupTerminals();
+    for (const request of requests()) {
+      const lease = `setup-apply:${request.id}`;
+      try {
+        if (request.state === "requesting") { await deliverSetupRequest(request); pauseCloudJobForSetup(request.job, request.id); continue; }
+        if (request.state === "waiting") { pauseCloudJobForSetup(request.job, request.id); continue; }
+        if (request.state === "cancelled") { releaseCodingSlot(lease); continue; }
+        if (request.state === "ready") {
+          if (["running", "queued"].includes(getJob(request.job)?.status ?? "") || codingChildPid(request.job)) continue;
+          if (!requestCodingSlot(lease).acquired) continue;
+          const previousResume = db.prepare("SELECT id FROM jobs WHERE json_extract(input,'$.setup_request') = ? ORDER BY rowid LIMIT 1").get(request.id) as { id: string } | undefined;
+          if (!previousResume) {
+            const repo = conversationRepos(request.conversation).find(r => r.name === request.repo);
+            if (!repo) throw new Error("Repository is no longer registered");
+            setupEnvironment(request.conversation, request.repo, request.environment);
+            const owned = await ensureConversationWorktree(request.conversation, request.repo);
+            if (request.kind !== "terminal") {
+              let data = setupData(request);
+              if (request.kind === "value") {
+                data = mergeSetupValue(repo.source, request.destination!, request.variable!, data);
+                if (existsSync(path.join(repo.source, request.destination!))) rememberExistingSetup({ repo: request.repo, environment: request.environment, destination: request.destination!, source: repo.source, worktree: owned.worktree!.path, conversation: request.conversation, from: "source" });
+              }
+              registerSetupFile({ repo: request.repo, environment: request.environment, destination: request.destination!, data, source: repo.source, worktree: owned.worktree!.path, conversation: request.conversation });
+            }
+          }
+          // Leave no gap for another setup application, but release before the resumed turn wants the slot.
+          releaseCodingSlot(lease);
+          const [source, workspace, id] = JSON.parse(request.conversation);
+          const original = getJob(request.job);
+          const description = request.kind === "terminal" ? "The requester completed the setup terminal. Verify the required CLI/login now." : `The requested setup file is installed at ${request.destination} for ${request.repo} (${request.environment}). Do not read or print its credential values. Verify the application can use it.`;
+          const resumed = previousResume ?? await enqueueJob({ type: "answer", input: {
+            conversation: { source, workspace, id }, setup_request: request.id, slack_requester: request.requester,
+            question: `${description}\nResume the original task and finish its requested delivery. Original request:\n${String(original?.input.question ?? original?.input.message ?? "Continue the task in this conversation")}`,
+            display_message: `Setup ready: ${request.repo} (${request.environment}). Resume the original task.`,
+            reply_to: { channel: request.channel, thread_ts: request.thread }, workspace,
+          } });
+          request.state = "resumed"; request.resumeJob = resumed.id; delete request.encrypted; delete request.notice; saveSetupRequest(request);
+        }
+        if (request.state === "resumed" && request.resumeJob) {
+          const job = getJob(request.resumeJob);
+          const phase = codingSlotStatus(request.resumeJob) ?? job?.status;
+          if (!phase || phase === request.notice) continue;
+          const url = cloudRunUrl(request.resumeJob);
+          const link = url ? `\n<${url}|View agent run>` : "";
+          const text = phase === "failed" ? "The resumed task stopped with an error. Its saved work is available in the agent run." : phase === "done" ? undefined : phase === "waiting" ? "Setup is ready. This task is queued behind another coding task." : phase === "coding" ? "Setup is ready. Your coding task has resumed." : request.notice ? undefined : "Setup is ready. I’m resuming the original task.";
+          if (text) await slackCall("chat.postMessage", { channel: request.channel, thread_ts: request.thread, text: text + link });
+          request.notice = phase; saveSetupRequest(request);
+        }
+      } catch {
+        // A conflict never retries destructive writes or exposes file contents. Keep encrypted input for retry.
+        if (request.notice !== "setup-error") {
+          try { await slackCall("chat.postMessage", { channel: request.dm, thread_ts: request.dmThread, text: "I couldn’t apply the setup yet. An existing file may conflict or the repository may be unavailable. Your supplied file is retained; resolve the setup conflict and I’ll retry." }); request.notice = "setup-error"; saveSetupRequest(request); } catch { /* Slack may be unavailable; retry later */ }
+        }
+      } finally {
+        // Retain a waiting lease's FIFO position; release only acquired/failed operations.
+        if (codingSlotStatus(lease) === "coding") releaseCodingSlot(lease);
+      }
+    }
+  } finally { sweeping = false; }
+}
+export function startSetupWorker(): () => void {
+  const timer = setInterval(() => { void sweepSetupRequests(); }, 1500); timer.unref();
+  return () => { clearInterval(timer); stopSetupTerminals(); };
+}

--- a/orchestrator/src/agents/setup-worker.ts
+++ b/orchestrator/src/agents/setup-worker.ts
@@ -6,7 +6,8 @@ import { codingSlotStatus, requestCodingSlot, releaseCodingSlot } from "./coding
 import { cloudMode, conversationRepos, ensureConversationWorktree } from "./cloud-workspaces.js";
 import { registerSetupFile, setupEnvironment, mergeSetupValue, rememberExistingSetup } from "./setup-files.js";
 import { requests, saveSetupRequest, setupData, slackCall, deliverSetupRequest } from "./setup-requests.js";
-import { cloudRunUrl } from "../slack-agent/runtime.js";
+import { redactCloudText } from "./repo-env.js";
+import { cloudRunUrl, renderAnswer } from "../slack-agent/runtime.js";
 import { sweepSetupTerminals, stopSetupTerminals } from "./setup-terminal.js";
 
 let sweeping = false;
@@ -48,16 +49,21 @@ export async function sweepSetupRequests(): Promise<void> {
             conversation: { source, workspace, id }, setup_request: request.id, slack_requester: request.requester,
             question: `${description}\nResume the original task and finish its requested delivery. Original request:\n${String(original?.input.question ?? original?.input.message ?? "Continue the task in this conversation")}`,
             display_message: `Setup ready: ${request.repo} (${request.environment}). Resume the original task.`,
-            reply_to: { channel: request.channel, thread_ts: request.thread }, workspace,
+            workspace,
           } });
           request.state = "resumed"; request.resumeJob = resumed.id; delete request.encrypted; delete request.notice; saveSetupRequest(request);
         }
         if (request.state === "resumed" && request.resumeJob) {
           const job = getJob(request.resumeJob);
           const phase = codingSlotStatus(request.resumeJob) ?? job?.status;
-          if (!phase || phase === request.notice) continue;
           const url = cloudRunUrl(request.resumeJob);
           const link = url ? `\n<${url}|View agent run>` : "";
+          if (job?.status === "done" && !request.delivered) {
+            const result = job.result_json ? JSON.parse(job.result_json) : {};
+            await slackCall("chat.postMessage", { channel: request.channel, thread_ts: request.thread, client_msg_id: request.resumeJob, text: redactCloudText(renderAnswer(result)) + link });
+            request.delivered = true; saveSetupRequest(request);
+          }
+          if (!phase || phase === request.notice) continue;
           const text = phase === "failed" ? "The resumed task stopped with an error. Its saved work is available in the agent run." : phase === "done" ? undefined : phase === "waiting" ? "Setup is ready. This task is queued behind another coding task." : phase === "coding" ? "Setup is ready. Your coding task has resumed." : request.notice ? undefined : "Setup is ready. I’m resuming the original task.";
           if (text) await slackCall("chat.postMessage", { channel: request.channel, thread_ts: request.thread, text: text + link });
           request.notice = phase; saveSetupRequest(request);

--- a/orchestrator/src/auth.ts
+++ b/orchestrator/src/auth.ts
@@ -51,7 +51,7 @@ export function requireAuth(
     return;
   }
 
-  if (req.method === "POST" && /^\/v1\/agents\/tasks\/[^/]+\/workspace$/.test(url)) {
+  if (req.method === "POST" && /^\/v1\/agents\/tasks\/[^/]+\/(?:workspace|setup)$/.test(url)) {
     done(); // Exact job-scoped authentication is enforced inside cloud-routes.
     return;
   }

--- a/orchestrator/src/index.ts
+++ b/orchestrator/src/index.ts
@@ -9,6 +9,8 @@ import { registerPolicyRoutes } from "./policy.js";
 import { registerCorpusRoutes } from "./corpus.js";
 import db from "./db.js";
 import { getJob, enqueueJob, recoverStalledJobs, killRunningJobChildren, repoStatuses } from "./opencode.js";
+import { registerSetupRoutes } from "./agents/setup-routes.js";
+import { startSetupWorker } from "./agents/setup-worker.js";
 import { registerRepoEnvRoutes } from "./agents/repo-env-routes.js";
 import { registerCloudViewRoutes } from "./agents/cloud-view-routes.js";
 import { activityForRepo } from "./job-activity.js";
@@ -98,6 +100,7 @@ registerMemoryRoutes(app);
 setNodeAnchorProvider(makeGatewayAnchorProvider());
 registerSourceRoutes(app);
 registerRepoEnvRoutes(app);
+registerSetupRoutes(app);
 registerCloudViewRoutes(app);
 registerSlackAgentRoutes(app);
 registerTelemetryRoutes(app);
@@ -251,9 +254,11 @@ app.get<{ Querystring: { status?: string } }>(
 // ------------------------------------------------------------------
 // Graceful shutdown hook (registered before listen)
 // ------------------------------------------------------------------
+let stopSetupWorker: (() => void) | undefined;
 let stopWorkspaceCleanup: (() => void) | undefined;
 app.addHook("onClose", async () => {
   stopWorkspaceCleanup?.();
+  stopSetupWorker?.();
   stopDrainer();
   stopAllPollers();
   stopTelemetryReporter();
@@ -285,6 +290,7 @@ const start = async (): Promise<void> => {
     recoverStalledJobs();
     const { startWorkspaceCleanup } = await import("./agents/cloud-cleanup.js");
     stopWorkspaceCleanup = startWorkspaceCleanup();
+    stopSetupWorker = startSetupWorker();
 
     // Start outbox drainer (no-ops if FLOW_DRAIN_DISABLE=1 or already running)
     if (process.env.FLOW_DRAIN_DISABLE !== "1") {

--- a/orchestrator/src/opencode.ts
+++ b/orchestrator/src/opencode.ts
@@ -680,7 +680,7 @@ function scheduleJob(id: string, opts: JobInput): void {
   }
   void withConversationTurn(key, async () => {
     if (getJob(id)?.status !== "queued") return;
-    await restoreConversationWorktrees(key, true);
+    // Workspace restoration/configuration happens under coding admission in the tool route.
     if (getJob(id)?.status !== "queued") return;
     // Resolve at execution time: the preceding turn may only just have created
     // its session, or may have failed after emitting its first session event.
@@ -888,6 +888,7 @@ async function runJob(id: string, opts: JobInput): Promise<void> {
       }
     }
   } catch (err) {
+    if (getJob(id)?.result_json?.includes('"setup_wait"')) return;
     updateJob.run({
       id,
       status: "failed",
@@ -1056,6 +1057,16 @@ interface SpawnResult { status: number | null; stdout: string; stderr: string; e
 // writing to the graph while the recovery pass re-queues a duplicate job.
 const jobChildren = new Map<string, ReturnType<typeof spawn>>();
 export function codingChildPid(id: string): number | undefined { return jobChildren.get(id)?.pid; }
+
+/** Persist the waiting outcome before stopping the CLI; its finally releases the coding slot. */
+export function pauseCloudJobForSetup(id: string, requestId: string): void {
+  const job = getJob(id);
+  if (!job || job.status !== "running") return;
+  updateJob.run({ id, status: "done", result_json: JSON.stringify({ setup_wait: requestId, answer_md: "I need some setup to continue. I’ve sent the original requester a DM and will resume this task when it’s ready." }) });
+  finishActivity(id, "done");
+  const child = jobChildren.get(id);
+  if (child) killTree(child);
+}
 
 export function cancelCloudJob(id: string): boolean {
   const job = getJob(id);

--- a/orchestrator/src/slack-agent/listeners.ts
+++ b/orchestrator/src/slack-agent/listeners.ts
@@ -9,6 +9,7 @@
 // delivers message.im for the agent's own DM conversations.
 
 import type { App } from "@slack/bolt";
+import { receiveSetupReply } from "../agents/setup-requests.js";
 import { cancelRun } from "./cancel.js";
 import { isEngaged, markEngaged } from "./engagement.js";
 import { respond, stripMentions } from "./respond.js";
@@ -57,6 +58,8 @@ export function registerListeners(app: App, deps: ListenerDeps): void {
     const threadTs = (event.thread_ts as string | undefined) ?? ts;
     const channelType = event.channel_type as string | undefined;
     const text = (event.text as string | undefined) ?? "";
+
+    if (await receiveSetupReply({ team: (context.teamId as string | undefined) ?? (event.team as string | undefined), channel: channelId, thread: threadTs, user: userId, text, files: Array.isArray(event.files) ? event.files : undefined })) return;
 
     let surface: Surface;
     if (channelType === "im") surface = "dm";

--- a/orchestrator/src/slack-agent/respond.ts
+++ b/orchestrator/src/slack-agent/respond.ts
@@ -146,7 +146,7 @@ export async function respond(args: RespondArgs): Promise<void> {
 
     if (controller.signal.aborted) return;
 
-    outcome = "Task finished. See the result in this thread.";
+    outcome = answer.waitingForSetup ? "Waiting for setup from the requester. The machine is available for other tasks." : "Task finished. See the result in this thread.";
 
     // Keep the thread engaged so plain follow-up replies reach us.
     markEngaged(args.channelId, args.threadTs);

--- a/orchestrator/src/slack-agent/runtime.ts
+++ b/orchestrator/src/slack-agent/runtime.ts
@@ -15,6 +15,7 @@ export type { TranscriptTurn, Surface, RuntimeQuery, RuntimeAnswer, AgentRuntime
 import type { AgentRuntime, RuntimeAnswer, RuntimeQuery } from "./types.js";
 
 interface AnswerPayload {
+  setup_wait?: string;
   answer_md?: string;
   citations?: { kind: string; ref: string }[];
   confidence?: number;
@@ -53,6 +54,7 @@ export class FlowRuntime implements AgentRuntime {
     const { id } = await enqueueJob({ type: "answer", input: {
       question,
       display_message: query.prompt,
+      slack_requester: query.context.userId,
       ...(query.images?.length ? { slack_images: query.images, slack_image_scope: query.imageScope } : {}),
       ...(conversation ? { conversation } : {}),
     } });
@@ -82,6 +84,7 @@ export class FlowRuntime implements AgentRuntime {
           const result = (job.result_json ? JSON.parse(job.result_json) : {}) as AnswerPayload;
           return {
             markdown: renderAnswer(result),
+            waitingForSetup: Boolean(result.setup_wait),
             citations: result.citations ?? [],
             confidence: result.confidence,
           };

--- a/orchestrator/src/slack-agent/runtime.ts
+++ b/orchestrator/src/slack-agent/runtime.ts
@@ -82,6 +82,7 @@ export class FlowRuntime implements AgentRuntime {
         if (!job) throw new Error(`answer job ${id} disappeared`);
         if (job.status === "done") {
           const result = (job.result_json ? JSON.parse(job.result_json) : {}) as AnswerPayload;
+          if (result.setup_wait && url) query.onRun?.(url);
           return {
             markdown: renderAnswer(result),
             waitingForSetup: Boolean(result.setup_wait),

--- a/orchestrator/src/slack-agent/types.ts
+++ b/orchestrator/src/slack-agent/types.ts
@@ -31,6 +31,7 @@ export interface RuntimeQuery {
 }
 
 export interface RuntimeAnswer {
+  waitingForSetup?: boolean;
   markdown: string;
   citations?: { kind: string; ref: string }[];
   confidence?: number;

--- a/orchestrator/test/cloud-opencode-smoke.test.ts
+++ b/orchestrator/test/cloud-opencode-smoke.test.ts
@@ -45,6 +45,13 @@ test("real OpenCode loads the cloud hook and refuses source edits before executi
   const server = createServer(async (req, res) => {
     let input = "";
     for await (const chunk of req) input += chunk;
+    if (req.url?.endsWith("/setup")) {
+      assert.equal(req.headers.authorization, "Bearer smoke-token");
+      assert.deepEqual(JSON.parse(input), { action: "list", repo: "api" });
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ files: [{ destination: "nested/.state.env", environment: "staging" }] }));
+      return;
+    }
     if (req.url?.endsWith("/workspace")) {
       assert.equal(req.headers.authorization, "Bearer smoke-token");
       const args = JSON.parse(input);
@@ -62,6 +69,7 @@ test("real OpenCode loads the cloud hook and refuses source edits before executi
       if (input.includes("Shared checkout edit blocked")) sawBlock = true;
       if (input.includes("without changing directories")) sawShellBlock = true;
       const calls = [
+        { name: "flow_setup", args: { action: "list", repo: "api" } },
         { name: "write", args: { filePath: path.join(source, "file.txt"), content: "should not land\n" } },
         { name: "read", args: { filePath: path.join(tree, "file.txt") } },
         { name: "write", args: { filePath: path.join(tree, "file.txt"), content: "changed\n" } },
@@ -113,6 +121,8 @@ test("real OpenCode loads the cloud hook and refuses source edits before executi
       throw new Error(`OpenCode smoke failed: ${err.message}\n${String(err.stdout).slice(-8000)}\n${String(err.stderr).slice(-12000)}`);
     });
     assert.ok(sawImage, "CLI image attachment did not reach the model request");
+    assert.ok(observedTools.has("flow_setup"), "Setup tool not exposed by real OpenCode");
+    assert.ok(result.stdout.includes("nested/.state.env"), "Setup tool was not executed successfully");
     assert.ok(observedTools.has("flow_workspace"), `Plugin tool not loaded: ${result.stderr}`);
     assert.ok(sawBlock, `Before-hook did not reject the shared path: ${result.stdout}`);
     assert.ok(sawShellBlock, `Before-hook did not reject the branch change: ${result.stdout}`);

--- a/orchestrator/test/setup.test.ts
+++ b/orchestrator/test/setup.test.ts
@@ -57,7 +57,13 @@ before(async () => {
     return realFetch(url, options);
   };
 });
-after(async () => { terminal.stopSetupTerminals(); globalThis.fetch = realFetch; await app.close(); rmSync(root, { recursive: true, force: true }); });
+after(async () => {
+  terminal.stopSetupTerminals();
+  for (const row of db.prepare("SELECT id FROM jobs WHERE status IN ('running','queued')").all() as { id: string }[]) jobs.cancelCloudJob(row.id);
+  for (const id of ["setup-parent", "second-task", "other-coding", "next-coding", "after-setup-pause"]) queue.releaseCodingSlot(id);
+  await new Promise(resolve => setTimeout(resolve, 100));
+  globalThis.fetch = realFetch; await app.close(); rmSync(root, { recursive: true, force: true });
+});
 
 test("arbitrary nested setup files persist privately to source/current/future worktrees and never enter Git", async () => {
   const { key, tree } = await fresh();
@@ -116,7 +122,7 @@ test("job-scoped request DMs original requester, pauses, releases slot, receives
   assert.ok(!JSON.stringify(resumed).includes("private-test-value"));
   assert.equal(readFileSync(path.join(source, "services/config.json"), "utf8"), fileContent.toString());
   await worker.sweepSetupRequests(); assert.equal((db.prepare("SELECT count(*) AS count FROM jobs WHERE json_extract(input,'$.setup_request') = ?").get(id) as { count: number }).count, 1);
-  for (let i = 0; i < 100 && jobs.getJob(request.resumeJob!)?.status !== "done"; i++) await new Promise(resolve => setTimeout(resolve, 20));
+  for (let i = 0; i < 500 && jobs.getJob(request.resumeJob!)?.status !== "done"; i++) await new Promise(resolve => setTimeout(resolve, 20));
   await worker.sweepSetupRequests(); await worker.sweepSetupRequests();
   const delivered = messages.filter(m => m.client_msg_id === request.resumeJob);
   assert.equal(delivered.length, 1); assert.equal(delivered[0].channel, "CTEST"); assert.equal(delivered[0].thread_ts, "slack-request");
@@ -140,16 +146,16 @@ test("interactive terminal shares the coding queue, accepts interactive input, a
   const marker = path.join(root, "terminal-input.txt");
   terminal.writeSetupTerminal(request.id, `read -r reply; printf '%s' "$reply" > '${marker}'\r`);
   terminal.writeSetupTerminal(request.id, "interactive-answer\r");
-  for (let i = 0; i < 100 && !existsSync(marker); i++) await new Promise(resolve => setTimeout(resolve, 20));
+  for (let i = 0; i < 500 && !existsSync(marker); i++) await new Promise(resolve => setTimeout(resolve, 20));
   assert.equal(readFileSync(marker, "utf8"), "interactive-answer");
   const foreground = path.join(root, "foreground.pid");
   if (process.platform === "linux") {
     terminal.writeSetupTerminal(request.id, `sh -c 'echo $$ > "${foreground}"; exec sleep 60'\r`);
-    for (let i = 0; i < 100 && !existsSync(foreground); i++) await new Promise(resolve => setTimeout(resolve, 20));
+    for (let i = 0; i < 500 && !existsSync(foreground); i++) await new Promise(resolve => setTimeout(resolve, 20));
     assert.ok(existsSync(foreground));
   }
   terminal.closeSetupTerminal(request.id, true);
-  for (let i = 0; i < 100 && !queue.requestCodingSlot("next-coding").acquired; i++) await new Promise(resolve => setTimeout(resolve, 20));
+  for (let i = 0; i < 500 && !queue.requestCodingSlot("next-coding").acquired; i++) await new Promise(resolve => setTimeout(resolve, 20));
   assert.equal(queue.requestCodingSlot("next-coding").acquired, true); queue.releaseCodingSlot("next-coding");
   assert.equal(requests.getSetupRequest(request.id)!.state, "ready");
   if (process.platform === "linux") {
@@ -163,15 +169,15 @@ test("setup pause stops a real coding subprocess and releases its slot without h
   const { key } = await fresh("pause-real-child");
   const [sourceType, workspace, id] = JSON.parse(key);
   const parent = await jobs.enqueueJob({ type: "answer", input: { conversation: { source: sourceType, workspace, id }, question: "Wait for setup", slack_requester: "UORIGINAL", manual_command: { repo: "demo", command: "sleep 60" } } });
-  for (let i = 0; i < 200 && !jobs.codingChildPid(parent.id); i++) await new Promise(resolve => setTimeout(resolve, 20));
+  for (let i = 0; i < 1000 && !jobs.codingChildPid(parent.id); i++) await new Promise(resolve => setTimeout(resolve, 20));
   assert.ok(jobs.codingChildPid(parent.id));
   const response = await app.inject({ method: "POST", url: `/v1/agents/tasks/${parent.id}/setup`, headers: { authorization: `Bearer ${jobs.jobScopedToken(parent.id)}` }, payload: { action: "request", repo: "demo", environment: "staging", kind: "file", destination: "pause.cfg", reason: "Need a test configuration" } });
   assert.equal(response.statusCode, 200, response.body);
-  for (let i = 0; i < 200 && jobs.codingChildPid(parent.id); i++) await new Promise(resolve => setTimeout(resolve, 20));
+  for (let i = 0; i < 1000 && jobs.codingChildPid(parent.id); i++) await new Promise(resolve => setTimeout(resolve, 20));
   assert.equal(jobs.codingChildPid(parent.id), undefined);
   assert.equal(jobs.getJob(parent.id)!.status, "done");
   assert.match(jobs.getJob(parent.id)!.result_json!, /setup_wait/);
-  for (let i = 0; i < 100 && !queue.requestCodingSlot("after-setup-pause").acquired; i++) await new Promise(resolve => setTimeout(resolve, 20));
+  for (let i = 0; i < 500 && !queue.requestCodingSlot("after-setup-pause").acquired; i++) await new Promise(resolve => setTimeout(resolve, 20));
   assert.equal(queue.requestCodingSlot("after-setup-pause").acquired, true);
   queue.releaseCodingSlot("after-setup-pause");
 });

--- a/orchestrator/test/setup.test.ts
+++ b/orchestrator/test/setup.test.ts
@@ -112,11 +112,15 @@ test("job-scoped request DMs original requester, pauses, releases slot, receives
   await worker.sweepSetupRequests(); assert.equal(requests.getSetupRequest(id)!.state, "ready");
   queue.releaseCodingSlot("second-task"); await worker.sweepSetupRequests();
   request = requests.getSetupRequest(id)!; assert.equal(request.state, "resumed"); assert.ok(request.resumeJob);
-  const resumed = jobs.getJob(request.resumeJob!)!; assert.equal(resumed.input.conversation_key, key); assert.deepEqual(resumed.input.reply_to, { channel: "CTEST", thread_ts: "slack-request" });
+  const resumed = jobs.getJob(request.resumeJob!)!; assert.equal(resumed.input.conversation_key, key); assert.equal(resumed.input.reply_to, undefined, "The setup worker owns final delivery, not the legacy outbox");
   assert.ok(!JSON.stringify(resumed).includes("private-test-value"));
   assert.equal(readFileSync(path.join(source, "services/config.json"), "utf8"), fileContent.toString());
   await worker.sweepSetupRequests(); assert.equal((db.prepare("SELECT count(*) AS count FROM jobs WHERE json_extract(input,'$.setup_request') = ?").get(id) as { count: number }).count, 1);
   for (let i = 0; i < 100 && jobs.getJob(request.resumeJob!)?.status !== "done"; i++) await new Promise(resolve => setTimeout(resolve, 20));
+  await worker.sweepSetupRequests(); await worker.sweepSetupRequests();
+  const delivered = messages.filter(m => m.client_msg_id === request.resumeJob);
+  assert.equal(delivered.length, 1); assert.equal(delivered[0].channel, "CTEST"); assert.equal(delivered[0].thread_ts, "slack-request");
+  assert.equal(requests.getSetupRequest(id)!.delivered, true);
 });
 test("setup upload rejects external URLs and cancellation prevents resume", async () => {
   const { key } = await fresh(); insertJob("cancel-parent", key, "done");

--- a/orchestrator/test/setup.test.ts
+++ b/orchestrator/test/setup.test.ts
@@ -1,0 +1,143 @@
+import { before, after, test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, symlinkSync, statSync, rmSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import Fastify from "fastify";
+
+const root = mkdtempSync(path.join(tmpdir(), "flow-setup-test-"));
+Object.assign(process.env, { DB_PATH: ":memory:", FLOW_MODE: "prod", FLOW_ADMIN_TOKEN: "test-admin", FLOW_PUBLIC_URL: "https://flow.example/project", FLOW_FAKE_OPENCODE: "1", FLOW_DRAIN_DISABLE: "1", OPENCODE_WORKSPACE_DIR: root, REPOS_JSON_PATH: path.join(root, "repos.json"), FLOW_CODING_STATE_DIR: path.join(root, "queue"), GATEWAY_URL: "http://127.0.0.1:1", FLOW_EMBED_URL: "http://127.0.0.1:1", SLACK_BOT_TOKEN: "test-bot" });
+const source = path.join(root, "repos", "demo");
+const git = (cwd: string, ...args: string[]) => execFileSync("git", ["-C", cwd, ...args], { encoding: "utf8" }).trim();
+let files: typeof import("../src/agents/setup-files.js");
+let requests: typeof import("../src/agents/setup-requests.js");
+let workspaces: typeof import("../src/agents/cloud-workspaces.js");
+let queue: typeof import("../src/agents/coding-slot.js");
+let jobs: typeof import("../src/opencode.js");
+let worker: typeof import("../src/agents/setup-worker.js");
+let terminal: typeof import("../src/agents/setup-terminal.js");
+let db: typeof import("../src/db.js").default;
+const app = Fastify();
+const realFetch = globalThis.fetch;
+const messages: Record<string, any>[] = [];
+let downloads = 0;
+let downloadUrl = "https://files.slack.com/test-config";
+let fileContent = Buffer.from('{"password":"private-test-value"}');
+let serial = 0;
+const fresh = async (name = String(++serial)) => {
+  const key = workspaces.conversationKey(workspaces.slackConversation("TTEST", "CTEST", name));
+  workspaces.ensureConversation(key);
+  files.setupEnvironment(key, "demo", "staging");
+  const repo = await workspaces.ensureConversationWorktree(key, "demo");
+  return { key, repo, tree: repo.worktree!.path };
+};
+function insertJob(id: string, key: string, status = "running") {
+  db.prepare("INSERT INTO jobs (id,type,input,status) VALUES (?,'answer',?,?)").run(id, JSON.stringify({ conversation_key: key, question: "Run the app", slack_requester: "UORIGINAL" }), status);
+}
+before(async () => {
+  mkdirSync(source, { recursive: true });
+  git(source, "init", "-q", "-b", "main"); git(source, "config", "user.name", "Test"); git(source, "config", "user.email", "test@example.com");
+  writeFileSync(path.join(source, "tracked.json"), "{}\n"); git(source, "add", "."); git(source, "commit", "-qm", "base");
+  writeFileSync(process.env.REPOS_JSON_PATH!, JSON.stringify({ repos: [{ name: "demo", branch: "main" }] }));
+  files = await import("../src/agents/setup-files.js"); requests = await import("../src/agents/setup-requests.js"); workspaces = await import("../src/agents/cloud-workspaces.js");
+  queue = await import("../src/agents/coding-slot.js"); jobs = await import("../src/opencode.js"); worker = await import("../src/agents/setup-worker.js"); terminal = await import("../src/agents/setup-terminal.js"); db = (await import("../src/db.js")).default;
+  app.addHook("onRequest", (await import("../src/auth.js")).requireAuth);
+  (await import("../src/agents/setup-routes.js")).registerSetupRoutes(app);
+  await app.ready();
+  globalThis.fetch = async (url, options) => {
+    const target = String(url);
+    if (target.startsWith("https://slack.com/api/")) {
+      const args = JSON.parse(String(options?.body ?? "{}"));
+      if (target.endsWith("conversations.open")) { assert.equal(args.users, "UORIGINAL"); return Response.json({ ok: true, channel: { id: "DTEST" } }); }
+      if (target.endsWith("chat.postMessage")) { messages.push(args); return Response.json({ ok: true, ts: `${messages.length}.001` }); }
+      if (target.endsWith("files.info")) return Response.json({ ok: true, file: { size: fileContent.length, url_private: downloadUrl } });
+    }
+    if (target === "https://files.slack.com/test-config") { downloads++; assert.equal(options?.redirect, "error"); return new Response(fileContent); }
+    return realFetch(url, options);
+  };
+});
+after(async () => { terminal.stopSetupTerminals(); globalThis.fetch = realFetch; await app.close(); rmSync(root, { recursive: true, force: true }); });
+
+test("arbitrary nested setup files persist privately to source/current/future worktrees and never enter Git", async () => {
+  const { key, tree } = await fresh();
+  files.registerSetupFile({ repo: "demo", environment: "staging", destination: "services/api/.state.env", data: Buffer.from("TEST_KEY=private-state-value\n"), source, worktree: tree, conversation: key });
+  for (const cwd of [source, tree]) { assert.equal(readFileSync(path.join(cwd, "services/api/.state.env"), "utf8"), "TEST_KEY=private-state-value\n"); assert.equal(statSync(path.join(cwd, "services/api/.state.env")).mode & 0o777, 0o600); assert.equal(git(cwd, "status", "--porcelain"), ""); }
+  assert.ok(!JSON.stringify(db.prepare("SELECT * FROM config").all()).includes("private-state-value"));
+  const next = await fresh(); assert.ok(existsSync(path.join(next.tree, "services/api/.state.env")));
+  assert.equal(files.unchangedSetupFile("demo", tree, "services/api/.state.env"), true);
+  writeFileSync(path.join(tree, "services/api/.state.env"), "user change");
+  assert.throws(() => files.applySetupFiles(key, "demo", tree), /changed locally/);
+  assert.equal(readFileSync(path.join(tree, "services/api/.state.env"), "utf8"), "user change");
+});
+test("rejects tracked destinations, traversal, symlinks and oversized files", async () => {
+  const { key, tree } = await fresh();
+  const save = (destination: string, data = Buffer.from("x")) => files.registerSetupFile({ repo: "demo", environment: "staging", destination, data, source, worktree: tree, conversation: key });
+  for (const invalid of ["../outside", "/tmp/config", ".git/config", "a/../../b", "a//b"]) assert.throws(() => save(invalid), /repository-relative/);
+  assert.throws(() => save("tracked.json"), /tracked by Git/);
+  symlinkSync(root, path.join(tree, "escape")); assert.throws(() => save("escape/stolen"), /symlinks/);
+  assert.throws(() => save("huge", Buffer.alloc(files.MAX_SETUP_BYTES + 1)), /1 MiB/);
+});
+test("separate environments are pinned per conversation; production is never an implicit default", async () => {
+  const a = await fresh();
+  files.registerSetupFile({ repo: "demo", environment: "production", destination: "config/runtime.json", data: Buffer.from('{"host":"production"}'), source, worktree: a.tree, conversation: a.key });
+  const b = await fresh(); assert.equal(files.setupEnvironment(b.key, "demo"), "staging"); assert.equal(existsSync(path.join(b.tree, "config/runtime.json")), false);
+  const raw = files.setupFiles("demo").find(f => f.environment === "production")!;
+  db.prepare("INSERT INTO config(key,value) VALUES (?,?)").run('setup-file:only-production', JSON.stringify({ ...raw, repo: "only-prod" }));
+  assert.throws(() => files.setupEnvironment("new-conversation", "only-prod"), /Choose a setup environment/);
+});
+test("single variable setup preserves unrelated env entries and refuses ambiguous replacement", async () => {
+  writeFileSync(path.join(source, "values.env"), "EXISTING=keep\n");
+  const merged = files.mergeSetupValue(source, "values.env", "MISSING", Buffer.from('MISSING="new"\n')).toString();
+  assert.equal(merged, 'EXISTING=keep\nMISSING="new"\n');
+  assert.throws(() => files.mergeSetupValue(source, "values.env", "EXISTING", Buffer.from("EXISTING=new")), /already exists/);
+});
+test("job-scoped request DMs original requester, pauses, releases slot, receives privately, resumes same thread exactly once", async () => {
+  const { key } = await fresh("slack-request"); insertJob("setup-parent", key);
+  queue.requestCodingSlot("setup-parent");
+  const bad = await app.inject({ method: "POST", url: "/v1/agents/tasks/setup-parent/setup", headers: { authorization: "Bearer wrong" }, payload: { action: "list", repo: "demo" } }); assert.equal(bad.statusCode, 401);
+  const response = await app.inject({ method: "POST", url: "/v1/agents/tasks/setup-parent/setup", headers: { authorization: `Bearer ${jobs.jobScopedToken("setup-parent")}` }, payload: { action: "request", repo: "demo", environment: "staging", kind: "file", destination: "services/config.json", reason: "The app needs its staging configuration" } });
+  assert.equal(response.statusCode, 200, response.body);
+  const id = response.json().request; let request = requests.getSetupRequest(id)!;
+  assert.equal(request.requester, "UORIGINAL"); assert.equal(request.dm, "DTEST");
+  await new Promise(resolve => setTimeout(resolve, 150)); assert.equal(jobs.getJob("setup-parent")!.status, "done");
+  // No child in this unit fixture, so mirror runJob's finally. The real CLI smoke covers process exit.
+  queue.releaseCodingSlot("setup-parent");
+  assert.equal(queue.requestCodingSlot("second-task").acquired, true);
+  const reply = { team: "TTEST", channel: "DTEST", thread: request.dmThread!, user: "UORIGINAL", text: "", files: [{ id: "FTEST" }] };
+  assert.equal(await requests.receiveSetupReply({ ...reply, user: "UOTHER" }), true); assert.equal(downloads, 0);
+  assert.equal(await requests.receiveSetupReply({ ...reply, team: "TOTHER" }), false);
+  await requests.receiveSetupReply(reply); await requests.receiveSetupReply(reply); assert.equal(downloads, 1);
+  assert.ok(!JSON.stringify(messages).includes("private-test-value"));
+  await worker.sweepSetupRequests(); assert.equal(requests.getSetupRequest(id)!.state, "ready");
+  queue.releaseCodingSlot("second-task"); await worker.sweepSetupRequests();
+  request = requests.getSetupRequest(id)!; assert.equal(request.state, "resumed"); assert.ok(request.resumeJob);
+  const resumed = jobs.getJob(request.resumeJob!)!; assert.equal(resumed.input.conversation_key, key); assert.deepEqual(resumed.input.reply_to, { channel: "CTEST", thread_ts: "slack-request" });
+  assert.ok(!JSON.stringify(resumed).includes("private-test-value"));
+  assert.equal(readFileSync(path.join(source, "services/config.json"), "utf8"), fileContent.toString());
+  await worker.sweepSetupRequests(); assert.equal((db.prepare("SELECT count(*) AS count FROM jobs WHERE json_extract(input,'$.setup_request') = ?").get(id) as { count: number }).count, 1);
+  for (let i = 0; i < 100 && jobs.getJob(request.resumeJob!)?.status !== "done"; i++) await new Promise(resolve => setTimeout(resolve, 20));
+});
+test("setup upload rejects external URLs and cancellation prevents resume", async () => {
+  const { key } = await fresh(); insertJob("cancel-parent", key, "done");
+  const request = await requests.createSetupRequest({ job: "cancel-parent", conversation: key, requester: "UORIGINAL", team: "TTEST", channel: "CTEST", thread: "cancel", repo: "demo", environment: "staging", destination: "extra.cfg", kind: "file", reason: "Need config" });
+  downloadUrl = "https://attacker.example/file";
+  const reply = { team: "TTEST", channel: request.dm!, thread: request.dmThread!, user: "UORIGINAL", text: "", files: [{ id: "FTEST" }] };
+  await requests.receiveSetupReply(reply); assert.equal(requests.getSetupRequest(request.id)!.state, "waiting"); downloadUrl = "https://files.slack.com/test-config";
+  await requests.receiveSetupReply({ ...reply, text: "cancel", files: [] }); await worker.sweepSetupRequests(); assert.equal(requests.getSetupRequest(request.id)!.state, "cancelled");
+});
+test("interactive terminal shares the coding queue, accepts interactive input, and releases on completion", async () => {
+  const { key } = await fresh(); insertJob("terminal-parent", key, "done");
+  const request = await requests.createSetupRequest({ job: "terminal-parent", conversation: key, requester: "UORIGINAL", team: "TTEST", channel: "CTEST", thread: "terminal", repo: "demo", environment: "staging", kind: "terminal", reason: "Install a test CLI" });
+  const unauthorized = await app.inject({ method: "GET", url: `/v1/agents/setup/${request.id}` }); assert.equal(unauthorized.statusCode, 401);
+  queue.requestCodingSlot("other-coding"); assert.equal((await terminal.openSetupTerminal(request.id)).queued, true);
+  queue.releaseCodingSlot("other-coding"); assert.equal((await terminal.openSetupTerminal(request.id)).queued, false);
+  assert.equal(queue.requestCodingSlot("next-coding").acquired, false);
+  terminal.writeSetupTerminal(request.id, "printf 'SETUP_PTY_OK\\n'\r");
+  for (let i = 0; i < 100 && !terminal.readSetupTerminal(request.id).output.includes("SETUP_PTY_OK"); i++) await new Promise(resolve => setTimeout(resolve, 20));
+  assert.match(terminal.readSetupTerminal(request.id).output, /SETUP_PTY_OK/);
+  terminal.closeSetupTerminal(request.id, true);
+  for (let i = 0; i < 100 && !queue.requestCodingSlot("next-coding").acquired; i++) await new Promise(resolve => setTimeout(resolve, 20));
+  assert.equal(queue.requestCodingSlot("next-coding").acquired, true); queue.releaseCodingSlot("next-coding");
+  assert.equal(requests.getSetupRequest(request.id)!.state, "ready");
+});

--- a/orchestrator/test/setup.test.ts
+++ b/orchestrator/test/setup.test.ts
@@ -51,7 +51,7 @@ before(async () => {
       const args = JSON.parse(String(options?.body ?? "{}"));
       if (target.endsWith("conversations.open")) { assert.equal(args.users, "UORIGINAL"); return Response.json({ ok: true, channel: { id: "DTEST" } }); }
       if (target.endsWith("chat.postMessage")) { messages.push(args); return Response.json({ ok: true, ts: `${messages.length}.001` }); }
-      if (target.endsWith("files.info")) return Response.json({ ok: true, file: { size: fileContent.length, url_private: downloadUrl } });
+      if (target.includes("files.info?")) { assert.equal(options?.method, "GET"); assert.equal(new URL(target).searchParams.get("file"), "FTEST"); return Response.json({ ok: true, file: { size: fileContent.length, url_private: downloadUrl } }); }
     }
     if (target === "https://files.slack.com/test-config") { downloads++; assert.equal(options?.redirect, "error"); return new Response(fileContent); }
     return realFetch(url, options);
@@ -133,11 +133,41 @@ test("interactive terminal shares the coding queue, accepts interactive input, a
   queue.requestCodingSlot("other-coding"); assert.equal((await terminal.openSetupTerminal(request.id)).queued, true);
   queue.releaseCodingSlot("other-coding"); assert.equal((await terminal.openSetupTerminal(request.id)).queued, false);
   assert.equal(queue.requestCodingSlot("next-coding").acquired, false);
-  terminal.writeSetupTerminal(request.id, "printf 'SETUP_PTY_OK\\n'\r");
-  for (let i = 0; i < 100 && !terminal.readSetupTerminal(request.id).output.includes("SETUP_PTY_OK"); i++) await new Promise(resolve => setTimeout(resolve, 20));
-  assert.match(terminal.readSetupTerminal(request.id).output, /SETUP_PTY_OK/);
+  const marker = path.join(root, "terminal-input.txt");
+  terminal.writeSetupTerminal(request.id, `read -r reply; printf '%s' "$reply" > '${marker}'\r`);
+  terminal.writeSetupTerminal(request.id, "interactive-answer\r");
+  for (let i = 0; i < 100 && !existsSync(marker); i++) await new Promise(resolve => setTimeout(resolve, 20));
+  assert.equal(readFileSync(marker, "utf8"), "interactive-answer");
+  const foreground = path.join(root, "foreground.pid");
+  if (process.platform === "linux") {
+    terminal.writeSetupTerminal(request.id, `sh -c 'echo $$ > "${foreground}"; exec sleep 60'\r`);
+    for (let i = 0; i < 100 && !existsSync(foreground); i++) await new Promise(resolve => setTimeout(resolve, 20));
+    assert.ok(existsSync(foreground));
+  }
   terminal.closeSetupTerminal(request.id, true);
   for (let i = 0; i < 100 && !queue.requestCodingSlot("next-coding").acquired; i++) await new Promise(resolve => setTimeout(resolve, 20));
   assert.equal(queue.requestCodingSlot("next-coding").acquired, true); queue.releaseCodingSlot("next-coding");
   assert.equal(requests.getSetupRequest(request.id)!.state, "ready");
+  if (process.platform === "linux") {
+    const pid = readFileSync(foreground, "utf8").trim();
+    const stat = `/proc/${pid}/stat`;
+    assert.ok(!existsSync(stat) || readFileSync(stat, "utf8").split(") ")[1].startsWith("Z"), "Foreground process survived terminal close");
+  }
+});
+
+test("setup pause stops a real coding subprocess and releases its slot without human input", async () => {
+  const { key } = await fresh("pause-real-child");
+  const [sourceType, workspace, id] = JSON.parse(key);
+  const parent = await jobs.enqueueJob({ type: "answer", input: { conversation: { source: sourceType, workspace, id }, question: "Wait for setup", slack_requester: "UORIGINAL", manual_command: { repo: "demo", command: "sleep 60" } } });
+  for (let i = 0; i < 200 && !jobs.codingChildPid(parent.id); i++) await new Promise(resolve => setTimeout(resolve, 20));
+  assert.ok(jobs.codingChildPid(parent.id));
+  const response = await app.inject({ method: "POST", url: `/v1/agents/tasks/${parent.id}/setup`, headers: { authorization: `Bearer ${jobs.jobScopedToken(parent.id)}` }, payload: { action: "request", repo: "demo", environment: "staging", kind: "file", destination: "pause.cfg", reason: "Need a test configuration" } });
+  assert.equal(response.statusCode, 200, response.body);
+  for (let i = 0; i < 200 && jobs.codingChildPid(parent.id); i++) await new Promise(resolve => setTimeout(resolve, 20));
+  assert.equal(jobs.codingChildPid(parent.id), undefined);
+  assert.equal(jobs.getJob(parent.id)!.status, "done");
+  assert.match(jobs.getJob(parent.id)!.result_json!, /setup_wait/);
+  for (let i = 0; i < 100 && !queue.requestCodingSlot("after-setup-pause").acquired; i++) await new Promise(resolve => setTimeout(resolve, 20));
+  assert.equal(queue.requestCodingSlot("after-setup-pause").acquired, true);
+  queue.releaseCodingSlot("after-setup-pause");
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,8 @@
       "dependencies": {
         "@falkordb/canvas": "^0.2.1",
         "@types/cytoscape": "^3.21.9",
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/xterm": "^6.0.0",
         "dompurify": "^3.4.11",
         "marked": "^18.0.5",
         "next": "16.2.10",
@@ -4310,6 +4312,21 @@
       "optional": true,
       "os": [
         "win32"
+      ]
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
       ]
     },
     "node_modules/abstract-logging": {
@@ -10084,6 +10101,22 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
+      }
+    },
+    "node_modules/node-pty/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
     "node_modules/node-releases": {
       "version": "2.0.50",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
@@ -13101,6 +13134,7 @@
         "@slack/web-api": "^7.18.0",
         "better-sqlite3": "^12.11.1",
         "fastify": "^4.28.0",
+        "node-pty": "^1.1.0",
         "shell-quote": "^1.10.0"
       },
       "devDependencies": {


### PR DESCRIPTION
Flow can now resolve missing configuration and CLI setup during a Slack task. The agent can DM the original requester for a file/value or an interactive setup terminal, end its turn while waiting, then resume the same conversation automatically. The dashboard env-upload panel is removed; the existing Agents UI shows “Needs setup”.

The new flow_setup tool supports arbitrary nested untracked config paths, private registration of existing files, environment selection, and setup requests. Files are encrypted in the project DB, copied into the source checkout and task worktree, and reused in later worktrees. Tracked files, symlinks, traversal, and locally modified destinations are protected. File replies are consumed before normal chat/image handling so their contents do not enter job prompts.

The authenticated browser terminal uses node-pty/xterm.js as the Flow OS user and holds the shared coding slot. Closing it kills foreground processes; completing setup releases the slot and resumes the task. Requests survive restarts; resume jobs and final Slack delivery are tracked durably. Resumed answers use the active Slack connection rather than the legacy outbox.

Validation:
- Full orchestrator suite: 398 passed, zero failed, two skipped (opt-in real OpenCode smoke and Linux-only recovery).
- Dashboard production build passed; changed dashboard files linted with no errors (one existing unused-import warning).
- Real OpenCode smoke verified the new flow_setup tool is loaded and executes.
- Linux targeted suite: nine tests passed, including real interactive input, foreground process cleanup, and pausing a real coding subprocess.
- Live Pixel Apps test uploaded JSON privately, resumed the original session, verified the file without printing its value, and delivered the result to the original Slack thread.
- Live browser terminal installed a harmless CLI. Its task queued behind the file task, then executed the CLI with exit 0 and delivered the final answer/run link.
- Verified matching config copies in the source checkout and two worktrees, clean Git status, and no private fixture value in job inputs. Removed validation files/CLI after testing.
- Visually inspected the browser terminal and verified the old upload panel is absent.

Evidence: file handoff https://pixelapps.slack.com/archives/D0BU9JAPZM5/p1788768424304599 and terminal handoff https://pixelapps.slack.com/archives/D0BU9JAPZM5/p1788768657729489.

Limits: this remains a trusted shared-host environment, not an OS sandbox. Setup files are limited to 1 MiB each. Applications load env files themselves; shell-only exports do not persist. Linux native installs require Python/make/C++ tools (already present in the Dockerfile). Existing unrelated TypeScript failures in corpus.ts, index.ts, pollers/engine.ts and memory.test.ts remain.
