### PR TITLE
feat(runtime): manage Flow chat and brain instances together

### DIFF
--- a/apps/server/src/brain/BrainRuntime.ts
+++ b/apps/server/src/brain/BrainRuntime.ts
@@ -278,6 +278,10 @@ export class BrainRuntime {
   private flowGraph(workspace: Workspace) {
     return this.db!.selectGraph(`flow_brain_${workspace.id.replaceAll("-", "")}`);
   }
+  assertAvailable() {
+    if (!this.db?.isRunning || this.closed)
+      throw new Error(this.database.message || "The app's brain runtime is unavailable.");
+  }
   private async readKnowledge(workspace: Workspace): Promise<BrainKnowledge> {
     if (this.db?.isRunning && workspace.sources.some((source) => source.pipeline === "flow")) {
       const graph = this.flowGraph(workspace);
@@ -729,6 +733,18 @@ export class BrainRuntime {
   ) {
     const workspace = this.workspaces.find((entry) => entry.projectIds.includes(projectId));
     if (!workspace) throw new Error("This project has no connected brain");
+    const result = await this.callBrainTool(workspace.id, name, args, context);
+    if (this.projectBrainId(projectId) !== workspace.id)
+      throw new Error("The project's brain changed.");
+    return result;
+  }
+  async callBrainTool(
+    workspaceId: string,
+    name: string,
+    args: Record<string, unknown>,
+    context: BrainSessionContext,
+  ) {
+    const workspace = this.workspace(workspaceId);
     if (
       (name === "source_read" || name === "source_search") &&
       !workspace.sources.some((source) => source.repository === args.repo)
@@ -736,8 +752,6 @@ export class BrainRuntime {
       throw new Error("Repository is not a source of the connected brain");
     await this.writeSessionSources(workspace);
     const worker = await this.sessionWorker(workspace);
-    if (this.projectBrainId(projectId) !== workspace.id)
-      throw new Error("The project's brain changed. Retry the tool call.");
     const repo = context.workspaceRoot
       ? await this.sessionRepository(context.workspaceRoot)
       : context.repo;
@@ -746,6 +760,10 @@ export class BrainRuntime {
   async captureProjectEvent(projectId: ProjectId, input: BrainCapture) {
     const workspace = this.workspaces.find((entry) => entry.projectIds.includes(projectId));
     if (!workspace) return;
+    return this.captureBrainEvent(workspace.id, input);
+  }
+  async captureBrainEvent(workspaceId: string, input: BrainCapture) {
+    const workspace = this.workspace(workspaceId);
     const repo = input.context.workspaceRoot
       ? await this.sessionRepository(input.context.workspaceRoot)
       : input.context.repo;

--- a/apps/server/src/brain/BrainService.ts
+++ b/apps/server/src/brain/BrainService.ts
@@ -5,6 +5,7 @@ import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import { ServerConfig } from "../config.ts";
+import { SharedBrainRuntime, serveSharedBrain, type BrainClient } from "./shared-runtime.ts";
 import { BrainRuntime } from "./BrainRuntime.ts";
 
 class BrainServiceError extends Schema.TaggedErrorClass<BrainServiceError>()("BrainServiceError", {
@@ -13,7 +14,7 @@ class BrainServiceError extends Schema.TaggedErrorClass<BrainServiceError>()("Br
 export class BrainService extends Context.Service<
   BrainService,
   {
-    readonly ready: Effect.Effect<BrainRuntime, BrainServiceError>;
+    readonly ready: Effect.Effect<BrainClient, BrainServiceError>;
   }
 >()("t3/brain/BrainService") {
   static readonly layer = Layer.effect(
@@ -23,25 +24,48 @@ export class BrainService extends Context.Service<
       const path = yield* Path.Path;
       const platform = yield* HostProcessPlatform;
       const architecture = yield* HostProcessArchitecture;
+      if (process.env.FLOW_SHARED_BRAIN_HOME) {
+        const shared = new SharedBrainRuntime(
+          process.env.FLOW_SHARED_BRAIN_HOME,
+          path.join(config.stateDir, "shared-brain"),
+          process.env.FLOW_MANAGED_INSTANCE_ID ?? "",
+        );
+        yield* Effect.addFinalizer(() => Effect.promise(() => shared.close()));
+        yield* Effect.tryPromise({
+          try: () => shared.initialize(),
+          catch: (cause) =>
+            new BrainServiceError({
+              message: cause instanceof Error ? cause.message : "Shared brain unavailable",
+            }),
+        });
+        return BrainService.of({ ready: Effect.succeed(shared) });
+      }
       const runtime = new BrainRuntime(path.join(config.stateDir, "brain"), {
         platform,
         architecture,
       });
-      let initialization: Promise<void> | undefined;
       yield* Effect.addFinalizer(() => Effect.promise(() => runtime.close()));
-      return BrainService.of({
-        ready: Effect.tryPromise({
-          try: async () => {
-            initialization ??= runtime.initialize();
-            await initialization;
-            return runtime;
-          },
+      yield* Effect.tryPromise({
+        try: async () => {
+          await runtime.initialize();
+          runtime.assertAvailable();
+        },
+        catch: (cause) =>
+          new BrainServiceError({
+            message: cause instanceof Error ? cause.message : "Could not open the brain.",
+          }),
+      });
+      if (process.env.FLOW_MANAGED_INSTANCE_ID) {
+        const close = yield* Effect.tryPromise({
+          try: () => serveSharedBrain(runtime, config.stateDir),
           catch: (cause) =>
             new BrainServiceError({
-              message: cause instanceof Error ? cause.message : "Could not open the brain.",
+              message: cause instanceof Error ? cause.message : "Brain transport unavailable",
             }),
-        }),
-      });
+        });
+        yield* Effect.addFinalizer(() => Effect.promise(close));
+      }
+      return BrainService.of({ ready: Effect.succeed(runtime) });
     }),
   );
 }

--- a/apps/server/src/brain/chat-context.ts
+++ b/apps/server/src/brain/chat-context.ts
@@ -60,8 +60,8 @@ export const makeBrainChatContextLoader = Effect.fn("brain.makeChatContextLoader
               ...(thread.value.branch ? { branch: thread.value.branch } : {}),
             },
           ),
-        catch: () =>
-          "Could not orient against the project's connected Flow brain. Retry when it is available.",
+        catch: (cause) =>
+          `Could not orient against the project's connected Flow brain: ${cause instanceof Error ? cause.message : "brain unavailable"}`,
       });
       if (result.isError)
         return yield* Effect.fail(

--- a/apps/server/src/brain/shared-runtime.test.ts
+++ b/apps/server/src/brain/shared-runtime.test.ts
@@ -1,0 +1,92 @@
+// @effect-diagnostics nodeBuiltinImport:off - Real local transport and persistence test.
+// @effect-diagnostics globalFetch:off - Verify authentication at the HTTP boundary.
+import { it, expect } from "vite-plus/test";
+import * as NodeFSP from "node:fs/promises";
+const { mkdtemp, mkdir, rm, readFile } = NodeFSP;
+import * as NodeOS from "node:os";
+const { tmpdir } = NodeOS;
+import * as NodePath from "node:path";
+const { join } = NodePath;
+import * as Schema from "effect/Schema";
+import { ProjectId, BrainState } from "@t3tools/contracts";
+import { serveSharedBrain, SharedBrainRuntime } from "./shared-runtime.ts";
+import type { BrainRuntime } from "./BrainRuntime.ts";
+import type { BrainCapture, BrainSessionContext } from "./session-worker.ts";
+const decodeProjectId = Schema.decodeUnknownSync(ProjectId);
+it("shares tools and capture over authenticated transport while isolating project bindings and replaying outages", async () => {
+  const root = await mkdtemp(join(tmpdir(), "flow-shared-test-"));
+  const source = join(root, "source");
+  await mkdir(source);
+  const sessions: string[] = [];
+  const captures: BrainCapture[] = [];
+  const project = decodeProjectId("test-project");
+  const state: BrainState = {
+    database: { status: "ready", message: "" },
+    embeddings: { status: "idle", message: "" },
+    github: { connected: false, login: "", message: "" },
+    clis: [],
+    workspaces: [
+      {
+        id: "brain",
+        name: "Brain",
+        cli: "claude",
+        sources: [],
+        projectIds: [project],
+        knowledge: { entities: [], edges: [], memories: [] },
+      },
+    ],
+  };
+  const runtime = {
+    state: async () => state,
+    callBrainTool: async (
+      _id: string,
+      _name: string,
+      _args: unknown,
+      context: BrainSessionContext,
+    ) => {
+      sessions.push(context.session);
+      return { content: [{ type: "text", text: "original orient" }] };
+    },
+    captureBrainEvent: async (_id: string, capture: BrainCapture) => {
+      captures.push(capture);
+    },
+  } as unknown as BrainRuntime;
+  let close = await serveSharedBrain(runtime, source);
+  let a = new SharedBrainRuntime(source, join(root, "a"), "instance-a");
+  const b = new SharedBrainRuntime(source, join(root, "b"), "instance-b");
+  try {
+    const endpoint = JSON.parse(await readFile(join(source, "brain-endpoint.json"), "utf8"));
+    expect((await fetch(endpoint.url, { method: "POST", body: "{}" })).status).toBe(401);
+    await a.initialize();
+    await b.initialize();
+    expect((await a.state()).workspaces[0]!.projectIds).toEqual([]);
+    await a.bindProject({ id: project, workspaceRoot: root }, "brain");
+    expect(b.projectBrainId(project)).toBeUndefined();
+    await b.bindProject({ id: project, workspaceRoot: root }, "brain");
+    await a.callProjectTool(project, "orient", {}, { session: "same-thread" });
+    await b.callProjectTool(project, "orient", {}, { session: "same-thread" });
+    expect(sessions).toEqual(["instance-a:same-thread", "instance-b:same-thread"]);
+    await close();
+    await a.captureProjectEvent(project, {
+      context: { session: "same-thread" },
+      receipt: "receipt-1",
+      kind: "user_prompt",
+      data: { text: "remember" },
+    });
+    await a.drainCapture();
+    await a.close();
+    close = await serveSharedBrain(runtime, source);
+    a = new SharedBrainRuntime(source, join(root, "a"), "instance-a");
+    await a.initialize();
+    await a.drainCapture();
+    expect(captures).toHaveLength(1);
+    expect(captures[0]!.context.session).toBe("instance-a:same-thread");
+    expect(a.projectBrainId(project)).toBe("brain");
+    expect(state.workspaces[0]!.projectIds).toEqual([project]);
+  } finally {
+    await a.close();
+    await b.close();
+    await close();
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/apps/server/src/brain/shared-runtime.ts
+++ b/apps/server/src/brain/shared-runtime.ts
@@ -1,0 +1,293 @@
+// @effect-diagnostics nodeBuiltinImport:off - Private local instance transport.
+// @effect-diagnostics globalFetch:off - Local transport outside the Effect runtime.
+// @effect-diagnostics globalTimers:off - Persisted capture retry lifecycle.
+// @effect-diagnostics globalDate:off - Ordered durable spool filenames.
+import * as NodeFSP from "node:fs/promises";
+import * as NodePath from "node:path";
+import * as NodeHttp from "node:http";
+import * as NodeCrypto from "node:crypto";
+import * as Schema from "effect/Schema";
+import { McpSchema } from "effect/unstable/ai";
+import { BrainCommand, BrainState, ProjectId } from "@t3tools/contracts";
+import type { BrainRuntime } from "./BrainRuntime.ts";
+import type { BrainCapture, BrainSessionContext } from "./session-worker.ts";
+export type BrainClient = Pick<
+  BrainRuntime,
+  | "projectBrainId"
+  | "callProjectTool"
+  | "captureProjectEvent"
+  | "bindProject"
+  | "listGithubRepositories"
+  | "listGithubBranches"
+  | "command"
+  | "state"
+  | "close"
+>;
+const Context = Schema.Struct({
+  session: Schema.String,
+  repo: Schema.optionalKey(Schema.String),
+  branch: Schema.optionalKey(Schema.String),
+  workspaceRoot: Schema.optionalKey(Schema.String),
+});
+const Capture = Schema.Struct({
+  context: Context,
+  receipt: Schema.String,
+  kind: Schema.Literals(["user_prompt", "update", "error", "created"]),
+  data: Schema.Unknown,
+  closed: Schema.optionalKey(Schema.Boolean),
+});
+const Request = Schema.Struct({
+  method: Schema.Literals(["state", "command", "call", "capture", "repositories", "branches"]),
+  instance: Schema.String,
+  workspace: Schema.optionalKey(Schema.String),
+  name: Schema.optionalKey(Schema.String),
+  args: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
+  context: Schema.optional(Context),
+  capture: Schema.optional(Capture),
+  command: Schema.optional(BrainCommand),
+});
+const decodeRequest = Schema.decodeUnknownSync(Request);
+const decodeDescriptor = Schema.decodeUnknownSync(
+  Schema.fromJsonString(Schema.Struct({ url: Schema.String, token: Schema.String })),
+);
+export async function serveSharedBrain(runtime: BrainRuntime, stateDir: string) {
+  const token = NodeCrypto.randomBytes(32).toString("hex");
+  const server = NodeHttp.createServer(async (request, response) => {
+    response.setHeader("content-type", "application/json");
+    if (
+      request.method !== "POST" ||
+      request.url !== "/" ||
+      request.headers.authorization !== `Bearer ${token}`
+    ) {
+      response.writeHead(401).end("{}");
+      return;
+    }
+    try {
+      let body = "";
+      for await (const chunk of request) {
+        body += String(chunk);
+        if (body.length > 4 * 1024 * 1024) throw Error("Request too large");
+      }
+      const input = decodeRequest(JSON.parse(body));
+      if (!/^[a-zA-Z0-9-]{1,100}$/.test(input.instance)) throw Error("Invalid source instance");
+      let result: unknown;
+      switch (input.method) {
+        case "state":
+          result = await runtime.state();
+          break;
+        case "repositories":
+          result = await runtime.listGithubRepositories();
+          break;
+        case "branches":
+          if (!input.name) throw Error("Missing repository");
+          result = await runtime.listGithubBranches(input.name);
+          break;
+        case "command":
+          if (!input.command || input.command.action === "bindProject")
+            throw Error("Project bindings belong to the calling instance");
+          result = await runtime.command(input.command);
+          break;
+        case "call":
+          if (!input.workspace || !input.name || !input.context)
+            throw Error("Missing brain/tool/context");
+          result = await runtime.callBrainTool(input.workspace, input.name, input.args ?? {}, {
+            ...input.context,
+            session: `${input.instance}:${input.context.session}`,
+          });
+          break;
+        case "capture":
+          if (!input.workspace || !input.capture) throw Error("Missing brain/capture");
+          await runtime.captureBrainEvent(input.workspace, {
+            ...input.capture,
+            context: {
+              ...input.capture.context,
+              session: `${input.instance}:${input.capture.context.session}`,
+            },
+          });
+          result = null;
+          break;
+      }
+      response.end(JSON.stringify({ result }));
+    } catch (error) {
+      response.writeHead(503).end(
+        JSON.stringify({
+          error: error instanceof Error ? error.message : "Brain request failed",
+        }),
+      );
+    }
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw Error("No brain transport address");
+  const file = NodePath.join(stateDir, "brain-endpoint.json");
+  await NodeFSP.writeFile(
+    file,
+    JSON.stringify({ url: `http://127.0.0.1:${address.port}`, token }),
+    {
+      mode: 0o600,
+    },
+  );
+  return async () => {
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await NodeFSP.rm(file, { force: true });
+  };
+}
+const decodeReply = Schema.decodeUnknownSync(
+  Schema.Struct({
+    result: Schema.optional(Schema.Unknown),
+    error: Schema.optionalKey(Schema.String),
+  }),
+);
+const decodeBindings = Schema.decodeUnknownSync(
+  Schema.fromJsonString(Schema.Record(Schema.String, Schema.String)),
+);
+const decodeState = Schema.decodeUnknownSync(BrainState);
+const decodeProjectId = Schema.decodeUnknownSync(ProjectId);
+const decodeToolResult = Schema.decodeUnknownSync(McpSchema.CallToolResult);
+const decodeWorkspaceId = Schema.decodeUnknownSync(Schema.NullOr(Schema.String));
+const decodeRepositories = Schema.decodeUnknownSync(
+  Schema.Array(Schema.Struct({ name: Schema.String, private: Schema.Boolean })),
+);
+const decodeBranches = Schema.decodeUnknownSync(Schema.Array(Schema.String));
+export class SharedBrainRuntime implements BrainClient {
+  private bindings: Record<string, string> = {};
+  private queue = Promise.resolve();
+  private writes = Promise.resolve();
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private closed = false;
+  private sequence = Date.now() * 1000;
+  private readonly source: string;
+  private readonly directory: string;
+  private readonly instance: string;
+  constructor(source: string, directory: string, instance: string) {
+    this.source = source;
+    this.directory = directory;
+    this.instance = instance;
+  }
+  private async request(
+    method: (typeof Request.Type)["method"],
+    input: Record<string, unknown> = {},
+  ): Promise<unknown> {
+    const endpoint = decodeDescriptor(
+      await NodeFSP.readFile(NodePath.join(this.source, "brain-endpoint.json"), "utf8"),
+    );
+    const url = new URL(endpoint.url);
+    if (url.protocol !== "http:" || url.hostname !== "127.0.0.1")
+      throw Error("Shared brain must be a local managed instance");
+    const response = await fetch(endpoint.url, {
+      method: "POST",
+      headers: { authorization: `Bearer ${endpoint.token}`, "content-type": "application/json" },
+      body: JSON.stringify({ method, instance: this.instance, ...input }),
+      signal: AbortSignal.timeout(30000),
+    });
+    const reply = decodeReply(await response.json());
+    if (!response.ok || reply.error) throw Error(reply.error || "Shared brain is unavailable");
+    return reply.result;
+  }
+  async initialize() {
+    await NodeFSP.mkdir(NodePath.join(this.directory, "capture"), { recursive: true });
+    try {
+      this.bindings = decodeBindings(
+        await NodeFSP.readFile(NodePath.join(this.directory, "bindings.json"), "utf8"),
+      );
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    const state = await this.state();
+    if (state.database.status !== "ready")
+      throw new Error(state.database.message || "Shared brain unavailable");
+    this.flush();
+  }
+  projectBrainId(project: ProjectId) {
+    return this.bindings[project];
+  }
+  async state() {
+    const state = decodeState(await this.request("state"));
+    return {
+      ...state,
+      workspaces: state.workspaces.map((w) => ({
+        ...w,
+        projectIds: Object.entries(this.bindings)
+          .filter(([, id]) => id === w.id)
+          .map(([id]) => decodeProjectId(id)),
+      })),
+    };
+  }
+  bindProject(project: { id: ProjectId; workspaceRoot: string }, workspace: string | null) {
+    const pending = this.writes.then(async () => {
+      if (workspace && !(await this.state()).workspaces.some((w) => w.id === workspace))
+        throw Error("Brain is not available on the source instance");
+      const next = { ...this.bindings };
+      if (workspace) next[project.id] = workspace;
+      else delete next[project.id];
+      const file = NodePath.join(this.directory, "bindings.json");
+      await NodeFSP.writeFile(file + ".tmp", JSON.stringify(next), { mode: 0o600 });
+      await NodeFSP.rename(file + ".tmp", file);
+      this.bindings = next;
+    });
+    this.writes = pending.catch(() => {});
+    return pending;
+  }
+  async callProjectTool(
+    project: ProjectId,
+    name: string,
+    args: Record<string, unknown>,
+    context: BrainSessionContext,
+  ) {
+    const workspace = this.bindings[project];
+    if (!workspace) throw Error("This project has no connected shared brain");
+    return decodeToolResult(await this.request("call", { workspace, name, args, context }));
+  }
+  async captureProjectEvent(project: ProjectId, capture: BrainCapture) {
+    const workspace = this.bindings[project];
+    if (!workspace) return;
+    this.sequence = Math.max(this.sequence + 1, Date.now() * 1000);
+    const file = NodePath.join(this.directory, "capture", `${this.sequence}.json`);
+    await NodeFSP.writeFile(file + ".tmp", JSON.stringify({ workspace, capture }), { mode: 0o600 });
+    await NodeFSP.rename(file + ".tmp", file);
+    this.flush();
+  }
+  private flush() {
+    this.queue = this.queue
+      .then(async () => {
+        for (const name of (await NodeFSP.readdir(NodePath.join(this.directory, "capture")))
+          .filter((n) => n.endsWith(".json"))
+          .sort()) {
+          const file = NodePath.join(this.directory, "capture", name);
+          await this.request("capture", JSON.parse(await NodeFSP.readFile(file, "utf8")));
+          await NodeFSP.unlink(file);
+        }
+      })
+      .catch(() => {
+        if (!this.closed && !this.timer) {
+          this.timer = setTimeout(() => {
+            this.timer = undefined;
+            this.flush();
+          }, 5000);
+          this.timer.unref();
+        }
+      });
+  }
+  async command(command: BrainCommand) {
+    return decodeWorkspaceId(await this.request("command", { command }));
+  }
+  async listGithubRepositories() {
+    return [...decodeRepositories(await this.request("repositories"))];
+  }
+  async listGithubBranches(repository: string) {
+    return [...decodeBranches(await this.request("branches", { name: repository }))];
+  }
+  async drainCapture() {
+    await this.queue;
+  }
+  async close() {
+    this.closed = true;
+    if (this.timer) clearTimeout(this.timer);
+    await this.writes;
+    await this.queue;
+  }
+}

--- a/apps/server/src/instanceOwnership.test.ts
+++ b/apps/server/src/instanceOwnership.test.ts
@@ -1,0 +1,109 @@
+// @effect-diagnostics nodeBuiltinImport:off - Exercise OS ownership across real processes.
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import * as NodeFSP from "node:fs/promises";
+const { mkdtemp, rm, symlink, writeFile } = NodeFSP;
+import * as NodeOS from "node:os";
+const { tmpdir } = NodeOS;
+import * as NodePath from "node:path";
+const { join } = NodePath;
+import * as NodeChildProcess from "node:child_process";
+const { spawn } = NodeChildProcess;
+const once = (emitter: NodeJS.EventEmitter, event: string) =>
+  new Promise<void>((resolve) => {
+    emitter.once(event, () => resolve());
+  });
+import { acquireInstanceOwnership } from "./instanceOwnership.ts";
+
+const cleanup: Array<() => void | Promise<void>> = [];
+afterEach(async () => {
+  for (const release of cleanup.splice(0).toReversed()) await release();
+});
+async function home() {
+  const dir = await mkdtemp(join(tmpdir(), "flow-instance-test-"));
+  cleanup.push(() => rm(dir, { recursive: true, force: true }));
+  return dir;
+}
+async function own(dir: string) {
+  const release = await acquireInstanceOwnership(dir);
+  cleanup.push(release);
+  return release;
+}
+describe("instance ownership", () => {
+  it("allows separate units but rejects another owner of the same unit", async () => {
+    const daily = await home();
+    const test = await home();
+    const release = await own(daily);
+    await own(test);
+    await expect(acquireInstanceOwnership(daily)).rejects.toThrow("already in use");
+    release();
+    await own(daily);
+  });
+  it("treats a symlink to the same home as the same unit", async () => {
+    const dir = await home();
+    const aliases = await home();
+    await symlink(dir, join(aliases, "alias"), "dir");
+    await own(dir);
+    await expect(acquireInstanceOwnership(join(aliases, "alias"))).rejects.toThrow(
+      "already in use",
+    );
+  });
+  it("recovers ownership after a crashed process without removing data", async () => {
+    const dir = await home();
+    await writeFile(join(dir, "keep.txt"), "preserved");
+    const child = spawn(
+      process.execPath,
+      [
+        "--input-type=module",
+        "-e",
+        `
+      import * as NodeSqlite from "node:sqlite";
+const { DatabaseSync } = NodeSqlite;
+      const db = new DatabaseSync(process.argv[1]);
+      db.exec('BEGIN EXCLUSIVE');
+      process.stdout.write('ready');
+      process.stdin.resume();
+    `,
+        join(dir, "instance-lock.sqlite"),
+      ],
+      { stdio: ["pipe", "pipe", "pipe"] },
+    );
+    cleanup.push(() => {
+      if (child.exitCode === null) child.kill();
+    });
+    await once(child.stdout!, "data");
+    await expect(acquireInstanceOwnership(dir)).rejects.toThrow("already in use");
+    const exited = once(child, "exit");
+    child.kill("SIGKILL");
+    await exited;
+    await own(dir);
+    const { readFile } = await import("node:fs/promises");
+    expect(await readFile(join(dir, "keep.txt"), "utf8")).toBe("preserved");
+  });
+  it("does not take over a live older server that lacks the new lock", async () => {
+    const dir = await home();
+    const child = spawn(
+      process.execPath,
+      ["-e", "process.stdout.write('ready'); process.stdin.resume()"],
+      { stdio: ["pipe", "pipe", "pipe"] },
+    );
+    cleanup.push(() => {
+      child.kill();
+    });
+    await once(child.stdout!, "data");
+    await writeFile(
+      join(dir, "server-runtime.json"),
+      JSON.stringify({
+        version: 1,
+        pid: child.pid,
+        port: 12345,
+        origin: "http://localhost:12345",
+        startedAt: "2026-09-08T00:00:00.000Z",
+      }),
+    );
+    await expect(acquireInstanceOwnership(dir)).rejects.toThrow("http://localhost:12345");
+    const exited = once(child, "exit");
+    child.kill();
+    await exited;
+    await own(dir);
+  });
+});

--- a/apps/server/src/instanceOwnership.ts
+++ b/apps/server/src/instanceOwnership.ts
@@ -1,0 +1,76 @@
+// @effect-diagnostics nodeBuiltinImport:off - Process-lifetime ownership of a local data directory.
+import * as NodeFSP from "node:fs/promises";
+import * as NodePath from "node:path";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+import { PersistedServerRuntimeState, isProcessAlive } from "./serverRuntimeState.ts";
+
+export class InstanceOwnershipError extends Schema.TaggedErrorClass<InstanceOwnershipError>()(
+  "InstanceOwnershipError",
+  { message: Schema.String },
+) {}
+
+const isOwnershipError = Schema.is(InstanceOwnershipError);
+const decodeRuntime = Schema.decodeUnknownSync(Schema.fromJsonString(PersistedServerRuntimeState));
+
+/** SQLite's OS lock is released even after a crash. Never delete this file:
+ * unlinking a locked inode would allow two owners of the same data directory.
+ * This database contains no application data and is independent of chat writes.
+ */
+export async function acquireInstanceOwnership(stateDir: string) {
+  await NodeFSP.mkdir(stateDir, { recursive: true });
+  const filename = NodePath.join(stateDir, "instance-lock.sqlite");
+  const db = process.versions.bun
+    ? new (await import("bun:sqlite")).Database(filename)
+    : new (await import("node:sqlite")).DatabaseSync(filename);
+  try {
+    db.exec("PRAGMA busy_timeout = 0; BEGIN EXCLUSIVE;");
+  } catch (cause) {
+    db.close();
+    throw new InstanceOwnershipError({
+      message: `This app's data directory is already in use (${stateDir}). Open the running app; chat and brain must run together in one server. ${cause instanceof Error ? cause.message : ""}`,
+    });
+  }
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
+    db.close();
+  };
+  try {
+    // Also protect upgrades from a server launched before ownership locking.
+    const saved = await NodeFSP.readFile(
+      NodePath.join(stateDir, "server-runtime.json"),
+      "utf8",
+    ).catch((error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") return null;
+      throw error;
+    });
+    if (saved) {
+      const owner = decodeRuntime(saved);
+      if (owner.pid !== process.pid && isProcessAlive(owner.pid)) {
+        throw new InstanceOwnershipError({
+          message: `This app is already running at ${owner.devUrl ?? owner.origin} (process ${owner.pid}). Open that app instead. Chat and brain share one server.`,
+        });
+      }
+    }
+    return release;
+  } catch (error) {
+    release();
+    throw error;
+  }
+}
+
+export const ownInstance = (stateDir: string) =>
+  Effect.acquireRelease(
+    Effect.tryPromise({
+      try: () => acquireInstanceOwnership(stateDir),
+      catch: (cause) =>
+        isOwnershipError(cause)
+          ? cause
+          : new InstanceOwnershipError({
+              message: `Could not acquire ownership of ${stateDir}: ${cause instanceof Error ? cause.message : String(cause)}`,
+            }),
+    }),
+    (release) => Effect.sync(release),
+  );

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1,4 +1,5 @@
 import { BRAND } from "@t3tools/shared/branding";
+import { ownInstance } from "./instanceOwnership.ts";
 import { brainHttpApiLayer } from "./brain/http.ts";
 import { EnvironmentHttpApi, ProviderDriverKind } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
@@ -573,6 +574,9 @@ export const makeRoutesLayer = Layer.mergeAll(
 export const makeServerLayer = Layer.unwrap(
   Effect.gen(function* () {
     const config = yield* ServerConfig.ServerConfig;
+    // Acquire before building any persistence, provider, or brain layers. The
+    // enclosing scope releases ownership after those services have shut down.
+    yield* ownInstance(config.stateDir);
     const activation = yield* Deferred.make<void>();
     const awaitActivation = Deferred.await(activation);
     const activationLayer = Layer.succeed(ServerActivation, awaitActivation);

--- a/docs/user/local-instances.md
+++ b/docs/user/local-instances.md
@@ -1,0 +1,72 @@
+# Run Flow in a browser
+
+The source-checkout launcher starts chat and brain together in the background.
+It requires Node.js 22.16+ or 24.10+ and the checkout's dependencies. To install
+its command and build the web app, run:
+
+```sh
+./scripts/install-flow.sh
+```
+
+Add the printed installation directory to PATH if needed. Then:
+
+```sh
+flow
+flow status
+flow stop
+flow restart
+```
+
+`flow` opens the existing app or starts it and opens a pairing link. You do not
+need to remember its port. Closing the terminal or browser leaves it running.
+`--no-open` prints the pairing link instead. Restart can interrupt active turns;
+it preserves application data. Provider CLI sign-ins remain shared.
+
+This installer runs from and retains a reference to its checkout; keep that
+checkout available. It does not yet download versioned releases or implement
+`flow update`/`flow repair`. Reinstalling refreshes the launcher without
+restarting apps. It refuses to overwrite an unrelated command. The existing
+`~/.flow/bin/flow` memory helper is left intact; integrations using its absolute
+path continue to work.
+
+## Development
+
+```sh
+flow dev test1 --isolated
+flow dev test2 --shared-brain --from primary
+flow dev ui1 --ui-only --from primary
+flow dev test1
+flow dev test1 --replace
+flow dev test3 --fresh
+flow dev list
+flow dev status test1
+flow dev stop test1
+```
+
+A new named instance defaults to isolated mode and records the current checkout.
+Use `--code /absolute/path/to/checkout` when creating it elsewhere. Later commands
+reuse that checkout, mode and data regardless of the current directory. To
+change the checkout or mode, create a new name. `--replace` restarts with saved
+settings; `--fresh` only accepts a new name and creates empty isolated storage.
+
+- **Isolated:** separate chat history, projects, brain, indexing and memory.
+- **Shared brain:** separate chats and project bindings, using the chosen
+  instance's live brain through authenticated local requests. Select/connect a
+  brain to the dev project in settings. Brain writes and captured memories
+  modify that shared brain. Start the source instance first.
+- **UI only:** another development frontend against the source's existing chat
+  server and brain. UI actions affect the source's real data. Its proxy follows
+  source restarts; stopping this frontend never stops the source.
+
+All modes share provider sign-ins. Separate application data does not isolate
+edits to the same working folder; use separate Git worktrees for independent
+coding tests. Test instances do not copy primary projects or connector settings.
+
+Data and saved instance configuration live beneath
+`~/.local/share/flow-app/instances`. For automation, `FLOW_INSTANCE_HOME` selects
+an entirely separate registry. It does not change provider credential homes.
+The first primary launch starts with new storage; existing legacy T3/Flow data
+is not migrated automatically.
+
+The current supervisor and installation script target macOS/Linux. Windows
+process-tree supervision and standalone release distribution remain follow-ups.

--- a/scripts/flow.mjs
+++ b/scripts/flow.mjs
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import { main } from "./instances/launcher.mjs";
+main(process.argv.slice(2)).catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/scripts/install-flow.sh
+++ b/scripts/install-flow.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -eu
+# Installs the browser launcher from this checkout; no Flow npm package is used.
+FLOW_SOURCE=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+FLOW_PREFIX=${HOME}/.local
+FLOW_BUILD=1
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --prefix) [ "$#" -ge 2 ] || { echo '--prefix requires a directory' >&2; exit 1; }; FLOW_PREFIX=$2; shift 2 ;;
+    --no-build) FLOW_BUILD=0; shift ;;
+    *) echo "Usage: $0 [--prefix DIRECTORY] [--no-build]" >&2; exit 1 ;;
+  esac
+done
+FLOW_NODE=$(command -v node || true)
+[ -n "$FLOW_NODE" ] || { echo 'Install Node.js 22.16+ or 24.10+ first.' >&2; exit 1; }
+"$FLOW_NODE" -e 'const [m,n]=process.versions.node.split(".").map(Number); if (!((m===22&&n>=16)||(m>=24&&!(m===24&&n<10)))) { console.error("Use Node.js 22.16+ or 24.10+."); process.exit(1); }'
+if [ "$FLOW_BUILD" = 1 ]; then
+  cd "$FLOW_SOURCE"
+  if [ ! -x node_modules/.bin/vp ]; then
+    npm exec --yes --package=vite-plus@0.3.0 -- vp install --frozen-lockfile
+  fi
+  node_modules/.bin/vp run --filter @t3tools/web build
+fi
+[ -f "$FLOW_SOURCE/apps/web/dist/index.html" ] || { echo 'Build the web app before installing the launcher.' >&2; exit 1; }
+mkdir -p "$FLOW_PREFIX/bin"
+FLOW_TARGET="$FLOW_PREFIX/bin/flow"
+if [ -e "$FLOW_TARGET" ] && ! grep -q '^# flow-managed-launcher$' "$FLOW_TARGET"; then
+  echo "Refusing to overwrite an existing command: $FLOW_TARGET. Choose another --prefix." >&2
+  exit 1
+fi
+# The launcher is installed separately from ~/.flow/bin/flow, preserving existing memory hooks.
+FLOW_TEMP=$(mktemp "$FLOW_PREFIX/bin/.flow-install.XXXXXX")
+trap 'rm -f "$FLOW_TEMP"' EXIT HUP INT TERM
+"$FLOW_NODE" --input-type=module - "$FLOW_NODE" "$FLOW_SOURCE/scripts/flow.mjs" "$FLOW_TEMP" <<'JS'
+import { writeFileSync } from 'node:fs';
+const [node, entry, target] = process.argv.slice(2);
+const quote = s => "'" + s.replaceAll("'", "'\\''") + "'";
+writeFileSync(target, '#!/bin/sh\n# flow-managed-launcher\nexec ' + quote(node) + ' ' + quote(entry) + ' "$@"\n', {mode:0o755});
+JS
+chmod 755 "$FLOW_TEMP"
+mv "$FLOW_TEMP" "$FLOW_TARGET"
+echo "Installed $FLOW_TARGET"
+echo "Add $FLOW_PREFIX/bin to PATH if needed, then run flow."
+echo 'Existing running instances and application data were left unchanged.'

--- a/scripts/instances/child-guard.mjs
+++ b/scripts/instances/child-guard.mjs
@@ -1,0 +1,40 @@
+/* eslint-disable t3code/no-global-process-runtime -- Process guardian uses its own OS process group. */
+import * as NodeChildProcess from "node:child_process";
+import * as NodeOS from "node:os";
+// The supervisor owns this process group. If it crashes, IPC disconnects and
+// this guardian shuts down its children instead of leaving a second app behind.
+const [command, ...args] = process.argv.slice(2);
+const child = NodeChildProcess.spawn(command, args, {
+  stdio: ["ignore", "inherit", "inherit"],
+  detached: false,
+  env: process.env,
+});
+let stopping = false;
+let orphaned = false;
+const stop = () => {
+  if (stopping) return;
+  stopping = true;
+  if (NodeOS.platform() === "win32") child.kill("SIGTERM");
+  else {
+    const force = setTimeout(() => {
+      try {
+        process.kill(-process.pid, "SIGKILL");
+      } catch {}
+    }, 20000);
+    if (!orphaned) force.unref();
+    process.kill(-process.pid, "SIGTERM");
+  }
+};
+process.on("SIGTERM", stop);
+process.once("disconnect", () => {
+  orphaned = true;
+  stop();
+});
+child.once("error", (error) => {
+  console.error(error.message);
+  process.exit(1);
+});
+child.once("exit", (code, signal) => {
+  if (!stopping) process.exit(code ?? (signal ? 1 : 0));
+  else if (!orphaned) process.exit(0);
+});

--- a/scripts/instances/launcher.mjs
+++ b/scripts/instances/launcher.mjs
@@ -1,0 +1,282 @@
+/* eslint-disable t3code/no-global-process-runtime -- Standalone Node bootstrap runs before workspace Effect services exist. */
+import * as NodeFSP from "node:fs/promises";
+const { mkdir, readFile, writeFile, rename, realpath, access, readdir } = NodeFSP;
+import * as NodeFS from "node:fs";
+const { openSync, closeSync } = NodeFS;
+import * as NodePath from "node:path";
+const { dirname, join, resolve } = NodePath;
+import * as NodeURL from "node:url";
+const { fileURLToPath } = NodeURL;
+import * as NodeOS from "node:os";
+const { homedir } = NodeOS;
+import * as NodeCrypto from "node:crypto";
+const { randomUUID } = NodeCrypto;
+import * as NodeChildProcess from "node:child_process";
+const { spawn, execFile } = NodeChildProcess;
+import * as NodeUtil from "node:util";
+const { promisify } = NodeUtil;
+import * as NodeTimersPromises from "node:timers/promises";
+const { setTimeout: delay } = NodeTimersPromises;
+const exec = promisify(execFile);
+export const sourceRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+export const registryRoot = () =>
+  resolve(process.env.FLOW_INSTANCE_HOME || join(homedir(), ".local/share/flow-app"));
+const reserved = new Set(["primary", "list", "status", "stop", "restart", "help"]);
+export async function json(path) {
+  try {
+    return JSON.parse(await readFile(path, "utf8"));
+  } catch (e) {
+    if (e.code === "ENOENT") return null;
+    throw e;
+  }
+}
+export async function atomic(path, data) {
+  const temp = `${path}.${randomUUID()}.tmp`;
+  await writeFile(temp, JSON.stringify(data, null, 2), { mode: 0o600 });
+  await rename(temp, path);
+}
+export function parse(args) {
+  const input = {
+    name: "primary",
+    action: "start",
+    dev: false,
+    noOpen: false,
+    replace: false,
+    fresh: false,
+  };
+  if (args[0] === "--supervise") return { action: "supervise", directory: args[1] };
+  if (args[0] === "--help" || args[0] === "help") return { action: "help" };
+  if (args[0] === "dev") {
+    input.dev = true;
+    args = args.slice(1);
+    if (["list", "status", "stop"].includes(args[0])) input.action = args.shift();
+    if (input.action !== "list") {
+      input.name = args.shift();
+      if (!input.name || !/^[a-z][a-z0-9-]{0,47}$/.test(input.name) || reserved.has(input.name))
+        throw Error("Choose a dev name using lowercase letters, digits and hyphens.");
+    }
+  } else if (["status", "stop", "restart"].includes(args[0])) input.action = args.shift();
+  for (let i = 0; i < args.length; i++) {
+    const flag = args[i];
+    if (flag === "--no-open") input.noOpen = true;
+    else if (flag === "--replace") input.replace = true;
+    else if (flag === "--fresh") input.fresh = true;
+    else if (["--isolated", "--ui-only", "--shared-brain"].includes(flag)) {
+      if (input.mode) throw Error("Choose only one development mode.");
+      input.mode = flag.slice(2);
+    } else if (["--code", "--from"].includes(flag)) {
+      const value = args[++i];
+      if (!value || value.startsWith("--")) throw Error(`${flag} requires a value.`);
+      input[flag.slice(2)] = value;
+    } else throw Error(`Unknown option: ${flag}`);
+  }
+  if (!input.dev && (input.mode || input.from || input.fresh || input.code || input.replace))
+    throw Error(
+      "Instance configuration flags belong to flow dev NAME. Use flow restart for primary.",
+    );
+  if (input.fresh && (input.replace || (input.mode && input.mode !== "isolated")))
+    throw Error("--fresh creates a new isolated unit; it cannot replace or share another unit.");
+  if (input.mode === "isolated" && input.from) throw Error("--isolated cannot use --from.");
+  if (
+    input.action !== "start" &&
+    (input.mode || input.from || input.fresh || input.code || input.replace)
+  )
+    throw Error("Configuration flags apply only when starting a development instance.");
+  return input;
+}
+export async function control(directory, action = "status") {
+  const state = await json(join(directory, "runtime.json"));
+  if (!state) return null;
+  const url = new URL(state.controlUrl);
+  if (url.hostname !== "127.0.0.1" || url.protocol !== "http:")
+    throw Error("Invalid instance control address.");
+  try {
+    const response = await fetch(`${url.origin}/${action}`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${state.token}` },
+      signal: AbortSignal.timeout(3000),
+    });
+    if (!response.ok) return null;
+    const result = await response.json();
+    if (result.generation !== state.generation || result.id !== state.id)
+      throw Error("Instance identity did not match; refusing to control it.");
+    return result;
+  } catch (error) {
+    if (error.message?.includes("identity")) throw error;
+    return null;
+  }
+}
+export async function configure(input, directory) {
+  const saved = await json(join(directory, "config.json"));
+  if (saved) {
+    if (input.fresh) throw Error(`${input.name} already exists. Use a new name for --fresh.`);
+    if (input.code && (await realpath(resolve(input.code))) !== saved.code)
+      throw Error("Use a new instance name to run a different checkout.");
+    if ((input.mode && input.mode !== saved.mode) || (input.from && input.from !== saved.from))
+      throw Error(
+        "Use a new instance name for a different brain mode/source. --replace preserves configuration.",
+      );
+    return saved;
+  }
+  const code = await realpath(
+    input.code ? resolve(input.code) : input.dev ? process.cwd() : sourceRoot,
+  );
+  await access(join(code, "apps/server/src/bin.ts"));
+  const mode = input.mode || "isolated";
+  if (input.from && mode === "isolated")
+    throw Error("--from requires --shared-brain or --ui-only.");
+  const from = mode === "isolated" ? undefined : input.from || "primary";
+  if (from && (!/^[a-z][a-z0-9-]{0,47}$/.test(from) || from === input.name))
+    throw Error("Invalid source instance.");
+  const config = {
+    version: 1,
+    id: randomUUID(),
+    name: input.name,
+    code,
+    mode,
+    ...(from ? { from } : {}),
+    dev: input.dev,
+    home: join(directory, "data"),
+  };
+  await atomic(join(directory, "config.json"), config);
+  return config;
+}
+export async function waitFor(directory, predicate, timeout = 120000) {
+  const end = Date.now() + timeout;
+  while (Date.now() < end) {
+    const status = await control(directory);
+    if (status?.phase === "failed" && !predicate(status))
+      throw Error(`${status.error}\nLog: ${join(directory, "runtime.log")}`);
+    if (predicate(status)) return status;
+    await delay(150);
+  }
+  throw Error(`Instance did not finish its transition. Inspect ${join(directory, "runtime.log")}`);
+}
+async function openBrowser(url) {
+  const command =
+    NodeOS.platform() === "darwin"
+      ? ["open", [url]]
+      : NodeOS.platform() === "win32"
+        ? ["rundll32", ["url.dll,FileProtocolHandler", url]]
+        : ["xdg-open", [url]];
+  await exec(...command).catch(() => console.log(`Open ${url}`));
+}
+export async function lockLauncher(directory) {
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  const { DatabaseSync } = await import("node:sqlite");
+  const mutex = new DatabaseSync(join(directory, "launcher-lock.sqlite"));
+  try {
+    const end = Date.now() + 180000;
+    while (true) {
+      try {
+        mutex.exec("BEGIN EXCLUSIVE");
+        return () => mutex.close();
+      } catch (error) {
+        if (error.errcode !== 5 || Date.now() >= end) throw error;
+        await delay(100);
+      }
+    }
+  } catch (error) {
+    mutex.close();
+    throw error;
+  }
+}
+export async function start(input) {
+  const directory = join(registryRoot(), "instances", input.name);
+  const release = await lockLauncher(directory);
+  try {
+    const config = await configure(input, directory);
+    let status = await control(directory);
+    if (status && (input.replace || input.action === "restart" || status.phase === "failed")) {
+      console.log(`Restarting ${input.name}; active turns may be interrupted. Data is preserved.`);
+      await control(directory, "stop");
+      await waitFor(directory, (value) => !value);
+      status = null;
+    }
+    if (!status) {
+      const log = openSync(join(directory, "runtime.log"), "a", 0o600);
+      const child = spawn(
+        process.execPath,
+        [join(sourceRoot, "scripts/flow.mjs"), "--supervise", directory],
+        { detached: true, stdio: ["ignore", log, log], env: process.env },
+      );
+      closeSync(log);
+      await new Promise((resolve, reject) => {
+        child.once("spawn", resolve);
+        child.once("error", reject);
+      });
+      child.unref();
+    }
+    status = await waitFor(directory, (value) => value?.phase === "ready");
+    console.log(
+      `${config.name}: ${status.url}\nMode: ${config.mode}${config.from ? ` (uses ${config.from})` : ""}`,
+    );
+    const pairingConfig =
+      config.mode === "ui-only"
+        ? await json(join(registryRoot(), "instances", config.from, "config.json"))
+        : config;
+    const bin = join(pairingConfig.code, "apps/server/src/bin.ts");
+    const { stdout } = await exec(
+      process.execPath,
+      ["--experimental-strip-types", bin, "pair", "--base-dir", pairingConfig.home],
+      {
+        cwd: pairingConfig.code,
+        maxBuffer: 1024 * 1024,
+        env: (await import("./supervisor.mjs")).cleanEnvironment(process.env),
+      },
+    );
+    const match = /Pairing URL: (https?:\/\/\S+)/.exec(stdout);
+    if (!match)
+      throw Error(
+        "App is ready but pairing could not be issued. Use flow status to find its address.",
+      );
+    const pairingUrl = new URL(match[1]);
+    const frontend = new URL(status.url);
+    pairingUrl.host = frontend.host;
+    pairingUrl.protocol = frontend.protocol;
+    if (!input.noOpen) await openBrowser(pairingUrl.toString());
+    else console.log(`Pairing URL: ${pairingUrl}`);
+    return status;
+  } finally {
+    release();
+  }
+}
+export async function main(args) {
+  const input = parse([...args]);
+  if (NodeOS.platform() === "win32" && input.action !== "help")
+    throw Error("The managed launcher currently supports macOS and Linux.");
+  if (input.action === "supervise")
+    return (await import("./supervisor.mjs")).supervise(input.directory);
+  if (input.action === "help")
+    return console.log(
+      "flow [status|stop|restart] [--no-open]\nflow dev NAME [--isolated|--ui-only|--shared-brain] [--from primary] [--code PATH] [--replace|--fresh] [--no-open]\nflow dev list\nflow dev status NAME\nflow dev stop NAME",
+    );
+  if (input.action === "list") {
+    const directory = join(registryRoot(), "instances");
+    const names = await readdir(directory).catch((e) => {
+      if (e.code === "ENOENT") return [];
+      throw e;
+    });
+    for (const name of names) {
+      const config = await json(join(directory, name, "config.json"));
+      if (!config) continue;
+      const status = await control(join(directory, name));
+      console.log(`${name}\t${config.mode}\t${status?.phase || "stopped"}\t${status?.url || ""}`);
+    }
+    return;
+  }
+  const directory = join(registryRoot(), "instances", input.name);
+  if (input.action === "status")
+    return console.log((await control(directory)) || `${input.name}: stopped`);
+  if (input.action === "stop") {
+    const release = await lockLauncher(directory);
+    try {
+      const status = await control(directory, "stop");
+      if (status) await waitFor(directory, (value) => !value);
+      return console.log(`${input.name}: stopped`);
+    } finally {
+      release();
+    }
+  }
+  return start(input);
+}

--- a/scripts/instances/launcher.test.mjs
+++ b/scripts/instances/launcher.test.mjs
@@ -1,0 +1,96 @@
+import * as NodeTest from "node:test";
+const { test } = NodeTest;
+import * as NodeAssert from "node:assert/strict";
+const assert = NodeAssert;
+import * as NodeFSP from "node:fs/promises";
+const { mkdtemp, mkdir, rm } = NodeFSP;
+import * as NodeOS from "node:os";
+const { tmpdir } = NodeOS;
+import * as NodePath from "node:path";
+const { join } = NodePath;
+import { parse, configure, sourceRoot } from "./launcher.mjs";
+import { cleanEnvironment } from "./supervisor.mjs";
+test("normal launch does not depend on instance arguments", () => {
+  assert.equal(parse([]).name, "primary");
+  assert.throws(() => parse(["--isolated"]), /development|dev/);
+});
+test("mode and destructive flag conflicts are rejected", () => {
+  assert.throws(() => parse(["dev", "test1", "--isolated", "--shared-brain"]), /one/);
+  assert.throws(() => parse(["dev", "test1", "--fresh", "--replace"]), /fresh/);
+  assert.throws(() => parse(["dev", "../primary"]), /name/);
+  assert.throws(() => parse(["dev", "primary"]), /name/);
+  assert.equal(parse(["dev", "test1", "--replace"]).replace, true);
+});
+test("reopening preserves code, identity and storage, and fresh never overwrites", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "flow-config-test-"));
+  try {
+    const input = parse(["dev", "test1", "--isolated", "--code", sourceRoot]);
+    const saved = await configure(input, directory);
+    assert.deepEqual(await configure(parse(["dev", "test1", "--replace"]), directory), saved);
+    await assert.rejects(
+      configure(parse(["dev", "test1", "--fresh"]), directory),
+      /already exists/,
+    );
+    await assert.rejects(
+      configure(parse(["dev", "test1", "--shared-brain"]), directory),
+      /different brain/,
+    );
+    const other = join(directory, "other");
+    await mkdir(other);
+    const second = await configure(parse(["dev", "test2", "--code", sourceRoot]), other);
+    assert.notEqual(second.id, saved.id);
+    assert.notEqual(second.home, saved.home);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+test("nested launches cannot inherit parent storage or brain routing", () => {
+  assert.deepEqual(
+    cleanEnvironment({
+      HOME: "/home/user",
+      PATH: "/bin",
+      ANTHROPIC_API_KEY: "shared",
+      T3CODE_HOME: "/daily",
+      FLOW_SHARED_BRAIN_HOME: "/daily",
+      FALKOR_SOCKET: "/daily.sock",
+      PORT: "123",
+      VITE_WS_URL: "daily",
+    }),
+    { HOME: "/home/user", PATH: "/bin", ANTHROPIC_API_KEY: "shared" },
+  );
+});
+NodeTest.test("guardian stops a child when its supervisor disconnects", async () => {
+  const { fork } = await import("node:child_process");
+  const { once } = await import("node:events");
+  const { setTimeout: delay } = await import("node:timers/promises");
+  const root = await mkdtemp(join(tmpdir(), "flow-guardian-test-"));
+  const marker = join(root, "stopped");
+  const guardian = fork(
+    join(sourceRoot, "scripts/instances/child-guard.mjs"),
+    [
+      process.execPath,
+      "-e",
+      `process.on('SIGTERM',()=>{require('node:fs').writeFileSync(process.argv[1],'stopped');process.exit(0)});process.stdout.write('ready');setInterval(()=>{},1000)`,
+      marker,
+    ],
+    { detached: true, stdio: ["ignore", "pipe", "pipe", "ipc"] },
+  );
+  try {
+    await once(guardian.stdout, "data");
+    guardian.disconnect();
+    for (let i = 0; i < 100; i++) {
+      try {
+        await NodeFSP.access(marker);
+        break;
+      } catch {
+        await delay(20);
+      }
+    }
+    assert.equal(await NodeFSP.readFile(marker, "utf8"), "stopped");
+  } finally {
+    const exited = once(guardian, "exit");
+    process.kill(-guardian.pid, "SIGKILL");
+    await exited;
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/instances/supervisor.mjs
+++ b/scripts/instances/supervisor.mjs
@@ -1,0 +1,240 @@
+/* eslint-disable t3code/no-global-process-runtime -- Standalone Node bootstrap runs before workspace Effect services exist. */
+import * as NodeOS from "node:os";
+import * as NodeSqlite from "node:sqlite";
+const { DatabaseSync } = NodeSqlite;
+import * as NodeHttp from "node:http";
+const { createServer } = NodeHttp;
+import * as NodeNet from "node:net";
+const { createServer: tcpServer } = NodeNet;
+import * as NodeCrypto from "node:crypto";
+const { randomUUID, randomBytes } = NodeCrypto;
+import * as NodeChildProcess from "node:child_process";
+const { spawn } = NodeChildProcess;
+import * as NodeEvents from "node:events";
+const { once } = NodeEvents;
+import * as NodePath from "node:path";
+const { join } = NodePath;
+import * as NodeFSP from "node:fs/promises";
+const { rm } = NodeFSP;
+import * as NodeTimersPromises from "node:timers/promises";
+const { setTimeout: delay } = NodeTimersPromises;
+import { atomic, json, registryRoot, control, sourceRoot } from "./launcher.mjs";
+export async function freePort() {
+  const server = tcpServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const port = server.address().port;
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+export function cleanEnvironment(env) {
+  return Object.fromEntries(
+    Object.entries(env).filter(
+      ([key]) =>
+        !/^(T3CODE_|T3_SERVICE_|T3_BOOT_|VITE_|FLOW_|FALKOR_|GRAPH_|GATEWAY_|ORCHESTRATOR_|OPENCODE_WORKSPACE|DB_PATH$|JOURNAL_PATH$|PORT$|HOST$)/.test(
+          key,
+        ),
+    ),
+  );
+}
+export async function supervise(directory) {
+  const ownership = new DatabaseSync(join(directory, "supervisor-lock.sqlite"));
+  try {
+    ownership.exec("BEGIN EXCLUSIVE");
+  } catch {
+    ownership.close();
+    return;
+  }
+  const config = await json(join(directory, "config.json"));
+  const generation = randomUUID();
+  const token = randomBytes(32).toString("hex");
+  const state = {
+    id: config.id,
+    generation,
+    name: config.name,
+    phase: "starting",
+    pid: process.pid,
+  };
+  const children = [];
+  let stopping = false;
+  let relay;
+  const signalChild = (child, signal) => {
+    if (!Number.isInteger(child.pid) || child.pid <= 0) return;
+    // Only process groups created by this supervisor are ever signalled.
+    try {
+      process.kill(NodeOS.platform() === "win32" ? child.pid : -child.pid, signal);
+    } catch (error) {
+      if (error.code !== "ESRCH") throw error;
+    }
+  };
+  const stop = async () => {
+    if (stopping) return;
+    stopping = true;
+    state.phase = "stopping";
+    for (const child of children) signalChild(child, "SIGTERM");
+    const force = setTimeout(() => {
+      for (const child of children) signalChild(child, "SIGKILL");
+    }, 20000);
+    force.unref();
+    await Promise.all(
+      children.map((child) =>
+        child.exitCode !== null || child.signalCode ? undefined : once(child, "exit"),
+      ),
+    );
+    clearTimeout(force);
+    for (const child of children) signalChild(child, "SIGKILL");
+    if (relay) await relay.close();
+    const saved = await json(join(directory, "runtime.json"));
+    if (saved?.generation === generation)
+      await rm(join(directory, "runtime.json"), { force: true });
+    await new Promise((resolve) => server.close(resolve));
+    ownership.close();
+  };
+  const server = createServer((request, response) => {
+    if (request.headers.authorization !== `Bearer ${token}` || request.method !== "POST") {
+      response.writeHead(401).end();
+      return;
+    }
+    if (!["/status", "/stop"].includes(request.url)) {
+      response.writeHead(404).end();
+      return;
+    }
+    response.setHeader("content-type", "application/json");
+    response.end(JSON.stringify(state));
+    if (request.url === "/stop") void stop();
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  await atomic(join(directory, "runtime.json"), {
+    id: config.id,
+    generation,
+    token,
+    controlUrl: `http://127.0.0.1:${server.address().port}`,
+    pid: process.pid,
+  });
+  process.once("SIGTERM", () => void stop());
+  process.once("SIGINT", () => void stop());
+  const launch = async (command, args, options = {}) => {
+    const child = spawn(
+      process.execPath,
+      [join(sourceRoot, "scripts/instances/child-guard.mjs"), command, ...args],
+      {
+        cwd: config.code,
+        env: cleanEnvironment(process.env),
+        stdio: ["ignore", "inherit", "inherit", "ipc"],
+        detached: NodeOS.platform() !== "win32",
+        ...options,
+      },
+    );
+    children.push(child);
+    await new Promise((resolve, reject) => {
+      child.once("spawn", resolve);
+      child.once("error", reject);
+    });
+    child.once("exit", (code) => {
+      if (!stopping) {
+        state.phase = "failed";
+        for (const peer of children) if (peer !== child) signalChild(peer, "SIGTERM");
+        state.error = `An owned process exited (${code}). Run flow ${config.name === "primary" ? "restart" : `dev ${config.name} --replace`}.`;
+      }
+    });
+    return child;
+  };
+  try {
+    const env = cleanEnvironment(process.env);
+    let source;
+    if (config.from) {
+      source = await control(join(registryRoot(), "instances", config.from));
+      if (source?.phase !== "ready")
+        throw Error(`Source ${config.from} is not ready. Start it before this instance.`);
+    }
+    const webPort = await freePort();
+    if (config.mode === "ui-only")
+      relay = await (
+        await import("./ui-proxy.mjs")
+      ).uiProxy(join(registryRoot(), "instances", config.from));
+    const serverPort = relay ? relay.port : await freePort();
+    const webUrl = `http://localhost:${config.dev ? webPort : serverPort}`;
+    let origin;
+    if (config.mode !== "ui-only") {
+      if (config.mode === "shared-brain") {
+        const sourceConfig = await json(
+          join(registryRoot(), "instances", config.from, "config.json"),
+        );
+        env.FLOW_SHARED_BRAIN_HOME = join(sourceConfig.home, "userdata");
+      }
+      env.FLOW_MANAGED_INSTANCE_ID = config.id;
+      env.T3CODE_HOME = config.home;
+      env.T3CODE_DEV_ALLOWED_ORIGINS = webUrl;
+      await launch(
+        process.execPath,
+        [
+          "--experimental-strip-types",
+          join(config.code, "apps/server/src/bin.ts"),
+          "--base-dir",
+          config.home,
+          "--port",
+          String(serverPort),
+          "--host",
+          "127.0.0.1",
+          ...(config.dev ? ["--dev-url", webUrl] : []),
+          "--no-browser",
+        ],
+        { cwd: join(config.code, "apps/server"), env },
+      );
+      origin = `http://127.0.0.1:${serverPort}`;
+    } else origin = source.origin;
+    // UI-only attaches to the existing backend. No server is started against its home.
+    if (config.dev)
+      await launch(
+        join(config.code, "node_modules/.bin/vp"),
+        ["dev", "--port", String(webPort), "--strictPort"],
+        {
+          cwd: join(config.code, "apps/web"),
+          env: {
+            ...env,
+            PORT: String(webPort),
+            T3CODE_PORT: String(serverPort),
+            T3CODE_SINGLE_ORIGIN_DEV: "1",
+          },
+        },
+      );
+    const deadline = Date.now() + 120000;
+    while (Date.now() < deadline) {
+      if (stopping) break;
+      if (state.phase === "failed") throw Error(state.error);
+      try {
+        const descriptor = await fetch(`${webUrl}/.well-known/t3/environment`, {
+          signal: AbortSignal.timeout(1500),
+        });
+        if (descriptor.ok) {
+          const remote = await descriptor.json();
+          const runtime =
+            config.mode === "ui-only"
+              ? source
+              : await json(join(config.home, "userdata/server-runtime.json"));
+          if (runtime && remote.environmentId) {
+            Object.assign(state, {
+              phase: "ready",
+              url: webUrl,
+              origin,
+              environmentId: remote.environmentId,
+              home: config.home,
+            });
+            break;
+          }
+        }
+      } catch {
+        /* Startup is still publishing its endpoint. */
+      }
+      await delay(200);
+    }
+    if (!stopping && state.phase !== "ready")
+      throw Error("Chat and brain did not become ready before the startup deadline.");
+  } catch (error) {
+    state.phase = "failed";
+    state.error = error.message;
+    console.error(error);
+    for (const child of children) signalChild(child, "SIGTERM");
+  }
+}

--- a/scripts/instances/ui-proxy.mjs
+++ b/scripts/instances/ui-proxy.mjs
@@ -1,0 +1,82 @@
+import * as NodeHttp from "node:http";
+import * as NodeEvents from "node:events";
+import { control } from "./launcher.mjs";
+// Keep Vite's target stable while the source app changes ports on replacement.
+export async function uiProxy(sourceDirectory) {
+  const sockets = new Set();
+  const target = async () => {
+    const source = await control(sourceDirectory);
+    if (source?.phase !== "ready") throw Error("Source instance is unavailable");
+    return new URL(source.origin);
+  };
+  const server = NodeHttp.createServer(async (request, response) => {
+    try {
+      const origin = await target();
+      const upstream = NodeHttp.request(
+        new URL(origin.origin + (request.url.startsWith("/") ? request.url : "/")),
+        { method: request.method, headers: { ...request.headers, host: origin.host } },
+        (remote) => {
+          response.writeHead(remote.statusCode, remote.headers);
+          remote.pipe(response);
+        },
+      );
+      upstream.on("error", () => {
+        if (!response.headersSent) response.writeHead(502);
+        response.end("Source instance is unavailable");
+      });
+      request.on("aborted", () => upstream.destroy());
+      request.pipe(upstream);
+    } catch {
+      response.writeHead(503).end("Source instance is unavailable");
+    }
+  });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
+  server.on("upgrade", async (request, socket, head) => {
+    try {
+      const origin = await target();
+      const upstream = NodeHttp.request(
+        new URL(origin.origin + (request.url.startsWith("/") ? request.url : "/")),
+        { headers: { ...request.headers, host: origin.host } },
+      );
+      upstream.on("upgrade", (response, remote, remoteHead) => {
+        socket.write(
+          `HTTP/1.1 ${response.statusCode} ${response.statusMessage}\r\n` +
+            response.rawHeaders.reduce(
+              (text, value, index, values) =>
+                index % 2 ? text : text + value + ": " + values[index + 1] + "\r\n",
+              "",
+            ) +
+            "\r\n",
+        );
+        if (remoteHead.length) socket.write(remoteHead);
+        if (head.length) remote.write(head);
+        socket.pipe(remote);
+        remote.pipe(socket);
+        socket.on("error", () => remote.destroy());
+        remote.on("error", () => socket.destroy());
+        socket.once("close", () => remote.destroy());
+        remote.once("close", () => socket.destroy());
+      });
+      upstream.on("response", () => {
+        socket.destroy();
+        upstream.destroy();
+      });
+      upstream.on("error", () => socket.destroy());
+      upstream.end();
+    } catch {
+      socket.destroy();
+    }
+  });
+  server.listen(0, "127.0.0.1");
+  await NodeEvents.once(server, "listening");
+  return {
+    port: server.address().port,
+    close: async () => {
+      for (const socket of sockets) socket.destroy();
+      await new Promise((resolve) => server.close(resolve));
+    },
+  };
+}

--- a/scripts/instances/ui-proxy.test.mjs
+++ b/scripts/instances/ui-proxy.test.mjs
@@ -1,0 +1,54 @@
+import * as NodeTest from "node:test";
+import * as NodeAssert from "node:assert/strict";
+import * as NodeHttp from "node:http";
+import * as NodeEvents from "node:events";
+import * as NodeFSP from "node:fs/promises";
+import * as NodePath from "node:path";
+import * as NodeOS from "node:os";
+import { uiProxy } from "./ui-proxy.mjs";
+NodeTest.test(
+  "UI proxy follows verified source replacements without changing frontend port",
+  async () => {
+    const directory = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "flow-ui-proxy-"));
+    const servers = [];
+    const listen = async (handler) => {
+      const server = NodeHttp.createServer(handler);
+      servers.push(server);
+      server.listen(0, "127.0.0.1");
+      await NodeEvents.once(server, "listening");
+      return `http://127.0.0.1:${server.address().port}`;
+    };
+    let relay;
+    try {
+      const first = await listen((req, res) => res.end("first"));
+      const second = await listen((req, res) => res.end("second"));
+      let origin = first;
+      const url = await listen((req, res) => {
+        NodeAssert.equal(req.headers.authorization, "Bearer test");
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({ id: "unit", generation: "generation", phase: "ready", origin }));
+      });
+      await NodeFSP.writeFile(
+        NodePath.join(directory, "runtime.json"),
+        JSON.stringify({ id: "unit", generation: "generation", token: "test", controlUrl: url }),
+      );
+      relay = await uiProxy(directory);
+      const address = `http://127.0.0.1:${relay.port}/api/test`;
+      NodeAssert.equal(await (await fetch(address)).text(), "first");
+      origin = second;
+      NodeAssert.equal(await (await fetch(address)).text(), "second");
+    } finally {
+      if (relay) await relay.close();
+      await Promise.all(
+        servers.map(
+          (s) =>
+            new Promise((r) => {
+              s.closeAllConnections();
+              s.close(r);
+            }),
+        ),
+      );
+      await NodeFSP.rm(directory, { recursive: true, force: true });
+    }
+  },
+);


### PR DESCRIPTION
Browser-only Flow users need chat and brain to start as one unit without remembering ports. Developers need separate test instances without accidentally opening the same database or stopping the primary brain.

This adds a source-checkout installer and a managed `flow` command that starts or reopens the primary app, opens its pairing link, and supports status, stop, and restart. Named development instances support isolated storage, an authenticated shared brain, or a UI-only frontend. Replacement preserves data; fresh mode requires a new name.

The runtime enforces exclusive ownership of application storage, supervises the processes it starts, and checks brain availability before serving chats. Shared-brain instances keep their own project bindings and durable capture queues, while UI-only proxies follow source port changes after replacement. Provider CLI sign-ins remain shared.

Validation:
- 7 focused server tests passed, covering ownership/crash recovery, shared-brain transport and capture replay, native brain integration, and chat context.
- 6 Node tests passed, covering launcher configuration, environment isolation, child cleanup, and proxy behavior.
- Scoped server typecheck, lint, build, and diff checks passed.
- Temporary-instance smoke tests passed for startup, pairing, concurrent reopen, isolated/shared/UI-only modes, replacement, original brain tool calls, and shutdown. All test instances were stopped afterward.

Current scope: macOS/Linux source-checkout installation with a compiled web frontend. The checkout must remain available; standalone release packaging, versioned downloads, update/repair, Windows support, and legacy data migration remain follow-ups. Shared-brain and UI-only modes require their source instance to be running. Shared-brain writes affect the source brain.

Implemented with GPT-6 in Codex.
