### PR TITLE
feat(client): present brain consultations clearly

### DIFF
--- a/apps/mobile/src/features/threads/thread-work-log.tsx
+++ b/apps/mobile/src/features/threads/thread-work-log.tsx
@@ -45,8 +45,9 @@ import {
   type ThreadWorkGroupScrollPosition,
 } from "./thread-feed-live-follow";
 import {
-  formatFlowBrainToolCallValue,
-  resolveFlowBrainToolCallDetails,
+  resolveFlowBrainConsultationDisplay,
+  type FlowBrainDisplayField,
+  type FlowBrainDisplayItem,
   resolveWorkEntryToolPresentation,
   type ToolGroupSummaryKind,
   workEntryViewedImagePath,
@@ -719,6 +720,84 @@ function workLogRowKey(row: ThreadFeedActivity): string {
   return row.id;
 }
 
+function BrainDisplayField({ field }: { readonly field: FlowBrainDisplayField }) {
+  const values = Array.isArray(field.value) ? field.value : null;
+  return (
+    <View className="gap-1">
+      <Text className="font-t3-medium text-3xs uppercase tracking-wider text-foreground-muted opacity-70">
+        {field.label}
+      </Text>
+      {values ? (
+        <View className="flex-row flex-wrap gap-1.5">
+          {values.map((value) => (
+            <View
+              key={value}
+              className="rounded-md border border-adaptive-neutral-300-a60-white-a12 bg-subtle px-2 py-1"
+            >
+              <Text selectable className="text-2xs leading-normal text-foreground-muted">
+                {value}
+              </Text>
+            </View>
+          ))}
+        </View>
+      ) : (
+        <Text
+          selectable
+          className={cn("text-2xs leading-normal text-foreground-muted", field.code && "font-mono")}
+        >
+          {field.value}
+        </Text>
+      )}
+    </View>
+  );
+}
+
+function BrainDisplayItem({ item }: { readonly item: FlowBrainDisplayItem }) {
+  return (
+    <View className="gap-1 rounded-md border border-adaptive-neutral-300-a60-white-a12 bg-subtle/40 px-2.5 py-2">
+      <View className="flex-row flex-wrap items-center gap-x-2 gap-y-0.5">
+        {item.eyebrow ? (
+          <Text className="font-t3-medium text-3xs uppercase tracking-wider text-foreground-muted opacity-70">
+            {item.eyebrow}
+          </Text>
+        ) : null}
+        {item.id ? (
+          <Text selectable className="font-mono text-3xs text-foreground-muted opacity-60">
+            {item.id}
+          </Text>
+        ) : null}
+      </View>
+      <Text selectable className="font-t3-medium text-2xs leading-normal text-foreground">
+        {item.title}
+      </Text>
+      {item.description ? (
+        <Text selectable className="text-2xs leading-normal text-foreground-muted">
+          {item.description}
+        </Text>
+      ) : null}
+      {(item.fields?.length ?? 0) > 0 ? (
+        <View className="mt-1 gap-2 border-t border-adaptive-neutral-300-a60-white-a12 pt-2">
+          {item.fields!.map((field) => (
+            <BrainDisplayField key={field.label} field={field} />
+          ))}
+        </View>
+      ) : null}
+      {(item.tags?.length ?? 0) > 0 ? (
+        <View className="mt-1 flex-row flex-wrap gap-1">
+          {item.tags!.map((tag) => (
+            <Text
+              key={tag}
+              className="rounded bg-subtle px-1.5 py-0.5 text-3xs text-foreground-muted"
+            >
+              {tag}
+            </Text>
+          ))}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
 const ThreadWorkLogRow = memo(function ThreadWorkLogRow(
   props: Omit<
     ThreadWorkLogProps,
@@ -738,7 +817,7 @@ const ThreadWorkLogRow = memo(function ThreadWorkLogRow(
   const canExpand = row.canExpand;
   const fullDetail = expanded ? row.getFullDetail() : null;
   const viewedImagePath = workEntryViewedImagePath(row.workEntry);
-  const brainDetails = resolveFlowBrainToolCallDetails(row.workEntry);
+  const brainDisplay = resolveFlowBrainConsultationDisplay(row.workEntry);
   const toolPresentation = resolveWorkEntryToolPresentation(row.workEntry);
   const previewText = workEntryRowLabel(row.workEntry);
   const displayText = workEntryRowLabel(row.workEntry, expanded);
@@ -866,54 +945,105 @@ const ThreadWorkLogRow = memo(function ThreadWorkLogRow(
               {props.renderImage({ href: viewedImagePath, alt: null, title: null })}
             </View>
           ) : null}
-          {brainDetails ? (
+          {brainDisplay ? (
             <ScrollView
               nestedScrollEnabled
               directionalLockEnabled
               showsVerticalScrollIndicator
-              className="max-h-72"
+              className="max-h-96"
               contentContainerStyle={{ paddingRight: 8, gap: 12 }}
             >
               <View className="flex-row items-center gap-1.5">
-                <SymbolView
-                  name="brain"
-                  size={12}
-                  tintColor={props.iconSubtleColor}
-                  type="monochrome"
-                />
-                <Text className="font-t3-medium text-xs text-foreground-muted">
-                  Brain consultation
-                </Text>
-                <Text className="ml-auto rounded bg-subtle px-1.5 py-0.5 font-mono text-3xs text-foreground-muted">
-                  {brainDetails.tool}
+                <View className="h-6 w-6 items-center justify-center rounded-md bg-adaptive-amber-500-a12-a16">
+                  <SymbolView
+                    name="brain"
+                    size={12}
+                    tintColor={props.iconSubtleColor}
+                    type="monochrome"
+                  />
+                </View>
+                <View className="min-w-0 flex-1">
+                  <Text className="font-t3-medium text-xs text-foreground">Brain consultation</Text>
+                  <Text className="text-3xs text-foreground-muted">{brainDisplay.toolLabel}</Text>
+                </View>
+                <Text className="rounded-full bg-subtle px-2 py-0.5 text-3xs text-foreground-muted">
+                  {brainDisplay.responseSummary}
                 </Text>
               </View>
-              <View className="gap-1.5">
+              <View className="gap-2">
                 <Text className="font-t3-medium text-3xs uppercase tracking-wider text-foreground-muted opacity-70">
                   Request
                 </Text>
-                <Text
-                  selectable
-                  className="font-mono text-2xs leading-normal text-foreground-muted"
-                >
-                  {formatFlowBrainToolCallValue(brainDetails.request, "No parameters")}
-                </Text>
+                {brainDisplay.requestFields.length > 0 ? (
+                  brainDisplay.requestFields.map((field) => (
+                    <BrainDisplayField key={field.label} field={field} />
+                  ))
+                ) : (
+                  <Text className="text-2xs text-foreground-muted">No parameters</Text>
+                )}
               </View>
-              <View className="gap-1.5 border-t border-adaptive-neutral-300-a60-white-a12 pt-2.5">
+              <View className="gap-2.5 border-t border-adaptive-neutral-300-a60-white-a12 pt-2.5">
                 <Text className="font-t3-medium text-3xs uppercase tracking-wider text-foreground-muted opacity-70">
                   Response
                 </Text>
-                <Text
-                  selectable
-                  className="font-mono text-2xs leading-normal text-foreground-muted"
-                >
-                  {formatFlowBrainToolCallValue(
-                    brainDetails.response,
-                    row.lifecycleStatus === "inProgress"
-                      ? "Waiting for response…"
-                      : "No response body",
-                  )}
-                </Text>
+                {brainDisplay.responseSections.length > 0 ? (
+                  brainDisplay.responseSections.map((section) => (
+                    <View
+                      key={section.title}
+                      className="gap-2 rounded-lg border border-adaptive-neutral-300-a60-white-a12 px-2.5 py-2"
+                    >
+                      <View className="flex-row items-baseline gap-2">
+                        <Text className="min-w-0 flex-1 font-t3-medium text-2xs text-foreground">
+                          {section.title}
+                        </Text>
+                        {section.subtitle ? (
+                          <Text className="text-3xs text-foreground-muted">{section.subtitle}</Text>
+                        ) : null}
+                      </View>
+                      {section.text ? (
+                        <Text
+                          selectable
+                          className={cn(
+                            "text-2xs leading-normal text-foreground-muted",
+                            section.code && "font-mono",
+                          )}
+                        >
+                          {section.text}
+                        </Text>
+                      ) : null}
+                      {(section.fields?.length ?? 0) > 0
+                        ? section.fields!.map((field) => (
+                            <BrainDisplayField key={field.label} field={field} />
+                          ))
+                        : null}
+                      {(section.tags?.length ?? 0) > 0 ? (
+                        <View className="flex-row flex-wrap gap-1.5">
+                          {section.tags!.map((tag) => (
+                            <Text
+                              key={tag}
+                              className="rounded-md bg-subtle px-2 py-1 font-mono text-3xs text-foreground-muted"
+                            >
+                              {tag}
+                            </Text>
+                          ))}
+                        </View>
+                      ) : null}
+                      {(section.items?.length ?? 0) > 0 ? (
+                        <View className="gap-1.5">
+                          {section.items!.map((item) => (
+                            <BrainDisplayItem key={item.id ?? item.title} item={item} />
+                          ))}
+                        </View>
+                      ) : section.text || section.fields?.length || section.tags?.length ? null : (
+                        <Text className="text-2xs text-foreground-muted">No results</Text>
+                      )}
+                    </View>
+                  ))
+                ) : (
+                  <Text className="text-2xs text-foreground-muted">
+                    {brainDisplay.responseSummary}
+                  </Text>
+                )}
               </View>
             </ScrollView>
           ) : (

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -10,8 +10,9 @@ import {
 import { parseScopedThreadKey } from "@t3tools/client-runtime/environment";
 import type { CodexArtifactTemplate } from "@t3tools/client-runtime/codex-artifact-templates";
 import {
-  formatFlowBrainToolCallValue,
-  resolveFlowBrainToolCallDetails,
+  resolveFlowBrainConsultationDisplay,
+  type FlowBrainDisplayField,
+  type FlowBrainDisplayItem,
   resolveWorkEntryToolPresentation,
   resolveViewedImageAsset,
   workEntryViewedImagePath,
@@ -3007,7 +3008,7 @@ function buildToolCallExpandedBody(
   if (
     workEntry.itemType === "mcp_tool_call" &&
     workEntry.toolData !== undefined &&
-    resolveFlowBrainToolCallDetails(workEntry) === null
+    resolveFlowBrainConsultationDisplay(workEntry) === null
   ) {
     addBlock(`MCP call\n${JSON.stringify(workEntry.toolData, null, 2)}`);
   }
@@ -3045,10 +3046,93 @@ function buildToolCallExpandedBody(
 const toolCallExpandedBodyClassName =
   "max-h-64 cursor-text overflow-auto whitespace-pre-wrap break-words font-mono text-secondary-label text-[length:var(--font-size-code,0.6875rem)] leading-relaxed select-text";
 
+function FlowBrainField({ field }: { field: FlowBrainDisplayField }) {
+  const values = Array.isArray(field.value) ? field.value : null;
+  return (
+    <div className="min-w-0">
+      <p className="mb-1 text-[.625rem] font-medium tracking-[.1em] text-secondary-label/65 uppercase">
+        {field.label}
+      </p>
+      {values ? (
+        <div className="flex flex-wrap gap-1.5">
+          {values.map((value) => (
+            <span
+              key={value}
+              className="rounded-md border border-border/50 bg-muted/35 px-2 py-1 text-xs leading-snug text-foreground/85"
+            >
+              {value}
+            </span>
+          ))}
+        </div>
+      ) : field.code ? (
+        <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded-md bg-muted/35 px-2.5 py-2 font-mono text-[.6875rem] leading-relaxed text-secondary-label select-text">
+          {field.value}
+        </pre>
+      ) : (
+        <p className="whitespace-pre-wrap break-words text-xs leading-relaxed text-foreground/85 select-text">
+          {field.value}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function FlowBrainItem({ item }: { item: FlowBrainDisplayItem }) {
+  return (
+    <article
+      className={cn(
+        "rounded-md border px-2.5 py-2",
+        item.tone === "danger"
+          ? "border-destructive/25 bg-destructive/5"
+          : item.tone === "warning"
+            ? "border-warning/25 bg-warning/5"
+            : "border-border/45 bg-background/55",
+      )}
+    >
+      <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+        {item.eyebrow ? (
+          <span className="text-[.625rem] font-medium tracking-[.08em] text-secondary-label/70 uppercase">
+            {item.eyebrow}
+          </span>
+        ) : null}
+        {item.id ? (
+          <code className="truncate text-[.625rem] text-secondary-label/60">{item.id}</code>
+        ) : null}
+      </div>
+      <p className="mt-0.5 whitespace-pre-wrap break-words text-xs font-medium leading-relaxed text-foreground/90 select-text">
+        {item.title}
+      </p>
+      {item.description ? (
+        <p className="mt-1 whitespace-pre-wrap break-words text-[.6875rem] leading-relaxed text-secondary-label select-text">
+          {item.description}
+        </p>
+      ) : null}
+      {(item.fields?.length ?? 0) > 0 ? (
+        <div className="mt-2 grid gap-2 border-t border-border/35 pt-2 sm:grid-cols-2">
+          {item.fields!.map((field) => (
+            <FlowBrainField key={field.label} field={field} />
+          ))}
+        </div>
+      ) : null}
+      {(item.tags?.length ?? 0) > 0 ? (
+        <div className="mt-2 flex flex-wrap gap-1">
+          {item.tags!.map((tag) => (
+            <span
+              key={tag}
+              className="rounded bg-muted/50 px-1.5 py-0.5 text-[.625rem] text-secondary-label"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
 function FlowBrainCallExpandedDetails({ workEntry }: { workEntry: TimelineWorkEntry }) {
-  const details = resolveFlowBrainToolCallDetails(workEntry);
-  if (!details) return null;
-  const waiting = workEntry.toolLifecycleStatus === "inProgress";
+  const display = resolveFlowBrainConsultationDisplay(workEntry);
+  if (!display) return null;
 
   return (
     <div
@@ -3056,32 +3140,109 @@ function FlowBrainCallExpandedDetails({ workEntry }: { workEntry: TimelineWorkEn
       onClick={stopRowToggle}
       onPointerDown={stopRowToggle}
     >
-      <div className="flex items-center gap-2 border-b border-border/50 px-3 py-2">
-        <BrainIcon aria-hidden className="size-3.5 text-icon-muted" />
-        <span className="text-xs font-medium text-foreground/85">Brain consultation</span>
-        <code className="ml-auto rounded bg-muted/60 px-1.5 py-0.5 text-[.625rem] text-secondary-label">
-          {details.tool}
-        </code>
+      <div className="flex items-center gap-2 border-b border-border/50 px-3 py-2.5">
+        <span className="flex size-6 items-center justify-center rounded-md bg-warning/10 text-warning">
+          <BrainIcon aria-hidden className="size-3.5" />
+        </span>
+        <div className="min-w-0">
+          <p className="text-xs font-medium text-foreground/90">Brain consultation</p>
+          <p className="text-[.625rem] text-secondary-label">{display.toolLabel}</p>
+        </div>
+        <span className="ml-auto rounded-full border border-border/50 bg-muted/35 px-2 py-0.5 text-[.625rem] text-secondary-label">
+          {display.responseSummary}
+        </span>
       </div>
-      <div className="grid gap-px bg-border/40 sm:grid-cols-2">
-        <section className="min-w-0 bg-background/70 px-3 py-2.5" aria-label="Brain request">
-          <p className="mb-1.5 text-[.625rem] font-medium tracking-[.12em] text-secondary-label/70 uppercase">
+      <div className="max-h-[32rem] overflow-y-auto bg-background/45">
+        <section className="min-w-0 px-3 py-3" aria-label="Brain request">
+          <p className="mb-2 text-[.625rem] font-medium tracking-[.12em] text-secondary-label/70 uppercase">
             Request
           </p>
-          <pre className={toolCallExpandedBodyClassName}>
-            {formatFlowBrainToolCallValue(details.request, "No parameters")}
-          </pre>
+          {display.requestFields.length > 0 ? (
+            <div className="grid gap-2.5 sm:grid-cols-2">
+              {display.requestFields.map((field) => (
+                <FlowBrainField key={field.label} field={field} />
+              ))}
+            </div>
+          ) : (
+            <p className="text-xs text-secondary-label">No parameters</p>
+          )}
         </section>
-        <section className="min-w-0 bg-background/70 px-3 py-2.5" aria-label="Brain response">
-          <p className="mb-1.5 text-[.625rem] font-medium tracking-[.12em] text-secondary-label/70 uppercase">
-            Response
-          </p>
-          <pre className={toolCallExpandedBodyClassName}>
-            {formatFlowBrainToolCallValue(
-              details.response,
-              waiting ? "Waiting for response…" : "No response body",
-            )}
-          </pre>
+        <section
+          className="min-w-0 border-t border-border/45 px-3 py-3"
+          aria-label="Brain response"
+        >
+          <div className="mb-2 flex items-center gap-2">
+            <p className="text-[.625rem] font-medium tracking-[.12em] text-secondary-label/70 uppercase">
+              Response
+            </p>
+            <span className="h-px flex-1 bg-border/35" />
+          </div>
+          {display.responseSections.length > 0 ? (
+            <div className="space-y-2.5">
+              {display.responseSections.map((section) => (
+                <div
+                  key={section.title}
+                  className={cn(
+                    "rounded-lg border border-border/45 bg-card/30 p-2.5",
+                    section.tone === "danger" && "border-destructive/25 bg-destructive/5",
+                    section.tone === "warning" && "border-warning/25 bg-warning/5",
+                  )}
+                >
+                  <div className="flex min-w-0 items-baseline gap-2">
+                    <h4 className="min-w-0 flex-1 truncate text-xs font-medium text-foreground/90">
+                      {section.title}
+                    </h4>
+                    {section.subtitle ? (
+                      <span className="shrink-0 text-[.625rem] text-secondary-label/65">
+                        {section.subtitle}
+                      </span>
+                    ) : null}
+                  </div>
+                  {section.text ? (
+                    section.code ? (
+                      <pre className="mt-2 overflow-x-auto whitespace-pre font-mono text-[.6875rem] leading-relaxed text-secondary-label select-text">
+                        {section.text}
+                      </pre>
+                    ) : (
+                      <p className="mt-1.5 whitespace-pre-wrap break-words text-[.6875rem] leading-relaxed text-secondary-label select-text">
+                        {section.text}
+                      </p>
+                    )
+                  ) : null}
+                  {(section.fields?.length ?? 0) > 0 ? (
+                    <div className="mt-2 grid gap-2.5 sm:grid-cols-2">
+                      {section.fields!.map((field) => (
+                        <FlowBrainField key={field.label} field={field} />
+                      ))}
+                    </div>
+                  ) : null}
+                  {(section.tags?.length ?? 0) > 0 ? (
+                    <div className="mt-2 flex flex-wrap gap-1.5">
+                      {section.tags!.map((tag) => (
+                        <span
+                          key={tag}
+                          className="rounded-md border border-border/45 bg-muted/35 px-2 py-1 font-mono text-[.625rem] text-secondary-label"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  ) : null}
+                  {(section.items?.length ?? 0) > 0 ? (
+                    <div className="mt-2 grid gap-1.5">
+                      {section.items!.map((item) => (
+                        <FlowBrainItem key={item.id ?? item.title} item={item} />
+                      ))}
+                    </div>
+                  ) : section.text || section.fields?.length || section.tags?.length ? null : (
+                    <p className="mt-1.5 text-[.6875rem] text-secondary-label">No results</p>
+                  )}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-xs text-secondary-label">{display.responseSummary}</p>
+          )}
         </section>
       </div>
     </div>
@@ -3265,7 +3426,7 @@ const PlainWorkEntryRow = memo(function PlainWorkEntryRow(props: {
         })
       : null;
   const commandMatchesVisibleLabel = workEntry.command?.trim() === previewText.trim();
-  const brainCallDetails = resolveFlowBrainToolCallDetails(workEntry);
+  const brainCallDetails = resolveFlowBrainConsultationDisplay(workEntry);
   const canExpand =
     (showFailedIndicator && previewText.trim().length > 0) ||
     (workEntry.itemType === "mcp_tool_call" && workEntry.toolData !== undefined) ||

--- a/packages/client-runtime/src/work-log/presentation.test.ts
+++ b/packages/client-runtime/src/work-log/presentation.test.ts
@@ -7,6 +7,7 @@ import {
   commandDetailRepeatsCommand,
   extractCommandOutputText,
   formatFlowBrainToolCallValue,
+  resolveFlowBrainConsultationDisplay,
   resolveFlowBrainToolCallDetails,
   resolveViewedImageAsset,
   resolveWorkEntryToolPresentation,
@@ -388,7 +389,7 @@ describe("Flow brain MCP presentation", () => {
       tool: "find_entity",
       toolLabel: "Find entity",
       request: { qs: ["tool activity rendering"] },
-      response: '{"status":"batch","count":1}',
+      response: { status: "batch", count: 1 },
     });
     expect(formatFlowBrainToolCallValue(details?.request, "No parameters")).toBe(
       '{\n  "qs": [\n    "tool activity rendering"\n  ]\n}',
@@ -396,6 +397,144 @@ describe("Flow brain MCP presentation", () => {
     expect(formatFlowBrainToolCallValue(details?.response, "No response body")).toBe(
       '{\n  "status": "batch",\n  "count": 1\n}',
     );
+  });
+
+  it("falls back to text content when MCP structured content is null", () => {
+    const details = resolveFlowBrainToolCallDetails({
+      ...brainEntry,
+      toolData: {
+        type: "mcpToolCall",
+        server: "flow-graph",
+        tool: "orient",
+        arguments: { repo: "flow" },
+        result: {
+          _meta: null,
+          content: [
+            {
+              type: "text",
+              text: 'CONNECTED PROJECT: "Flow"\n[flow orient — repo "flow" @ main-v2]',
+            },
+          ],
+          structuredContent: null,
+        },
+      },
+    });
+
+    expect(details?.response).toBe(
+      'CONNECTED PROJECT: "Flow"\n[flow orient — repo "flow" @ main-v2]',
+    );
+  });
+
+  it("projects batched entity searches into query groups and readable result cards", () => {
+    const display = resolveFlowBrainConsultationDisplay({
+      ...brainEntry,
+      toolData: {
+        ...brainEntry.toolData,
+        arguments: { qs: ["auth middleware", "personal access tokens"], limit: 5 },
+        result: {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                status: "batch",
+                count: 2,
+                groups: [
+                  {
+                    query: "auth middleware",
+                    status: "similar",
+                    matches: [
+                      {
+                        type: "Handler",
+                        id: "handler:auth",
+                        name: "Authentication middleware",
+                        description: "Checks the session before routing.",
+                        anchor: "apps/server/src/auth.ts:12",
+                        via: "vector",
+                      },
+                    ],
+                    memory_hits: [
+                      "[Memory:decision] Sessions are checked on every request. (strong) [mem:abc]",
+                    ],
+                  },
+                  {
+                    query: "personal access tokens",
+                    status: "none",
+                    matches: [],
+                  },
+                ],
+              }),
+            },
+          ],
+        },
+      },
+    });
+
+    expect(display).toMatchObject({
+      toolLabel: "Find entity",
+      requestFields: [
+        { label: "Queries", value: ["auth middleware", "personal access tokens"] },
+        { label: "Result limit", value: "5" },
+      ],
+      responseSummary: "1 entity · 1 memory · 2 queries",
+      responseSections: [
+        {
+          title: "auth middleware",
+          subtitle: "Similar",
+          items: [
+            {
+              eyebrow: "Handler",
+              title: "Authentication middleware",
+              id: "handler:auth",
+              description: "Checks the session before routing.",
+              fields: [{ label: "Code", value: "apps/server/src/auth.ts:12", code: true }],
+              tags: ["Semantic match"],
+            },
+            {
+              eyebrow: "Memory · Decision · Strong",
+              title: "Sessions are checked on every request.",
+              id: "mem:abc",
+            },
+          ],
+        },
+        { title: "personal access tokens", subtitle: "None", items: [] },
+      ],
+    });
+  });
+
+  it("turns knowledge-search prose into one card per memory", () => {
+    const display = resolveFlowBrainConsultationDisplay({
+      ...brainEntry,
+      toolData: {
+        server: "flow-graph",
+        tool: "search_knowledge",
+        arguments: { query: "auth sessions" },
+        result: {
+          content: JSON.stringify({
+            status: "ok",
+            results:
+              "MEMORY:\n- Auth uses signed cookies. [decision/strong] (memory 123)\n- Local mode is open. [gotcha/medium] (memory 456)",
+          }),
+        },
+      },
+    });
+
+    expect(display).toMatchObject({
+      requestFields: [{ label: "Query", value: "auth sessions" }],
+      responseSummary: "2 memories",
+      responseSections: [
+        {
+          title: "Matches",
+          items: [
+            {
+              eyebrow: "Memory · Decision · Strong",
+              title: "Auth uses signed cookies.",
+              id: "123",
+            },
+            { eyebrow: "Memory · Gotcha · Medium", title: "Local mode is open.", id: "456" },
+          ],
+        },
+      ],
+    });
   });
 
   it("counts brain consultations separately from commands and generic tools", () => {

--- a/packages/client-runtime/src/work-log/presentation.ts
+++ b/packages/client-runtime/src/work-log/presentation.ts
@@ -111,6 +111,41 @@ export interface FlowBrainToolCallDetails {
   readonly response: unknown;
 }
 
+export interface FlowBrainDisplayField {
+  readonly label: string;
+  readonly value: string | ReadonlyArray<string>;
+  readonly code?: boolean;
+}
+
+export interface FlowBrainDisplayItem {
+  readonly title: string;
+  readonly eyebrow?: string;
+  readonly id?: string;
+  readonly description?: string;
+  readonly fields?: ReadonlyArray<FlowBrainDisplayField>;
+  readonly tags?: ReadonlyArray<string>;
+  readonly tone?: "default" | "muted" | "warning" | "danger";
+}
+
+export interface FlowBrainDisplaySection {
+  readonly title: string;
+  readonly subtitle?: string;
+  readonly items?: ReadonlyArray<FlowBrainDisplayItem>;
+  readonly fields?: ReadonlyArray<FlowBrainDisplayField>;
+  readonly tags?: ReadonlyArray<string>;
+  readonly text?: string;
+  readonly code?: boolean;
+  readonly tone?: "default" | "muted" | "warning" | "danger";
+}
+
+export interface FlowBrainConsultationDisplay {
+  readonly tool: string;
+  readonly toolLabel: string;
+  readonly requestFields: ReadonlyArray<FlowBrainDisplayField>;
+  readonly responseSummary: string;
+  readonly responseSections: ReadonlyArray<FlowBrainDisplaySection>;
+}
+
 function flowBrainToolLabel(tool: string): string {
   const words = tool.replace(/[-_]+/g, " ").trim();
   return words.length > 0 ? `${words.charAt(0).toUpperCase()}${words.slice(1)}` : "Brain query";
@@ -218,11 +253,50 @@ function nonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
 }
 
+function parseJsonValue(value: string): unknown {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return value;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return value;
+  }
+}
+
 function unwrapMcpResult(value: unknown): unknown {
-  const record = asRecord(value);
-  if (!record) return value;
-  const keys = Object.keys(record);
-  return keys.length === 1 && keys[0] === "content" ? record.content : value;
+  let current = value;
+  for (let depth = 0; depth < 4; depth += 1) {
+    if (typeof current === "string") {
+      const parsed = parseJsonValue(current);
+      if (parsed === current) return current;
+      current = parsed;
+      continue;
+    }
+    if (Array.isArray(current)) {
+      const text = current
+        .map((entry) => nonEmptyString(asRecord(entry)?.text))
+        .filter((entry): entry is string => entry !== null);
+      if (text.length !== current.length || text.length === 0) return current;
+      current = text.join("\n");
+      continue;
+    }
+    const record = asRecord(current);
+    if (!record) return current;
+    if (record.structuredContent !== undefined && record.structuredContent !== null) {
+      current = record.structuredContent;
+      continue;
+    }
+    const keys = Object.keys(record);
+    const looksLikeMcpResult = keys.every((key) =>
+      ["content", "isError", "_meta", "structuredContent"].includes(key),
+    );
+    if (looksLikeMcpResult && record.content !== undefined) {
+      current = record.content;
+      continue;
+    }
+    return current;
+  }
+  return current;
 }
 
 /** Extracts the user-relevant request/response from provider-specific Flow MCP payloads. */
@@ -268,6 +342,478 @@ export function formatFlowBrainToolCallValue(value: unknown, emptyLabel: string)
   } catch {
     return String(value);
   }
+}
+
+const FLOW_BRAIN_FIELD_LABELS: Readonly<Record<string, string>> = {
+  q: "Query",
+  qs: "Queries",
+  query: "Query",
+  queries: "Queries",
+  id: "Entity",
+  ids: "Entities",
+  type: "Entity type",
+  graph: "Graph",
+  repo: "Repository",
+  branch: "Branch",
+  path: "File",
+  revision: "Revision",
+  start_line: "Start line",
+  end_line: "End line",
+  limit: "Result limit",
+  cypher: "Graph query",
+  text: "Memory",
+  target_ids: "Entities",
+  reason: "Reason",
+  evidence: "Evidence",
+};
+
+function titleCase(value: string): string {
+  const words = value.replace(/[-_]+/g, " ").trim();
+  return words ? `${words.charAt(0).toUpperCase()}${words.slice(1)}` : value;
+}
+
+function displayField(key: string, value: unknown): FlowBrainDisplayField | null {
+  if (value === undefined || value === null || value === "") return null;
+  const label = FLOW_BRAIN_FIELD_LABELS[key] ?? titleCase(key);
+  if (
+    Array.isArray(value) &&
+    value.every((entry) => ["string", "number", "boolean"].includes(typeof entry))
+  ) {
+    return { label, value: value.map(String) };
+  }
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return {
+      label,
+      value: String(value),
+      ...(key === "cypher" || key === "path" || key === "revision" || key === "evidence"
+        ? { code: true }
+        : {}),
+    };
+  }
+  return { label, value: formatFlowBrainToolCallValue(value, ""), code: true };
+}
+
+function displayFields(value: unknown, excluded = new Set<string>()): FlowBrainDisplayField[] {
+  const record = asRecord(value);
+  if (!record) return value === undefined ? [] : [{ label: "Value", value: String(value) }];
+  return Object.entries(record).flatMap(([key, entry]) => {
+    if (excluded.has(key)) return [];
+    const field = displayField(key, entry);
+    return field ? [field] : [];
+  });
+}
+
+function strings(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.flatMap((entry) => (nonEmptyString(entry) ? [String(entry)] : []))
+    : [];
+}
+
+function records(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value)
+    ? value.flatMap((entry) => {
+        const record = asRecord(entry);
+        return record ? [record] : [];
+      })
+    : [];
+}
+
+function compactCount(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function memoryLineItem(line: string): FlowBrainDisplayItem {
+  const findEntity = line.match(
+    /^\[Memory:([^\]]+)\]\s+([\s\S]*?)\s+\(([^)]+)\)\s+\[mem:([^\]]+)\]$/i,
+  );
+  if (findEntity) {
+    return {
+      eyebrow: `Memory · ${titleCase(findEntity[1]!)} · ${titleCase(findEntity[3]!)}`,
+      title: findEntity[2]!,
+      id: `mem:${findEntity[4]}`,
+    };
+  }
+  const searchMemory = line.match(
+    /^[-•]\s+([\s\S]*?)\s+\[([^/\]]+)\/([^\]]+)\]\s+\((?:memory|ticket|thread)\s+([^)]+)\)$/i,
+  );
+  if (searchMemory) {
+    return {
+      eyebrow: `Memory · ${titleCase(searchMemory[2]!)} · ${titleCase(searchMemory[3]!)}`,
+      title: searchMemory[1]!,
+      id: searchMemory[4]!,
+    };
+  }
+  return { eyebrow: "Memory", title: line.replace(/^[-•]\s+/, "") };
+}
+
+function entityItem(value: unknown): FlowBrainDisplayItem {
+  const record = asRecord(value) ?? {};
+  const props = asRecord(record.props) ?? record;
+  const id = nonEmptyString(record.id) ?? nonEmptyString(props.id) ?? undefined;
+  const name = nonEmptyString(record.name) ?? nonEmptyString(props.name);
+  const type = nonEmptyString(record.type) ?? nonEmptyString(props.type);
+  const note = nonEmptyString(record.note);
+  const anchor = nonEmptyString(record.anchor) ?? nonEmptyString(props.anchor);
+  const evidence = nonEmptyString(props.evidence);
+  const via = nonEmptyString(record.via);
+  return {
+    title: name ?? id ?? "Unnamed entity",
+    ...(type ? { eyebrow: titleCase(type) } : {}),
+    ...(name && id ? { id } : {}),
+    ...((nonEmptyString(record.description) ?? nonEmptyString(props.description) ?? note)
+      ? {
+          description:
+            nonEmptyString(record.description) ?? nonEmptyString(props.description) ?? note!,
+        }
+      : {}),
+    ...(anchor || evidence
+      ? {
+          fields: [
+            ...(anchor ? [{ label: "Code", value: anchor, code: true as const }] : []),
+            ...(evidence ? [{ label: "Evidence", value: evidence, code: true as const }] : []),
+          ],
+        }
+      : {}),
+    ...(via ? { tags: [via === "vector" ? "Semantic match" : "Exact text match"] } : {}),
+    ...(note ? { tone: "muted" as const } : {}),
+  };
+}
+
+function findEntityDisplay(
+  response: Record<string, unknown>,
+  request: Record<string, unknown> | null,
+): Pick<FlowBrainConsultationDisplay, "responseSummary" | "responseSections"> {
+  const groups = response.status === "batch" ? records(response.groups) : [response];
+  let entityCount = 0;
+  let memoryCount = 0;
+  const sections = groups.map((group, index): FlowBrainDisplaySection => {
+    const matches = Array.isArray(group.matches) ? group.matches : [];
+    const memoryHits = strings(group.memory_hits);
+    entityCount += matches.length;
+    memoryCount += memoryHits.length;
+    const requestQueries = strings(request?.qs);
+    const query =
+      nonEmptyString(group.query) ??
+      nonEmptyString(request?.q) ??
+      requestQueries[index] ??
+      "Entity lookup";
+    const status = nonEmptyString(group.status);
+    const error = nonEmptyString(group.error);
+    const warning = nonEmptyString(group.warning);
+    return {
+      title: query,
+      ...(status ? { subtitle: titleCase(status) } : {}),
+      items: [...matches.map(entityItem), ...memoryHits.map(memoryLineItem)],
+      ...(error || warning ? { text: error ?? warning!, tone: error ? "danger" : "warning" } : {}),
+    };
+  });
+  const counts = [
+    compactCount(entityCount, "entity", "entities"),
+    ...(memoryCount > 0 ? [compactCount(memoryCount, "memory", "memories")] : []),
+    ...(groups.length > 1 ? [compactCount(groups.length, "query", "queries")] : []),
+  ];
+  return { responseSummary: counts.join(" · "), responseSections: sections };
+}
+
+function parseKnowledgeSearch(text: string): FlowBrainDisplaySection[] {
+  const sections: Array<{ title: string; items: FlowBrainDisplayItem[]; lines: string[] }> = [];
+  let current = { title: "Matches", items: [] as FlowBrainDisplayItem[], lines: [] as string[] };
+  let category = "Memory";
+  const flush = () => {
+    if (current.items.length > 0 || current.lines.length > 0) sections.push(current);
+  };
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.trim();
+    const queryHeading = line.match(/^===\s+q\d+:\s*([\s\S]*?)\s*===$/i);
+    if (queryHeading) {
+      flush();
+      current = { title: queryHeading[1]!, items: [], lines: [] };
+      category = "Memory";
+      continue;
+    }
+    if (/^[A-Z][A-Z /_-]+:$/.test(line)) {
+      category = titleCase(line.slice(0, -1).toLowerCase());
+      continue;
+    }
+    if (/^[-•]\s+/.test(line)) {
+      const item = memoryLineItem(line);
+      current.items.push({
+        ...item,
+        ...(item.eyebrow ? { eyebrow: item.eyebrow.replace(/^Memory/, category) } : {}),
+      });
+    } else if (line) {
+      current.lines.push(line);
+    }
+  }
+  flush();
+  return sections.map((section) => ({
+    title: section.title,
+    ...(section.items.length > 0 ? { items: section.items } : {}),
+    ...(section.lines.length > 0 ? { text: section.lines.join("\n") } : {}),
+  }));
+}
+
+function getEntityResultItem(value: unknown): FlowBrainDisplayItem {
+  const result = asRecord(value) ?? {};
+  if (result.status === "not_found") {
+    return {
+      eyebrow: "Not found",
+      title: nonEmptyString(result.id) ?? "Unknown entity",
+      tone: "warning",
+    };
+  }
+  if (result.status === "error") {
+    const error = nonEmptyString(result.error);
+    return {
+      eyebrow: "Error",
+      title: nonEmptyString(result.id) ?? "Entity lookup failed",
+      ...(error ? { description: error } : {}),
+      tone: "danger",
+    };
+  }
+  const card = asRecord(result.card);
+  if (card) {
+    const kind = nonEmptyString(card.kind) ?? nonEmptyString(result.card_type) ?? "context";
+    const title =
+      nonEmptyString(card.claim) ??
+      nonEmptyString(card.title) ??
+      nonEmptyString(card.text) ??
+      nonEmptyString(card.root_text) ??
+      nonEmptyString(card.identifier) ??
+      nonEmptyString(result.id) ??
+      "Brain context";
+    const description = nonEmptyString(card.description);
+    const strength = asRecord(card.strength);
+    const tags = [
+      nonEmptyString(card.memory_kind),
+      nonEmptyString(strength?.tier),
+      ...strings(card.anchors),
+      ...strings(card.anchored_nodes),
+    ].filter((entry): entry is string => entry !== null);
+    return {
+      eyebrow: titleCase(kind),
+      title,
+      ...(nonEmptyString(result.id) ? { id: nonEmptyString(result.id)! } : {}),
+      ...(description ? { description } : {}),
+      ...(tags.length > 0 ? { tags } : {}),
+      fields: displayFields(
+        card,
+        new Set([
+          "kind",
+          "claim",
+          "title",
+          "text",
+          "root_text",
+          "identifier",
+          "description",
+          "strength",
+          "memory_kind",
+          "anchors",
+          "anchored_nodes",
+          "evidence",
+          "messages",
+        ]),
+      ).slice(0, 6),
+    };
+  }
+  const node = asRecord(result.node);
+  if (node) {
+    const item = entityItem(node);
+    const outgoing = records(result.outgoing);
+    const incoming = records(result.incoming);
+    const connections = [...outgoing, ...incoming].slice(0, 10).map((relation) => {
+      const rel = nonEmptyString(relation.rel) ?? "RELATED";
+      const target = nonEmptyString(relation.name) ?? nonEmptyString(relation.id) ?? "entity";
+      return `${titleCase(rel)} · ${target}`;
+    });
+    return {
+      ...item,
+      tags: [
+        ...(item.tags ?? []),
+        ...connections,
+        ...(outgoing.length + incoming.length > connections.length
+          ? [`+${outgoing.length + incoming.length - connections.length} connections`]
+          : []),
+      ],
+    };
+  }
+  return entityItem(result);
+}
+
+function getEntityDisplay(
+  response: Record<string, unknown>,
+): Pick<FlowBrainConsultationDisplay, "responseSummary" | "responseSections"> {
+  const results = response.status === "batch" ? records(response.results) : [response];
+  const found =
+    typeof response.found === "number"
+      ? response.found
+      : results.filter((result) => result.status !== "not_found" && result.status !== "error")
+          .length;
+  const missing = results.length - found;
+  return {
+    responseSummary: [
+      compactCount(found, "result"),
+      ...(missing > 0 ? [`${missing} missing`] : []),
+    ].join(" · "),
+    responseSections: [{ title: "Retrieved context", items: results.map(getEntityResultItem) }],
+  };
+}
+
+function genericObjectDisplay(
+  response: Record<string, unknown>,
+): Pick<FlowBrainConsultationDisplay, "responseSummary" | "responseSections"> {
+  const status = nonEmptyString(response.status);
+  const error = nonEmptyString(response.error);
+  const fields = displayFields(response, new Set(["status", "error"]));
+  return {
+    responseSummary: error
+      ? "The consultation failed"
+      : status
+        ? titleCase(status)
+        : "Response received",
+    responseSections: [
+      {
+        title: error ? "Error" : "Response",
+        ...(error ? { text: error, tone: "danger" as const } : {}),
+        ...(fields.length > 0 ? { fields } : {}),
+      },
+    ],
+  };
+}
+
+function responseDisplay(
+  tool: string,
+  request: unknown,
+  responseValue: unknown,
+  waiting: boolean,
+): Pick<FlowBrainConsultationDisplay, "responseSummary" | "responseSections"> {
+  if (responseValue === undefined || responseValue === null) {
+    return {
+      responseSummary: waiting ? "Waiting for the brain…" : "No response body",
+      responseSections: [],
+    };
+  }
+  const response = asRecord(responseValue);
+  const requestRecord = asRecord(request);
+  if (tool === "find_entity" && response) return findEntityDisplay(response, requestRecord);
+  if (tool === "get_entity" && response) return getEntityDisplay(response);
+  if (tool === "search_knowledge" && response) {
+    const text = nonEmptyString(response.results) ?? nonEmptyString(response.lines);
+    if (text) {
+      const sections = parseKnowledgeSearch(text);
+      const resultCount = sections.reduce(
+        (count, section) => count + (section.items?.length ?? 0),
+        0,
+      );
+      return {
+        responseSummary:
+          resultCount > 0 ? compactCount(resultCount, "memory", "memories") : "Search complete",
+        responseSections: sections,
+      };
+    }
+  }
+  if (tool === "list_schema" && response) {
+    const nodeTypes = strings(response.nodeTypes);
+    const edgeTypes = strings(response.edgeTypes);
+    return {
+      responseSummary: `${compactCount(nodeTypes.length, "node type")} · ${compactCount(edgeTypes.length, "relationship")}`,
+      responseSections: [
+        { title: "Node types", tags: nodeTypes },
+        { title: "Relationships", tags: edgeTypes.map(titleCase) },
+      ],
+    };
+  }
+  if (tool === "read_query" && response && Array.isArray(response.rows)) {
+    const rows = records(response.rows);
+    return {
+      responseSummary: compactCount(rows.length, "row"),
+      responseSections: [
+        {
+          title: "Query results",
+          items: rows.map((row, index) => ({
+            title: `Row ${index + 1}`,
+            fields: displayFields(row),
+          })),
+        },
+      ],
+    };
+  }
+  if (tool === "source_search" && response && Array.isArray(response.matches)) {
+    const matches = records(response.matches);
+    return {
+      responseSummary: compactCount(matches.length, "source match"),
+      responseSections: [
+        {
+          title: "Source matches",
+          items: matches.map((match) => {
+            const description = nonEmptyString(match.text);
+            return {
+              eyebrow: nonEmptyString(response.repo) ?? "Repository",
+              title: `${nonEmptyString(match.path) ?? "Unknown file"}:${String(match.line ?? "?")}`,
+              ...(description ? { description } : {}),
+            };
+          }),
+        },
+      ],
+    };
+  }
+  if (tool === "source_read" && response && nonEmptyString(response.content)) {
+    const subtitle = nonEmptyString(response.repo);
+    return {
+      responseSummary: `${nonEmptyString(response.path) ?? "Source file"} · lines ${String(response.start_line ?? "?")}–${String(response.end_line ?? "?")}`,
+      responseSections: [
+        {
+          title: nonEmptyString(response.path) ?? "Source",
+          ...(subtitle ? { subtitle } : {}),
+          text: nonEmptyString(response.content)!,
+          code: true,
+        },
+      ],
+    };
+  }
+  if (tool === "orient" && typeof responseValue === "string") {
+    const blocks = responseValue
+      .split(/\n\s*\n/)
+      .map((block) => block.trim())
+      .filter(Boolean);
+    return {
+      responseSummary: "Project context loaded",
+      responseSections: blocks.map((block, index) => {
+        const [first, ...rest] = block.split("\n");
+        const heading = first?.match(/^([A-Z][A-Z ]+):\s*(.*)$/);
+        return heading
+          ? {
+              title: titleCase(heading[1]!.toLowerCase()),
+              text: [heading[2], ...rest].filter(Boolean).join("\n"),
+            }
+          : { title: index === 0 ? "Project" : "Context", text: block };
+      }),
+    };
+  }
+  if (response) return genericObjectDisplay(response);
+  return {
+    responseSummary: "Response received",
+    responseSections: [{ title: "Response", text: String(responseValue) }],
+  };
+}
+
+/** Projects known Flow graph schemas into a compact UI model shared by all clients. */
+export function resolveFlowBrainConsultationDisplay(
+  entry: Pick<
+    WorkLogPresentationEntry,
+    "label" | "toolTitle" | "toolData" | "detail" | "toolLifecycleStatus"
+  >,
+): FlowBrainConsultationDisplay | null {
+  const details = resolveFlowBrainToolCallDetails(entry);
+  if (!details) return null;
+  const requestFields = displayFields(details.request);
+  const response = responseDisplay(
+    details.tool,
+    details.request,
+    details.response,
+    entry.toolLifecycleStatus === "inProgress",
+  );
+  return { ...details, requestFields, ...response };
 }
 
 function commandResultContent(value: unknown): string | null {


### PR DESCRIPTION
Flow brain MCP calls were displayed as generic request and response JSON, and valid MCP payloads with null structuredContent appeared as having no response body.

This adds a shared semantic projection for known Flow brain tools, renders readable schema-aware consultation cards on web and mobile, and falls back to MCP text content whenever structuredContent is null.

Verification:
- 60 focused presentation tests passed
- Formatting and diff checks passed
- UI verified by the Flow developer on the isolated dashboard

Model: GPT-5.6 Sol
Harness: Flow Codex