### PR TITLE
Highlight graph nodes consulted by chat

### DIFF
--- a/apps/server/src/brain/BrainRuntime.integration.test.ts
+++ b/apps/server/src/brain/BrainRuntime.integration.test.ts
@@ -323,6 +323,9 @@ describe("native brain persistence", () => {
           expect(
             found.content.flatMap((item) => (item.type === "text" ? [item.text] : [])).join("\n"),
           ).toContain("Demo");
+          expect(found._meta?.["flow/nodeIds"]).toEqual(
+            expect.arrayContaining(["repo:octocat/Hello-World"]),
+          );
           const denied = await reopened.callProjectTool(
             project.id,
             "read_query",
@@ -350,7 +353,7 @@ describe("native brain persistence", () => {
             data: { text: "Preserve the complete Flow brain" },
           });
           await reopened.drainCapture();
-          expect(captureState.receipts[0]).toEqual(captureState.receipts[1]);
+          expect(captureState.receipts.at(-2)).toEqual(captureState.receipts.at(-1));
           const memory = await reopened.callProjectTool(
             project.id,
             "search_knowledge",
@@ -364,7 +367,11 @@ describe("native brain persistence", () => {
           await reopened.drain();
           const chatNotes = await reopened.chatMemories(project.id, context.session);
           expect(chatNotes.memories.some((note) => note.text.includes("zebrapotato"))).toBe(true);
+          expect(chatNotes.consultedNodeIds).toContain("repo:octocat/Hello-World");
           expect((await reopened.chatMemories(project.id, "another-chat")).memories).toEqual([]);
+          expect(
+            (await reopened.chatMemories(project.id, "another-chat")).consultedNodeIds,
+          ).toEqual([]);
           expect(chatNotes.revision).toBeTruthy();
           const changed = reopened.chatMemories(project.id, context.session, chatNotes.revision);
           await reopened.callProjectTool(

--- a/apps/server/src/brain/BrainRuntime.ts
+++ b/apps/server/src/brain/BrainRuntime.ts
@@ -49,6 +49,8 @@ const decodeGithubRepositories = Schema.decodeUnknownSync(
     }),
   ),
 );
+const decodeConsultedNodeIds = Schema.decodeUnknownSync(Schema.Array(Schema.String));
+const FLOW_NODE_IDS_META_KEY = "flow/nodeIds";
 const emptyKnowledge = (): BrainKnowledge => ({ entities: [], edges: [], memories: [] });
 const active = (source: Source) =>
   ["queued", "cloning", "indexing", "embedding"].includes(source.status);
@@ -791,7 +793,25 @@ export class BrainRuntime {
     const repo = context.workspaceRoot
       ? await this.sessionRepository(context.workspaceRoot)
       : context.repo;
-    return worker.call(name, args, { ...context, ...(repo ? { repo } : {}) });
+    const resolvedContext = { ...context, ...(repo ? { repo } : {}) };
+    const result = await worker.call(name, args, resolvedContext);
+    if (name === "find_entity") {
+      let nodeIds: ReadonlyArray<string> = [];
+      try {
+        nodeIds = decodeConsultedNodeIds(result._meta?.[FLOW_NODE_IDS_META_KEY] ?? []);
+      } catch {
+        // Activity metadata is optional and must never make a brain lookup fail.
+      }
+      if (nodeIds.length > 0) {
+        await this.captureBrainEvent(workspace.id, {
+          context: resolvedContext,
+          receipt: `graph-${NodeCrypto.randomUUID()}`,
+          kind: "graph",
+          data: { verb: name, nodeIds },
+        }).catch(() => {});
+      }
+    }
+    return result;
   }
   async captureProjectEvent(projectId: ProjectId, input: BrainCapture) {
     const workspace = this.workspaces.find((entry) => entry.id === this.projectBrainId(projectId));

--- a/apps/server/src/brain/shared-runtime.ts
+++ b/apps/server/src/brain/shared-runtime.ts
@@ -35,7 +35,7 @@ const Context = Schema.Struct({
 const Capture = Schema.Struct({
   context: Context,
   receipt: Schema.String,
-  kind: Schema.Literals(["user_prompt", "update", "error", "created"]),
+  kind: Schema.Literals(["user_prompt", "update", "error", "created", "graph"]),
   data: Schema.Unknown,
   closed: Schema.optionalKey(Schema.Boolean),
 });

--- a/apps/web/src/components/brain/BrainGraph.tsx
+++ b/apps/web/src/components/brain/BrainGraph.tsx
@@ -8,23 +8,28 @@ import { Button } from "../ui/button";
 import { XIcon } from "lucide-react";
 
 const colors = ["#d39c38", "#64a58a", "#8296d9", "#b28bc5", "#62a5bb", "#c48180"];
+const noHighlightedNodeIds: readonly string[] = [];
 export function BrainGraph({
   knowledge,
   compact = false,
+  highlightedNodeIds = noHighlightedNodeIds,
 }: {
   knowledge: Pick<BrainKnowledge, "entities" | "edges">;
   compact?: boolean;
+  highlightedNodeIds?: readonly string[];
 }) {
   const host = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<FalkorDBCanvas | null>(null);
   const numericIds = useRef(new Map<string, number>());
   const topology = useRef("");
   const signature = useRef("");
+  const highlightedIds = useRef(new Set<string>());
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [error, setError] = useState("");
   const { theme, resolvedTheme } = useTheme();
   const types = [...new Set(knowledge.entities.map((entry) => entry.kind))].sort();
   const selected = knowledge.entities.find((entry) => entry.id === selectedId);
+  const highlightSignature = [...new Set(highlightedNodeIds)].sort().join("\u0000");
   useEffect(() => {
     let cancelled = false;
     let fitTimer: ReturnType<typeof setTimeout> | undefined;
@@ -45,13 +50,21 @@ export function BrainGraph({
           degree.set(edge.to, (degree.get(edge.to) ?? 0) + 1);
         }
         const nodeTypes = [...new Set(knowledge.entities.map((entry) => entry.kind))].sort();
+        const highlighted = new Set(highlightSignature ? highlightSignature.split("\u0000") : []);
+        const hasHighlights = highlighted.size > 0;
+        highlightedIds.current = highlighted;
         const data = {
           nodes: knowledge.entities.map((entry) => ({
             id: numId(entry.id),
             labels: [entry.kind],
-            color: colors[nodeTypes.indexOf(entry.kind) % colors.length]!,
+            color: highlighted.has(entry.id)
+              ? "#f8cf54"
+              : colors[nodeTypes.indexOf(entry.kind) % colors.length]!,
             visible: true,
-            size: 8 + Math.min(degree.get(entry.id) ?? 0, 20) * 0.8,
+            size:
+              8 +
+              Math.min(degree.get(entry.id) ?? 0, 20) * 0.8 +
+              (highlighted.has(entry.id) ? 4 : 0),
             data: { name: entry.name, displayId: entry.id },
           })),
           links: knowledge.edges.map((edge, i) => ({
@@ -86,16 +99,19 @@ export function BrainGraph({
           captionsKeys: [["name", true]],
           showPropertyKeyPrefix: false,
           nodeStyle: { fontFamily: style.fontFamily },
+          isNodeDimmed: (node: GraphNode) =>
+            hasHighlights && !highlightedIds.current.has(String(node.data?.displayId ?? "")),
           eventHandlers: {
             onNodeClick: (node: GraphNode) => setSelectedId(String(node.data?.displayId ?? "")),
             onBackgroundClick: () => setSelectedId(null),
           },
         });
+        canvas.setDimmed(hasHighlights);
         const nextTopology = JSON.stringify([
           knowledge.entities.map((entry) => entry.id).sort(),
           knowledge.edges,
         ]);
-        const nextSignature = JSON.stringify([knowledge, theme, resolvedTheme]);
+        const nextSignature = JSON.stringify([knowledge, theme, resolvedTheme, highlightSignature]);
         if (firstPaint || topology.current !== nextTopology) canvas.setData(data);
         else if (signature.current !== nextSignature) canvas.setGraphData(data);
         topology.current = nextTopology;
@@ -116,7 +132,7 @@ export function BrainGraph({
       cancelled = true;
       clearTimeout(fitTimer);
     };
-  }, [knowledge, theme, resolvedTheme]);
+  }, [knowledge, theme, resolvedTheme, highlightSignature]);
   useEffect(
     () => () => {
       canvasRef.current?.remove();

--- a/apps/web/src/components/brain/ChatBrainPanel.tsx
+++ b/apps/web/src/components/brain/ChatBrainPanel.tsx
@@ -1,5 +1,5 @@
 import { BrainIcon } from "./BrainIcon";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { BrainResponse, EnvironmentId, ProjectId, ThreadId } from "@t3tools/contracts";
 import {
   BrainCircuitIcon,
@@ -44,6 +44,7 @@ export function ChatBrainPanel({
   const [connecting, setConnecting] = useState(false);
   const [connectionError, setConnectionError] = useState("");
   const [refreshKey, setRefreshKey] = useState(0);
+  const autoExpandedThread = useRef<ThreadId | null>(null);
   async function connectBrain() {
     if (connecting) return;
     setConnecting(true);
@@ -145,6 +146,13 @@ export function ChatBrainPanel({
   const brain = response?.state.workspaces[0];
   const failedSources = brain?.sources.filter((source) => source.status === "error") ?? [];
   const notes = response?.chatMemories;
+  const consultedNodeIds = [...new Set(notes?.consultedNodeIds ?? [])];
+  const consultedNodeCount = consultedNodeIds.length;
+  useEffect(() => {
+    if (consultedNodeCount === 0 || autoExpandedThread.current === threadId) return;
+    autoExpandedThread.current = threadId;
+    setBrainExpanded(true);
+  }, [consultedNodeCount, threadId]);
   const selectedMemory = notes?.memories.find((memory) => view === `memory:${memory.id}`);
   const memoryStatus = !brain
     ? "Connect a brain to save memories."
@@ -218,6 +226,11 @@ export function ChatBrainPanel({
                         {brain?.name ?? "No brain connected"}
                       </span>
                     </span>
+                    {consultedNodeCount > 0 && (
+                      <span className="shrink-0 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
+                        {consultedNodeCount} used
+                      </span>
+                    )}
                     <ChevronDownIcon
                       className={`size-4 shrink-0 text-muted-foreground ${brainExpanded ? "rotate-180" : ""}`}
                     />
@@ -276,12 +289,25 @@ export function ChatBrainPanel({
                         {response.state.database.message}
                       </p>
                     ) : brain?.knowledge.entities.length ? (
-                      <BrainGraph knowledge={brain.knowledge} compact />
+                      <BrainGraph
+                        knowledge={brain.knowledge}
+                        highlightedNodeIds={consultedNodeIds}
+                        compact
+                      />
                     ) : (
                       <p className="p-3 text-xs text-muted-foreground">
                         {brain
                           ? "Index sources to see your knowledge graph."
                           : "Connect a brain above to give this chat shared knowledge."}
+                      </p>
+                    )}
+                    {consultedNodeCount > 0 && (
+                      <p
+                        role="status"
+                        className="border-t border-border/50 px-3 py-2 text-[11px] text-muted-foreground"
+                      >
+                        Highlighting {consultedNodeCount}{" "}
+                        {consultedNodeCount === 1 ? "node" : "nodes"} used by this chat
                       </p>
                     )}
                     <Link
@@ -388,7 +414,7 @@ export function ChatBrainPanel({
           <DialogPanel>
             {view === "brain" ? (
               brain && response?.state.database.status === "ready" ? (
-                <BrainGraph knowledge={brain.knowledge} />
+                <BrainGraph knowledge={brain.knowledge} highlightedNodeIds={consultedNodeIds} />
               ) : (
                 <p className="text-sm text-muted-foreground">The brain is currently unavailable.</p>
               )

--- a/flow-t3/shared/graph-gateway/src/session-mcp.ts
+++ b/flow-t3/shared/graph-gateway/src/session-mcp.ts
@@ -2,6 +2,19 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { callVerb, verbs } from "./verbs.js";
 import { SESSION_VERBS } from "./session-verbs.js";
 
+const FLOW_NODE_IDS_META_KEY = "flow/nodeIds";
+
+function collectNodeIds(value: unknown, ids: Set<string>, depth = 0): void {
+  if (ids.size >= 50 || depth > 6 || value === null || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    for (const item of value) collectNodeIds(item, ids, depth + 1);
+    return;
+  }
+  const id = (value as Record<string, unknown>).id;
+  if (typeof id === "string" && id.length > 0 && id.length < 200) ids.add(id);
+  for (const item of Object.values(value)) collectNodeIds(item, ids, depth + 1);
+}
+
 // One server per HTTP request: no mutable process.env or shared client context.
 // The authenticated endpoint chooses the graph, never the calling agent.
 export function createSessionMcp(context: { graph: string; actor: string }) {
@@ -27,10 +40,14 @@ export function createSessionMcp(context: { graph: string; actor: string }) {
       }
       const result = await callVerb(name, input);
       const isError = typeof result === "object" && result !== null && "status" in result && result.status === "error";
-      return {
+      const nodeIds = new Set<string>();
+      if (name === "find_entity" && !isError) collectNodeIds(result, nodeIds);
+      const response = {
         isError,
         content: [{ type: "text" as const, text: typeof result === "string" ? result : JSON.stringify(result, null, 2) }],
       };
+      if (nodeIds.size === 0) return response;
+      return { ...response, _meta: { [FLOW_NODE_IDS_META_KEY]: [...nodeIds] } };
     });
   }
   return server;

--- a/flow-t3/shared/orchestrator/src/brain-runtime.ts
+++ b/flow-t3/shared/orchestrator/src/brain-runtime.ts
@@ -1,6 +1,6 @@
 // App-owned host for the original Flow brain. No interactive ACP sessions or
 // integration pollers are started here. Database/model ownership stays with T3.
-import { createHash } from "node:crypto";
+import * as NodeCrypto from "node:crypto";
 import { LiveMemoryScheduler } from "./memory/live-scheduler.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
@@ -88,10 +88,33 @@ if (process.argv.includes("--catalog")) {
   });
   const readMemories = (sessionId: string) => {
     const memories = db.prepare(`SELECT id, claim AS text, created_at * 1000 AS createdAt, source_weight AS origin FROM observations WHERE session_id = ? AND id NOT IN (SELECT observation_id FROM chat_memory_retired) ORDER BY created_at, id`).all(sessionId);
+    const allConsultedNodeIds = new Set<string>();
+    const recentConsultedNodeIds = new Set<string>();
+    const recentCutoff = Date.now() - 45_000;
+    const graphRows = db.prepare("SELECT data, ts FROM t3_capture WHERE session = ? AND kind = 'graph' ORDER BY seq DESC LIMIT 100").all(sessionId) as Array<{ data: string; ts: number }>;
+    for (const row of graphRows) {
+      let data: { nodeIds?: unknown };
+      try { data = JSON.parse(row.data) as { nodeIds?: unknown }; }
+      catch { continue; }
+      if (!Array.isArray(data.nodeIds)) continue;
+      for (const id of data.nodeIds) {
+        if (typeof id !== "string" || id.length === 0 || id.length >= 200) continue;
+        if (allConsultedNodeIds.size < 100) allConsultedNodeIds.add(id);
+        if (row.ts >= recentCutoff && recentConsultedNodeIds.size < 100) {
+          recentConsultedNodeIds.add(id);
+        }
+      }
+    }
+    const consultedNodeIds = recentConsultedNodeIds.size > 0
+      ? [...recentConsultedNodeIds]
+      : [...allConsultedNodeIds];
     const pending = db.prepare("SELECT error FROM memory_distill_jobs WHERE session_id = ? AND status = 'pending' LIMIT 1").get(sessionId) as { error: string | null } | undefined;
     const status = process.env.FLOW_DISTILLER === "0" ? "disabled" : pending?.error ? "error" : live.pending(sessionId) || pending ? "extracting" : "idle";
-    const value = { memories, status };
-    return { ...value, revision: createHash("sha256").update(JSON.stringify(value)).digest("hex") };
+    const value = { memories, status, consultedNodeIds };
+    return {
+      ...value,
+      revision: NodeCrypto.createHash("sha256").update(JSON.stringify(value)).digest("hex"),
+    };
   };
   const catalog = await session("catalog");
   process.send?.({ ready: true, tools: (await catalog.client.listTools()).tools });
@@ -113,7 +136,7 @@ if (process.argv.includes("--catalog")) {
       } else if (message.method === "capture") {
         const input = message.params as Parameters<typeof capture>[0];
         const stored = capture(input);
-        if (process.env.FLOW_DISTILLER !== "0") {
+        if (process.env.FLOW_DISTILLER !== "0" && input.kind !== "graph") {
           const data = input.data as { content?: { text?: string }; text?: string; sessionUpdate?: string };
           const text = input.kind === "user_prompt" ? data.text ?? "" : data.sessionUpdate === "agent_message_chunk" ? data.content?.text ?? "" : "";
           live.capture(stored.id, text.length, Boolean(input.closed));

--- a/flow-t3/shared/runtime/src/contracts.ts
+++ b/flow-t3/shared/runtime/src/contracts.ts
@@ -8,7 +8,7 @@ export interface BrainSessionContext {
 export interface BrainCapture {
   context: BrainSessionContext;
   receipt: string;
-  kind: "user_prompt" | "update" | "error" | "created";
+  kind: "user_prompt" | "update" | "error" | "created" | "graph";
   data: unknown;
   closed?: boolean;
 }

--- a/packages/contracts/src/brain.ts
+++ b/packages/contracts/src/brain.ts
@@ -99,6 +99,7 @@ export const BrainState = Schema.Struct({
 export type BrainState = typeof BrainState.Type;
 export const ChatMemoryList = Schema.Struct({
   revision: Schema.optionalKey(Schema.String),
+  consultedNodeIds: Schema.optionalKey(Schema.Array(Schema.String)),
   memories: Schema.Array(
     Schema.Struct({
       id: Schema.String,


### PR DESCRIPTION
## Summary
- attach matched graph node IDs to successful `find_entity` results
- persist consulted nodes per chat with legacy recent/all-session behavior
- highlight, enlarge, and count consulted nodes in the compact and expanded Brain views

## Verification
- `vp test run apps/server/src/brain/BrainRuntime.integration.test.ts`
- contracts, server, and web typechecks
- graph-gateway typecheck and test suite
- shared orchestrator test suite (106 tests)
- focused lint and diff checks

The active Flow instance was not stopped or restarted.