### PR TITLE
feat(clients): show Flow brain consultations

### DIFF
--- a/apps/mobile/src/features/threads/thread-work-log.tsx
+++ b/apps/mobile/src/features/threads/thread-work-log.tsx
@@ -45,6 +45,8 @@ import {
   type ThreadWorkGroupScrollPosition,
 } from "./thread-feed-live-follow";
 import {
+  formatFlowBrainToolCallValue,
+  resolveFlowBrainToolCallDetails,
   resolveWorkEntryToolPresentation,
   type ToolGroupSummaryKind,
   workEntryViewedImagePath,
@@ -336,6 +338,8 @@ function workRowSymbolName(icon: ThreadFeedActivity["icon"]): AppSymbolName {
       return { ios: "exclamationmark.triangle", android: "error" };
     case "browser":
       return { ios: "safari", android: "public" };
+    case "brain":
+      return "brain";
     case "check":
       return { ios: "checkmark", android: "check" };
     case "command":
@@ -734,6 +738,7 @@ const ThreadWorkLogRow = memo(function ThreadWorkLogRow(
   const canExpand = row.canExpand;
   const fullDetail = expanded ? row.getFullDetail() : null;
   const viewedImagePath = workEntryViewedImagePath(row.workEntry);
+  const brainDetails = resolveFlowBrainToolCallDetails(row.workEntry);
   const toolPresentation = resolveWorkEntryToolPresentation(row.workEntry);
   const previewText = workEntryRowLabel(row.workEntry);
   const displayText = workEntryRowLabel(row.workEntry, expanded);
@@ -861,17 +866,69 @@ const ThreadWorkLogRow = memo(function ThreadWorkLogRow(
               {props.renderImage({ href: viewedImagePath, alt: null, title: null })}
             </View>
           ) : null}
-          <ScrollView
-            nestedScrollEnabled
-            directionalLockEnabled
-            showsVerticalScrollIndicator
-            className="max-h-60"
-            contentContainerStyle={{ paddingRight: 8 }}
-          >
-            <Text selectable className="font-mono text-2xs leading-normal text-foreground-muted">
-              {fullDetail}
-            </Text>
-          </ScrollView>
+          {brainDetails ? (
+            <ScrollView
+              nestedScrollEnabled
+              directionalLockEnabled
+              showsVerticalScrollIndicator
+              className="max-h-72"
+              contentContainerStyle={{ paddingRight: 8, gap: 12 }}
+            >
+              <View className="flex-row items-center gap-1.5">
+                <SymbolView
+                  name="brain"
+                  size={12}
+                  tintColor={props.iconSubtleColor}
+                  type="monochrome"
+                />
+                <Text className="font-t3-medium text-xs text-foreground-muted">
+                  Brain consultation
+                </Text>
+                <Text className="ml-auto rounded bg-subtle px-1.5 py-0.5 font-mono text-3xs text-foreground-muted">
+                  {brainDetails.tool}
+                </Text>
+              </View>
+              <View className="gap-1.5">
+                <Text className="font-t3-medium text-3xs uppercase tracking-wider text-foreground-muted opacity-70">
+                  Request
+                </Text>
+                <Text
+                  selectable
+                  className="font-mono text-2xs leading-normal text-foreground-muted"
+                >
+                  {formatFlowBrainToolCallValue(brainDetails.request, "No parameters")}
+                </Text>
+              </View>
+              <View className="gap-1.5 border-t border-adaptive-neutral-300-a60-white-a12 pt-2.5">
+                <Text className="font-t3-medium text-3xs uppercase tracking-wider text-foreground-muted opacity-70">
+                  Response
+                </Text>
+                <Text
+                  selectable
+                  className="font-mono text-2xs leading-normal text-foreground-muted"
+                >
+                  {formatFlowBrainToolCallValue(
+                    brainDetails.response,
+                    row.lifecycleStatus === "inProgress"
+                      ? "Waiting for response…"
+                      : "No response body",
+                  )}
+                </Text>
+              </View>
+            </ScrollView>
+          ) : (
+            <ScrollView
+              nestedScrollEnabled
+              directionalLockEnabled
+              showsVerticalScrollIndicator
+              className="max-h-60"
+              contentContainerStyle={{ paddingRight: 8 }}
+            >
+              <Text selectable className="font-mono text-2xs leading-normal text-foreground-muted">
+                {fullDetail}
+              </Text>
+            </ScrollView>
+          )}
         </Animated.View>
       ) : null}
     </Animated.View>
@@ -886,7 +943,7 @@ export function ThreadWorkGroupToggle(props: {
   readonly iconSubtleColor: import("react-native").ColorValue;
   readonly summary: string;
   readonly summaryKind: ToolGroupSummaryKind;
-  readonly summaryToolIcon?: "browser" | "t3-code";
+  readonly summaryToolIcon?: "brain" | "browser" | "t3-code";
   readonly themeAppearance: "light" | "dark";
   readonly toolSurface?: import("@t3tools/contracts").ToolActivitySurface;
   readonly toolIcon?: ToolActivityIcon;
@@ -1230,6 +1287,8 @@ function toolGroupSummarySymbolName(kind: ToolGroupSummaryKind): AppSymbolName {
       return { ios: "square.and.pencil", android: "edit" };
     case "command":
       return { ios: "terminal", android: "terminal" };
+    case "brain":
+      return "brain";
     case "browser":
     case "search":
       return { ios: "globe", android: "public" };

--- a/apps/mobile/src/lib/threadActivity.test.ts
+++ b/apps/mobile/src/lib/threadActivity.test.ts
@@ -1246,6 +1246,61 @@ describe("buildThreadFeed", () => {
     expect(group.activities[0]?.getFullDetail()).not.toContain("repository.search");
   });
 
+  it("formats Flow MCP request and response details as a brain consultation", () => {
+    const turnId = TurnId.make("turn-brain");
+    const thread = makeThread({
+      id: ThreadId.make("thread-brain"),
+      projectId: ProjectId.make("project-1"),
+      title: "Brain consultation",
+      latestTurn: {
+        turnId,
+        state: "completed",
+        requestedAt: "2026-04-01T00:00:00.000Z",
+        startedAt: "2026-04-01T00:00:01.000Z",
+        completedAt: "2026-04-01T00:00:03.000Z",
+        assistantMessageId: null,
+      },
+      activities: [
+        makeActivity({
+          id: EventId.make("brain-completed"),
+          kind: "tool.completed",
+          tone: "tool",
+          summary: "MCP tool call",
+          createdAt: "2026-04-01T00:00:02.000Z",
+          turnId,
+          payload: {
+            title: "flow-graph · find_entity",
+            itemType: "mcp_tool_call",
+            status: "completed",
+            data: {
+              item: {
+                server: "flow-graph",
+                tool: "find_entity",
+                arguments: { q: "tool activity rendering" },
+                result: { content: '{"status":"ok"}' },
+              },
+            },
+          },
+        }),
+      ],
+    });
+
+    const group = buildThreadFeed(thread)[0];
+    expect(group).toMatchObject({
+      type: "activity-group",
+      activities: [
+        {
+          summary: "Consulted the brain · Find entity",
+          icon: "brain",
+        },
+      ],
+    });
+    if (group?.type !== "activity-group") return;
+    expect(group.activities[0]?.getFullDetail()).toBe(
+      'Brain consultation · Find entity\n\nRequest\n{\n  "q": "tool activity rendering"\n}\n\nResponse\n{\n  "status": "ok"\n}',
+    );
+  });
+
   it.each([
     {
       source: "raw MCP browser identity",

--- a/apps/mobile/src/lib/threadActivity.ts
+++ b/apps/mobile/src/lib/threadActivity.ts
@@ -16,11 +16,13 @@ import {
   commandDetailRepeatsCommand,
   extractCommandOutputText,
   extractWorkLogToolLifecycleStatus,
+  formatFlowBrainToolCallValue,
   isWorktreeSetupActivity,
   liveActivityToolStatus,
   normalizeCompactToolLabel,
   omitSupersededLifecycleMarkers,
   resolveWorkEntryToolPresentation,
+  resolveFlowBrainToolCallDetails,
   summarizeToolGroup,
   toolGroupAction,
   toolGroupSummaryKind,
@@ -56,6 +58,7 @@ export interface ThreadFeedActivity {
     | "agent"
     | "alert"
     | "browser"
+    | "brain"
     | "check"
     | "command"
     | "computer"
@@ -162,7 +165,7 @@ export type ThreadFeedEntry =
       readonly summaryKind: ToolGroupSummaryKind;
       readonly toolSurface?: WorkLogEntry["toolSurface"];
       readonly toolIcon?: WorkLogEntry["toolIcon"];
-      readonly summaryToolIcon?: "browser" | "t3-code";
+      readonly summaryToolIcon?: "brain" | "browser" | "t3-code";
       readonly hasFailure: boolean;
       readonly live: boolean;
       readonly shimmer: boolean;
@@ -922,6 +925,7 @@ function workEntryIcon(entry: DerivedWorkLogEntry): ThreadFeedActivity["icon"] {
     return "message";
   }
   if (entry.sourceActivityKind === "runtime.warning") return "warning";
+  if (resolveWorkEntryToolPresentation(entry)?.icon === "brain") return "brain";
   if (entry.toolSurface) return entry.toolSurface;
   if (entry.requestKind === "command") return "command";
   if (entry.requestKind === "file-read") return "eye";
@@ -942,6 +946,17 @@ function workEntryIcon(entry: DerivedWorkLogEntry): ThreadFeedActivity["icon"] {
 
 function buildWorkEntryExpandedBody(entry: WorkLogEntry): string | null {
   if (entry.agentSpawn) return agentSpawnExpandedBody(entry.agentSpawn);
+  const brainDetails = resolveFlowBrainToolCallDetails(entry);
+  if (brainDetails) {
+    return [
+      `Brain consultation · ${brainDetails.toolLabel}`,
+      `Request\n${formatFlowBrainToolCallValue(brainDetails.request, "No parameters")}`,
+      `Response\n${formatFlowBrainToolCallValue(
+        brainDetails.response,
+        entry.toolLifecycleStatus === "inProgress" ? "Waiting for response…" : "No response body",
+      )}`,
+    ].join("\n\n");
+  }
   const blocks: string[] = [];
   const visibleLabel = workEntryRowLabel(entry, true).trim();
   const appendBlock = (value: string | null | undefined) => {

--- a/apps/server/src/orchestration/ActivityPayloadProjection.test.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.test.ts
@@ -249,6 +249,55 @@ describe("projectActivityPayload", () => {
     expect(JSON.stringify(projected.payload).length).toBeLessThan(500);
   });
 
+  it("preserves the full response payload for Codex-shaped Flow brain calls", () => {
+    const result = {
+      content: [{ type: "text", text: `brain response\n${"x".repeat(5000)}` }],
+      structuredContent: { entities: Array.from({ length: 100 }, (_, index) => ({ index })) },
+    };
+    const projected = projectActivityPayload(
+      activity({
+        itemType: "mcp_tool_call",
+        data: {
+          item: {
+            type: "mcpToolCall",
+            id: "brain-item-1",
+            tool: "find_entity",
+            server: "flow-graph",
+            status: "completed",
+            arguments: { q: "tool activity rendering" },
+            result,
+            _meta: { internal: true },
+          },
+        },
+      }),
+    );
+    const data = (projected.payload as Record<string, unknown>).data as Record<string, unknown>;
+    const item = data.item as Record<string, unknown>;
+
+    expect(item.result).toEqual(result);
+    expect(item._meta).toBeUndefined();
+  });
+
+  it("preserves the full response payload for Flow verbs exposed by t3-code", () => {
+    const result = {
+      type: "tool_result",
+      content: [{ type: "text", text: `orientation\n${"z".repeat(5000)}` }],
+    };
+    const projected = projectActivityPayload(
+      activity({
+        itemType: "mcp_tool_call",
+        data: {
+          toolName: "mcp__t3_code__orient",
+          input: { repo: "flow" },
+          result,
+        },
+      }),
+    );
+    const data = (projected.payload as Record<string, unknown>).data as Record<string, unknown>;
+
+    expect(data.result).toEqual(result);
+  });
+
   it("passes task lifecycle payloads (no data field) through untouched", () => {
     const source = activity({
       taskId: "task-9",

--- a/apps/server/src/orchestration/ActivityPayloadProjection.ts
+++ b/apps/server/src/orchestration/ActivityPayloadProjection.ts
@@ -3,6 +3,7 @@ import type {
   OrchestrationThreadActivity,
   OrchestrationThreadDetailSnapshot,
 } from "@t3tools/contracts";
+import { flowBrainMcpToolNameFromData } from "@t3tools/shared/flowBrainMcp";
 import { isWorkspaceImagePreviewPath } from "@t3tools/shared/filePreview";
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -248,6 +249,7 @@ function summarizeMcpResult(result: unknown): Record<string, unknown> | undefine
  */
 function projectMcpToolCallData(data: Record<string, unknown>): Record<string, unknown> {
   const projectedData: Record<string, unknown> = {};
+  const isFlowBrainCall = flowBrainMcpToolNameFromData(data) !== null;
 
   const item = asRecord(data.item);
   if (item) {
@@ -257,9 +259,13 @@ function projectMcpToolCallData(data: Record<string, unknown>): Record<string, u
         projectedItem[key] = item[key];
       }
     }
-    const result = summarizeMcpResult(item.result);
-    if (result) {
-      projectedItem.result = result;
+    if (isFlowBrainCall && "result" in item) {
+      projectedItem.result = item.result;
+    } else {
+      const result = summarizeMcpResult(item.result);
+      if (result) {
+        projectedItem.result = result;
+      }
     }
     projectedData.item = projectedItem;
   }
@@ -271,9 +277,16 @@ function projectMcpToolCallData(data: Record<string, unknown>): Record<string, u
     projectedData.input = data.input;
   }
   if (!item) {
-    const result = summarizeMcpResult(data.result);
-    if (result) {
-      projectedData.result = result;
+    if (isFlowBrainCall && "result" in data) {
+      projectedData.result = data.result;
+    } else {
+      const result = summarizeMcpResult(data.result);
+      if (result) {
+        projectedData.result = result;
+      }
+    }
+    if (isFlowBrainCall && "error" in data) {
+      projectedData.error = data.error;
     }
   }
 

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -2621,6 +2621,60 @@ describe("deriveMessagesTimelineRows", () => {
     });
   });
 
+  it("surfaces Flow MCP calls as a distinct brain consultation in mixed work", () => {
+    const timelineEntries = [
+      {
+        id: "brain-entry",
+        kind: "work" as const,
+        createdAt: "2026-01-01T00:00:01Z",
+        entry: {
+          id: "brain",
+          createdAt: "2026-01-01T00:00:01Z",
+          label: "MCP tool call",
+          tone: "tool" as const,
+          itemType: "mcp_tool_call" as const,
+          toolLifecycleStatus: "completed" as const,
+          toolData: {
+            server: "flow-graph",
+            tool: "find_entity",
+            arguments: { q: "tool activity rendering" },
+            result: { content: '{"status":"ok"}' },
+          },
+        },
+      },
+      {
+        id: "command-entry",
+        kind: "work" as const,
+        createdAt: "2026-01-01T00:00:02Z",
+        entry: {
+          id: "command",
+          createdAt: "2026-01-01T00:00:02Z",
+          label: "Ran command",
+          tone: "tool" as const,
+          itemType: "command_execution" as const,
+          toolLifecycleStatus: "completed" as const,
+          command: "git status",
+        },
+      },
+    ];
+
+    expect(
+      deriveMessagesTimelineRows({
+        timelineEntries,
+        isWorking: false,
+        activeTurnStartedAt: null,
+        turnDiffSummaries: [],
+        supportsConversationRollback: false,
+      }),
+    ).toMatchObject([
+      {
+        kind: "work-toggle",
+        summary: "Consulted the brain and ran 1 command",
+        summaryKind: "mixed",
+      },
+    ]);
+  });
+
   it("deduplicates integration sources and uses the first source icon for the group", () => {
     const chromeSource = {
       key: "browser-use:chrome",

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -309,7 +309,7 @@ export type MessagesTimelineRow =
       summaryKind: ToolGroupSummaryKind;
       toolSurface?: WorkLogEntry["toolSurface"];
       toolIcon?: WorkLogEntry["toolIcon"];
-      summaryToolIcon?: "browser" | "t3-code";
+      summaryToolIcon?: "brain" | "browser" | "t3-code";
       hasFailure: boolean;
     }
   | {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -10,6 +10,8 @@ import {
 import { parseScopedThreadKey } from "@t3tools/client-runtime/environment";
 import type { CodexArtifactTemplate } from "@t3tools/client-runtime/codex-artifact-templates";
 import {
+  formatFlowBrainToolCallValue,
+  resolveFlowBrainToolCallDetails,
   resolveWorkEntryToolPresentation,
   resolveViewedImageAsset,
   workEntryViewedImagePath,
@@ -2137,6 +2139,8 @@ function toolGroupSummaryIconName(
       return "square-pen";
     case "command":
       return "terminal";
+    case "brain":
+      return "brain";
     case "browser":
       return "browser";
     case "search":
@@ -3000,7 +3004,11 @@ function buildToolCallExpandedBody(
     seen.add(text);
     blocks.push(text);
   };
-  if (workEntry.itemType === "mcp_tool_call" && workEntry.toolData !== undefined) {
+  if (
+    workEntry.itemType === "mcp_tool_call" &&
+    workEntry.toolData !== undefined &&
+    resolveFlowBrainToolCallDetails(workEntry) === null
+  ) {
     addBlock(`MCP call\n${JSON.stringify(workEntry.toolData, null, 2)}`);
   }
   const command = workEntry.command?.trim();
@@ -3036,6 +3044,49 @@ function buildToolCallExpandedBody(
 
 const toolCallExpandedBodyClassName =
   "max-h-64 cursor-text overflow-auto whitespace-pre-wrap break-words font-mono text-secondary-label text-[length:var(--font-size-code,0.6875rem)] leading-relaxed select-text";
+
+function FlowBrainCallExpandedDetails({ workEntry }: { workEntry: TimelineWorkEntry }) {
+  const details = resolveFlowBrainToolCallDetails(workEntry);
+  if (!details) return null;
+  const waiting = workEntry.toolLifecycleStatus === "inProgress";
+
+  return (
+    <div
+      className="mt-1 ms-7 cursor-default overflow-hidden rounded-lg border border-border/60 bg-card/40"
+      onClick={stopRowToggle}
+      onPointerDown={stopRowToggle}
+    >
+      <div className="flex items-center gap-2 border-b border-border/50 px-3 py-2">
+        <BrainIcon aria-hidden className="size-3.5 text-icon-muted" />
+        <span className="text-xs font-medium text-foreground/85">Brain consultation</span>
+        <code className="ml-auto rounded bg-muted/60 px-1.5 py-0.5 text-[.625rem] text-secondary-label">
+          {details.tool}
+        </code>
+      </div>
+      <div className="grid gap-px bg-border/40 sm:grid-cols-2">
+        <section className="min-w-0 bg-background/70 px-3 py-2.5" aria-label="Brain request">
+          <p className="mb-1.5 text-[.625rem] font-medium tracking-[.12em] text-secondary-label/70 uppercase">
+            Request
+          </p>
+          <pre className={toolCallExpandedBodyClassName}>
+            {formatFlowBrainToolCallValue(details.request, "No parameters")}
+          </pre>
+        </section>
+        <section className="min-w-0 bg-background/70 px-3 py-2.5" aria-label="Brain response">
+          <p className="mb-1.5 text-[.625rem] font-medium tracking-[.12em] text-secondary-label/70 uppercase">
+            Response
+          </p>
+          <pre className={toolCallExpandedBodyClassName}>
+            {formatFlowBrainToolCallValue(
+              details.response,
+              waiting ? "Waiting for response…" : "No response body",
+            )}
+          </pre>
+        </section>
+      </div>
+    </div>
+  );
+}
 
 function workEntryIconName(workEntry: TimelineWorkEntry): WorkEntryIconName {
   if (
@@ -3214,6 +3265,7 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
         })
       : null;
   const commandMatchesVisibleLabel = workEntry.command?.trim() === previewText.trim();
+  const brainCallDetails = resolveFlowBrainToolCallDetails(workEntry);
   const canExpand =
     (showFailedIndicator && previewText.trim().length > 0) ||
     (workEntry.itemType === "mcp_tool_call" && workEntry.toolData !== undefined) ||
@@ -3350,7 +3402,9 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
           />
         </div>
       ) : null}
-      {expanded && canExpand && expandedBody ? (
+      {expanded && brainCallDetails ? (
+        <FlowBrainCallExpandedDetails workEntry={workEntry} />
+      ) : expanded && canExpand && expandedBody ? (
         <div
           className="mt-1 ms-7 cursor-default rounded-md bg-muted/40 px-3 py-2"
           onClick={stopRowToggle}

--- a/packages/client-runtime/src/work-log/presentation.test.ts
+++ b/packages/client-runtime/src/work-log/presentation.test.ts
@@ -6,6 +6,8 @@ import { ThreadId } from "@t3tools/contracts";
 import {
   commandDetailRepeatsCommand,
   extractCommandOutputText,
+  formatFlowBrainToolCallValue,
+  resolveFlowBrainToolCallDetails,
   resolveViewedImageAsset,
   resolveWorkEntryToolPresentation,
   summarizeToolGroup,
@@ -329,6 +331,86 @@ describe("resolveWorkEntryToolPresentation", () => {
         toolData: { server: "another-server", tool: "preview_click" },
       }),
     ).toBeNull();
+  });
+});
+
+describe("Flow brain MCP presentation", () => {
+  const brainEntry = {
+    label: "MCP tool call",
+    tone: "tool",
+    itemType: "mcp_tool_call",
+    toolLifecycleStatus: "completed",
+    toolData: {
+      type: "mcpToolCall",
+      server: "flow-graph",
+      tool: "find_entity",
+      arguments: { qs: ["tool activity rendering"] },
+      result: { content: '{"status":"batch","count":1}' },
+    },
+  } satisfies WorkLogPresentationEntry;
+
+  it("presents Flow MCP calls as brain consultations", () => {
+    expect(resolveWorkEntryToolPresentation(brainEntry)).toEqual({
+      displayName: "Consulted the brain · Find entity",
+      icon: "brain",
+    });
+    expect(
+      resolveWorkEntryToolPresentation({ ...brainEntry, toolLifecycleStatus: "inProgress" }),
+    ).toEqual({
+      displayName: "Consulting the brain · Find entity",
+      icon: "brain",
+    });
+    expect(toolGroupAction(brainEntry)).toBe("brain");
+    expect(toolGroupSummaryKind([brainEntry])).toBe("brain");
+  });
+
+  it("recognizes Flow verbs exposed through the t3-code MCP server", () => {
+    expect(
+      resolveWorkEntryToolPresentation({
+        label: "MCP tool call",
+        toolData: { toolName: "mcp__t3_code__orient", input: { repo: "flow" } },
+      }),
+    ).toEqual({
+      displayName: "Consulting the brain · Orient",
+      icon: "brain",
+    });
+    expect(
+      resolveWorkEntryToolPresentation({
+        label: "MCP tool call",
+        toolData: { server: "github", tool: "find_entity" },
+      }),
+    ).toBeNull();
+  });
+
+  it("extracts and formats the request and response without provider metadata", () => {
+    const details = resolveFlowBrainToolCallDetails(brainEntry);
+    expect(details).toEqual({
+      tool: "find_entity",
+      toolLabel: "Find entity",
+      request: { qs: ["tool activity rendering"] },
+      response: '{"status":"batch","count":1}',
+    });
+    expect(formatFlowBrainToolCallValue(details?.request, "No parameters")).toBe(
+      '{\n  "qs": [\n    "tool activity rendering"\n  ]\n}',
+    );
+    expect(formatFlowBrainToolCallValue(details?.response, "No response body")).toBe(
+      '{\n  "status": "batch",\n  "count": 1\n}',
+    );
+  });
+
+  it("counts brain consultations separately from commands and generic tools", () => {
+    expect(
+      summarizeToolGroup([
+        brainEntry,
+        { ...brainEntry, toolCallId: "brain-2" },
+        {
+          label: "Ran command",
+          tone: "tool",
+          itemType: "command_execution",
+          command: "git status",
+        },
+      ]),
+    ).toBe("Consulted the brain 2 times and ran 1 command");
   });
 });
 

--- a/packages/client-runtime/src/work-log/presentation.ts
+++ b/packages/client-runtime/src/work-log/presentation.ts
@@ -10,6 +10,10 @@ import {
 import { classifyMarkdownImageSource } from "@t3tools/client-runtime/markdown-images";
 import { resolveMediaSource } from "@t3tools/client-runtime/media-source";
 import { isWorkspaceImagePreviewPath } from "@t3tools/shared/filePreview";
+import {
+  flowBrainMcpToolNameFromData,
+  flowBrainMcpToolNameFromLabel,
+} from "@t3tools/shared/flowBrainMcp";
 
 export function isWorktreeSetupActivity(kind: string): boolean {
   return kind === "setup-script.requested" || kind === "setup-script.started";
@@ -40,6 +44,7 @@ export type ToolGroupAction =
   | "read"
   | "edit"
   | "command"
+  | "brain"
   | "browser"
   | "code-search"
   | "search"
@@ -99,6 +104,35 @@ const T3_MCP_TOOL_LABELS: Record<
   preview_recording_stop: ["Stop", "Stopping", "Stopped", "recording the preview browser"],
 };
 
+export interface FlowBrainToolCallDetails {
+  readonly tool: string;
+  readonly toolLabel: string;
+  readonly request: unknown;
+  readonly response: unknown;
+}
+
+function flowBrainToolLabel(tool: string): string {
+  const words = tool.replace(/[-_]+/g, " ").trim();
+  return words.length > 0 ? `${words.charAt(0).toUpperCase()}${words.slice(1)}` : "Brain query";
+}
+
+function resolveFlowBrainMcpToolPresentation(tool: string, status: string | undefined) {
+  const verb =
+    status === undefined || status === "inProgress"
+      ? "Consulting the brain"
+      : status === "failed"
+        ? "Couldn't consult the brain"
+        : status === "declined"
+          ? "Declined to consult the brain"
+          : status === "stopped"
+            ? "Stopped consulting the brain"
+            : "Consulted the brain";
+  return {
+    displayName: `${verb} · ${flowBrainToolLabel(tool)}`,
+    icon: "brain" as const,
+  };
+}
+
 function resolveT3McpToolPresentation(value: string | undefined, status: string | undefined) {
   if (!value) return null;
   const name = normalizeCompactToolLabel(value).replace(
@@ -141,6 +175,10 @@ export function resolveWorkEntryToolPresentation(
 ) {
   const status = entry.toolLifecycleStatus ?? fallbackStatus;
   const data = entry.toolData;
+  const structuredBrainTool = flowBrainMcpToolNameFromData(data);
+  if (structuredBrainTool) {
+    return resolveFlowBrainMcpToolPresentation(structuredBrainTool, status);
+  }
   if (data !== null && typeof data === "object") {
     if (
       "server" in data &&
@@ -153,6 +191,15 @@ export function resolveWorkEntryToolPresentation(
     if ("toolName" in data && typeof data.toolName === "string") {
       return resolveT3McpToolPresentation(data.toolName, status);
     }
+  }
+
+  const titledBrainTool = flowBrainMcpToolNameFromLabel(entry.toolTitle);
+  if (titledBrainTool) {
+    return resolveFlowBrainMcpToolPresentation(titledBrainTool, status);
+  }
+  const labeledBrainTool = flowBrainMcpToolNameFromLabel(entry.label);
+  if (labeledBrainTool) {
+    return resolveFlowBrainMcpToolPresentation(labeledBrainTool, status);
   }
 
   return (
@@ -169,6 +216,58 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 
 function nonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function unwrapMcpResult(value: unknown): unknown {
+  const record = asRecord(value);
+  if (!record) return value;
+  const keys = Object.keys(record);
+  return keys.length === 1 && keys[0] === "content" ? record.content : value;
+}
+
+/** Extracts the user-relevant request/response from provider-specific Flow MCP payloads. */
+export function resolveFlowBrainToolCallDetails(
+  entry: Pick<WorkLogPresentationEntry, "label" | "toolTitle" | "toolData" | "detail">,
+): FlowBrainToolCallDetails | null {
+  const data = asRecord(entry.toolData);
+  const item = asRecord(data?.item) ?? data;
+  const tool =
+    flowBrainMcpToolNameFromData(entry.toolData) ??
+    flowBrainMcpToolNameFromLabel(entry.toolTitle) ??
+    flowBrainMcpToolNameFromLabel(entry.label);
+  if (!tool) return null;
+
+  const request = item?.arguments ?? item?.input ?? data?.input;
+  const result = item?.result ?? data?.result;
+  const error = item?.error ?? data?.error;
+  return {
+    tool,
+    toolLabel: flowBrainToolLabel(tool),
+    request,
+    response: unwrapMcpResult(result ?? error ?? entry.detail),
+  };
+}
+
+/** Pretty-prints structured MCP values while leaving prose responses readable. */
+export function formatFlowBrainToolCallValue(value: unknown, emptyLabel: string): string {
+  if (value === undefined || value === null) return emptyLabel;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return emptyLabel;
+    if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+      try {
+        return JSON.stringify(JSON.parse(trimmed), null, 2);
+      } catch {
+        return trimmed;
+      }
+    }
+    return trimmed;
+  }
+  try {
+    return JSON.stringify(value, null, 2) ?? String(value);
+  } catch {
+    return String(value);
+  }
 }
 
 function commandResultContent(value: unknown): string | null {
@@ -411,7 +510,9 @@ export function toolGroupAction(entry: WorkLogPresentationEntry): ToolGroupActio
   ) {
     return "update";
   }
-  if (resolveWorkEntryToolPresentation(entry)?.icon === "browser") return "browser";
+  const toolPresentationIcon = resolveWorkEntryToolPresentation(entry)?.icon;
+  if (toolPresentationIcon === "brain") return "brain";
+  if (toolPresentationIcon === "browser") return "browser";
   if (
     entry.requestKind === "file-read" ||
     entry.itemType === "image_view" ||
@@ -511,6 +612,8 @@ function toolGroupActionLabel(action: ToolGroupAction, count: number): string {
       return `Changed ${count} ${count === 1 ? "file" : "files"}`;
     case "command":
       return `Ran ${count} ${count === 1 ? "command" : "commands"}`;
+    case "brain":
+      return count === 1 ? "Consulted the brain" : `Consulted the brain ${count} times`;
     case "browser":
       return `Used browser ${count} ${count === 1 ? "time" : "times"}`;
     case "search":
@@ -529,11 +632,11 @@ export function summarizeToolGroup(entries: ReadonlyArray<WorkLogPresentationEnt
   const sources = new Map<string, ToolActivitySource>();
   const groupedEntries = new Map<ToolGroupAction, WorkLogPresentationEntry[]>();
   for (const entry of summaryEntries) {
-    if (entry.toolSource) {
+    const action = toolGroupAction(entry);
+    if (entry.toolSource && action !== "brain") {
       sources.set(entry.toolSource.key, entry.toolSource);
       continue;
     }
-    const action = toolGroupAction(entry);
     const group = groupedEntries.get(action);
     if (group) group.push(entry);
     else groupedEntries.set(action, [entry]);

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -79,6 +79,10 @@
       "types": "./src/toolActivity.ts",
       "import": "./src/toolActivity.ts"
     },
+    "./flowBrainMcp": {
+      "types": "./src/flowBrainMcp.ts",
+      "import": "./src/flowBrainMcp.ts"
+    },
     "./favicon": {
       "types": "./src/favicon.ts",
       "import": "./src/favicon.ts"

--- a/packages/shared/src/flowBrainMcp.ts
+++ b/packages/shared/src/flowBrainMcp.ts
@@ -1,0 +1,77 @@
+const FLOW_BRAIN_MCP_TOOLS = new Set([
+  "correct_graph",
+  "find_entity",
+  "get_chat_memories",
+  "get_entity",
+  "list_schema",
+  "orient",
+  "read_query",
+  "remember",
+  "search_knowledge",
+  "source_read",
+  "source_search",
+]);
+
+interface McpToolIdentity {
+  readonly server: string | null;
+  readonly tool: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function normalizeMcpServerName(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function parseMcpToolIdentity(value: string | null): McpToolIdentity | null {
+  if (!value) return null;
+  const normalized = value.replace(/\s+(?:complete|completed)\s*$/i, "").trim();
+  const prefixed = normalized.match(/^mcp__(.+)__([^_].*)$/i);
+  if (prefixed?.[1] && prefixed[2]) {
+    return { server: prefixed[1], tool: prefixed[2].trim().toLowerCase() };
+  }
+
+  const qualified = normalized.match(/^(.+?)(?:\s*·\s*|[.:/])\s*([a-z0-9_-]+)$/i);
+  if (qualified?.[1] && qualified[2]) {
+    return { server: qualified[1], tool: qualified[2].trim().toLowerCase() };
+  }
+
+  const tool = normalized.toLowerCase();
+  return /^[a-z0-9_-]+$/.test(tool) ? { server: null, tool } : null;
+}
+
+function flowBrainToolFromIdentity(identity: McpToolIdentity | null): string | null {
+  if (!identity) return null;
+  const server = identity.server ? normalizeMcpServerName(identity.server) : null;
+  if (server === "flowgraph") return identity.tool;
+  if ((server === null || server === "t3code") && FLOW_BRAIN_MCP_TOOLS.has(identity.tool)) {
+    return identity.tool;
+  }
+  return null;
+}
+
+/** Recognizes a Flow-brain MCP tool from provider-qualified names and labels. */
+export function flowBrainMcpToolNameFromLabel(value: string | null | undefined): string | null {
+  return flowBrainToolFromIdentity(parseMcpToolIdentity(value ?? null));
+}
+
+/** Recognizes Codex (`item.server/tool`) and Claude/OpenCode (`toolName`) MCP payloads. */
+export function flowBrainMcpToolNameFromData(value: unknown): string | null {
+  const data = asRecord(value);
+  if (!data) return null;
+  const item = asRecord(data.item) ?? data;
+  const server = nonEmptyString(item.server);
+  const tool = nonEmptyString(item.tool);
+  if (tool) return flowBrainToolFromIdentity({ server, tool: tool.toLowerCase() });
+  return flowBrainMcpToolNameFromLabel(
+    nonEmptyString(data.toolName) ?? nonEmptyString(item.toolName),
+  );
+}


### PR DESCRIPTION
Flow brain MCP calls currently appear as generic tool activity, which hides how the project brain contributed and ordinary MCP projection can truncate the response.

This adds shared Flow brain tool detection and presentation, preserves full result payloads for Flow calls, and renders dedicated expandable request and response panels on web and mobile. Focused coverage verifies recognition, labels, grouping, UI details, and full-payload projection while keeping ordinary MCP results slim.

Verification:
- 270 focused tests passed across client runtime, server, web, and mobile
- shared, web, mobile, and server typechecks passed
- isolated web instance verified the completed/failed brain consultation presentation and expandable request/response panels
- client-runtime package typecheck remains blocked by three unrelated pre-existing Effect diagnostics in relay/discovery.ts, rpc/session.test.ts, and state/brain.ts

Built with GPT-5.6-Sol via the Codex harness.