### PR TITLE
fix(web): show brain connection and loading feedback

### DIFF
--- a/apps/web/src/components/brain/BrainPage.tsx
+++ b/apps/web/src/components/brain/BrainPage.tsx
@@ -13,6 +13,7 @@ export function BrainPage({
   hasBrain,
   isIndexing,
   loading,
+  connectionNotice,
   error,
   toolbar,
   indexing,
@@ -23,6 +24,7 @@ export function BrainPage({
   hasBrain: boolean;
   isIndexing: boolean;
   loading: boolean;
+  connectionNotice: { title: string; description: string } | null;
   error: string | null;
   toolbar: ReactNode;
   indexing: ReactNode;
@@ -38,6 +40,14 @@ export function BrainPage({
       <main className="min-h-0 flex-1 overflow-y-auto">
         <div className="mx-auto max-w-6xl space-y-6 px-5 py-6 md:px-8">
           {toolbar}
+          {snapshot.entities.length > 0 && connectionNotice && (
+            <p
+              role="status"
+              className="rounded-lg border border-border bg-muted/30 p-3 text-sm text-muted-foreground"
+            >
+              {connectionNotice.title} {connectionNotice.description}
+            </p>
+          )}
           {error && (
             <p
               role="alert"
@@ -83,29 +93,42 @@ export function BrainPage({
               />
             ) : (
               <div className="brain-graph-surface">
-                <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
+                <div
+                  role="status"
+                  className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center"
+                >
                   <BrainCircuit size={28} className="text-muted-foreground/60" />
                   <h3 className="text-sm font-medium">
-                    {loading
-                      ? "Opening brain…"
-                      : !hasBrain
-                        ? "Create your first brain"
-                        : isIndexing
-                          ? "Building your knowledge graph…"
-                          : snapshot.sources.length > 0
-                            ? "No knowledge indexed yet"
-                            : "Your brain starts with a source"}
+                    {connectionNotice
+                      ? connectionNotice.title
+                      : loading
+                        ? "Opening brain…"
+                        : error && !hasBrain
+                          ? "Brain unavailable"
+                          : !hasBrain
+                            ? "Create your first brain"
+                            : isIndexing
+                              ? "Building your knowledge graph…"
+                              : snapshot.sources.length > 0
+                                ? "No knowledge indexed yet"
+                                : "Your brain starts with a source"}
                   </h3>
                   <p className="max-w-sm text-xs leading-relaxed text-muted-foreground">
-                    {hasBrain
-                      ? isIndexing
-                        ? "Nodes and connections appear here as the indexer discovers them."
-                        : snapshot.sources.length > 0
-                          ? "Check the connected sources below to start or retry indexing."
-                          : "Connect a GitHub repository or local folder below."
-                      : "Choose a name and the CLI that will build its knowledge."}
+                    {connectionNotice
+                      ? connectionNotice.description
+                      : loading
+                        ? "Loading your brains and their knowledge."
+                        : error && !hasBrain
+                          ? "Your brain could not be opened. Check the connection or choose another brain in Brain settings."
+                          : hasBrain
+                            ? isIndexing
+                              ? "Nodes and connections appear here as the indexer discovers them."
+                              : snapshot.sources.length > 0
+                                ? "Check the connected sources below to start or retry indexing."
+                                : "Connect a GitHub repository or local folder below."
+                            : "Choose a name and the CLI that will build its knowledge."}
                   </p>
-                  {!hasBrain && !loading && (
+                  {!hasBrain && !loading && !connectionNotice && !error && (
                     <Button variant="outline" onClick={onCreate}>
                       <PlusIcon size={14} />
                       New brain

--- a/apps/web/src/components/brain/LiveBrainPage.test.tsx
+++ b/apps/web/src/components/brain/LiveBrainPage.test.tsx
@@ -1,0 +1,247 @@
+import { act, type ReactNode } from "react";
+import { create, type ReactTestRenderer } from "react-test-renderer";
+import type { BrainResponse, BrainState } from "@t3tools/contracts";
+import type { EnvironmentConnectionPhase } from "@t3tools/client-runtime/connection";
+import * as Option from "effect/Option";
+import * as Cause from "effect/Cause";
+import { AsyncResult } from "effect/unstable/reactivity";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const runtime = vi.hoisted(() => ({
+  isReady: false,
+  hasEnvironment: true,
+  prepared: false,
+  phase: "connecting" as EnvironmentConnectionPhase,
+  execute: vi.fn(),
+}));
+
+vi.mock("../../state/environments", () => ({
+  usePrimaryEnvironmentId: () => "local",
+  useEnvironments: () => ({
+    isReady: runtime.isReady,
+    environments: runtime.hasEnvironment
+      ? [
+          {
+            environmentId: "local",
+            label: "My computer",
+            connection: { phase: runtime.phase, error: null },
+          },
+        ]
+      : [],
+  }),
+}));
+vi.mock("../../state/session", () => ({
+  usePreparedConnection: () => (runtime.prepared ? Option.some({}) : Option.none()),
+}));
+vi.mock("../../state/brain", () => ({ brainCommand: Symbol("brain") }));
+vi.mock("../../state/use-atom-command", () => ({ useAtomCommand: () => runtime.execute }));
+vi.mock("../../state/entities", () => ({ useProjects: () => [] }));
+vi.mock("../../env", () => ({ isElectron: false }));
+vi.mock("../ui/sidebar", () => ({
+  SidebarInset: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("../WorkspacePageHeader", () => ({
+  WorkspacePageHeader: ({ children }: { children: ReactNode }) => <header>{children}</header>,
+}));
+vi.mock("../ui/button", () => ({
+  Button: ({
+    children,
+    disabled,
+    onClick,
+  }: {
+    children: ReactNode;
+    disabled?: boolean;
+    onClick?: () => void;
+  }) => (
+    <button disabled={disabled} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+vi.mock("../ui/dialog", () => ({
+  Dialog: () => null,
+  DialogPopup: () => null,
+  DialogHeader: () => null,
+  DialogTitle: () => null,
+  DialogDescription: () => null,
+  DialogPanel: () => null,
+}));
+vi.mock("./BrainControls", () => ({
+  BrainSelect: () => null,
+  CreateBrainDialog: () => null,
+  cliName: (id: string) => id,
+}));
+vi.mock("./BrainSources", () => ({ BrainSources: () => null, BrainIndexing: () => null }));
+vi.mock("./BrainGraph", () => ({ BrainGraph: () => <div>Knowledge graph content</div> }));
+
+import { LiveBrainPage } from "./LiveBrainPage";
+
+const emptyState: BrainState = {
+  database: { status: "ready", message: "" },
+  embeddings: { status: "ready", message: "" },
+  github: { connected: false, login: "", message: "" },
+  clis: [],
+  workspaces: [],
+};
+const onSelectionChange = vi.fn();
+let renderer: ReactTestRenderer | undefined;
+let finishRead: (result: AsyncResult.AsyncResult<BrainResponse, Error>) => void;
+
+async function render(environment = "local", workspace: string | null = null) {
+  await act(() => {
+    const page = (
+      <LiveBrainPage
+        selectedWorkspaceId={workspace}
+        selectedEnvironmentId={environment}
+        onSelectionChange={onSelectionChange}
+      />
+    );
+    if (renderer) renderer.update(page);
+    else renderer = create(page);
+  });
+}
+
+function content() {
+  return JSON.stringify(renderer?.toJSON());
+}
+
+beforeEach(() => {
+  runtime.isReady = false;
+  runtime.hasEnvironment = true;
+  runtime.prepared = false;
+  runtime.phase = "connecting";
+  runtime.execute.mockReset().mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        finishRead = resolve;
+      }),
+  );
+  onSelectionChange.mockClear();
+  vi.useFakeTimers();
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.stubGlobal("window", { setInterval, clearInterval });
+  vi.stubGlobal("document", {
+    visibilityState: "visible",
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+});
+
+afterEach(async () => {
+  await act(() => renderer?.unmount());
+  renderer = undefined;
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("Brain startup", () => {
+  it("waits for the catalog and prepared connection, then shows creation only after a successful empty read", async () => {
+    await render();
+    expect(content()).toContain("Opening brain…");
+    expect(content()).not.toContain("Create your first brain");
+    expect(runtime.execute).not.toHaveBeenCalled();
+
+    runtime.isReady = true;
+    runtime.phase = "connected";
+    await render();
+    expect(content()).toContain("Connecting to your brain…");
+    expect(runtime.execute).not.toHaveBeenCalled();
+
+    runtime.prepared = true;
+    await render();
+    expect(runtime.execute).toHaveBeenCalledTimes(1);
+    expect(content()).toContain("Loading your brains and their knowledge.");
+    expect(content()).not.toContain("Create your first brain");
+
+    await act(() =>
+      finishRead(AsyncResult.success({ state: emptyState, error: null, createdWorkspaceId: null })),
+    );
+    expect(content()).toContain("Create your first brain");
+  });
+
+  it.each(["offline", "error", "reconnecting"] as const)(
+    "does not treat %s as an empty brain list",
+    async (phase) => {
+      runtime.isReady = true;
+      runtime.phase = phase;
+      runtime.prepared = true;
+      await render();
+      expect(content()).not.toContain("Create your first brain");
+      expect(content()).not.toContain("Choose a name and the CLI");
+      expect(runtime.execute).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps a missing selected remote host from falling back to the local brain", async () => {
+    runtime.isReady = true;
+    runtime.phase = "connected";
+    runtime.prepared = true;
+    await render("missing-remote");
+    expect(content()).toContain("Choose a brain computer");
+    expect(content()).not.toContain("Create your first brain");
+    expect(runtime.execute).not.toHaveBeenCalled();
+  });
+
+  it("shows a read failure without offering creation, then recovers on the next read", async () => {
+    runtime.isReady = true;
+    runtime.phase = "connected";
+    runtime.prepared = true;
+    await render();
+    await act(() =>
+      finishRead(AsyncResult.failure(Cause.fail(new Error("Brain service unavailable")))),
+    );
+    expect(content()).toContain("Brain service unavailable");
+    expect(content()).toContain("Brain unavailable");
+    expect(content()).not.toContain("Create your first brain");
+    await act(() => vi.advanceTimersByTime(2000));
+    await act(() =>
+      finishRead(AsyncResult.success({ state: emptyState, error: null, createdWorkspaceId: null })),
+    );
+    expect(content()).not.toContain("Brain service unavailable");
+    expect(content()).toContain("Create your first brain");
+  });
+
+  it("retains loaded knowledge while reconnecting and refreshes immediately on reconnection", async () => {
+    runtime.isReady = true;
+    runtime.phase = "connected";
+    runtime.prepared = true;
+    await render("local", "brain");
+    await act(() =>
+      finishRead(
+        AsyncResult.success({
+          error: null,
+          createdWorkspaceId: null,
+          state: {
+            ...emptyState,
+            workspaces: [
+              {
+                id: "brain",
+                name: "My brain",
+                cli: "codex",
+                sources: [],
+                knowledge: {
+                  entities: [
+                    { id: "node", name: "Node", kind: "Service", description: "", source: "" },
+                  ],
+                  edges: [],
+                  memories: [],
+                },
+              },
+            ],
+          },
+        }),
+      ),
+    );
+    runtime.phase = "reconnecting";
+    runtime.prepared = false;
+    await render("local", "brain");
+    expect(content()).toContain("Reconnecting to your brain…");
+    expect(content()).toContain("Knowledge graph content");
+    expect(runtime.execute).toHaveBeenCalledTimes(1);
+    runtime.phase = "connected";
+    runtime.prepared = true;
+    await render("local", "brain");
+    expect(runtime.execute).toHaveBeenCalledTimes(2);
+    expect(content()).not.toContain("Reconnecting to your brain…");
+  });
+});

--- a/apps/web/src/components/brain/LiveBrainPage.tsx
+++ b/apps/web/src/components/brain/LiveBrainPage.tsx
@@ -9,10 +9,13 @@ import type {
   EnvironmentId,
 } from "@t3tools/contracts";
 import { squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime";
+import type { EnvironmentConnectionPresentation } from "@t3tools/client-runtime/connection";
+import * as Option from "effect/Option";
 import { PlusIcon, SettingsIcon, Folder } from "lucide-react";
 import { brainCommand } from "../../state/brain";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { useEnvironments, usePrimaryEnvironmentId } from "../../state/environments";
+import { usePreparedConnection } from "../../state/session";
 import { useProjects } from "../../state/entities";
 import type { BrainSnapshot } from "../../brain/repository";
 import { BrainPage } from "./BrainPage";
@@ -63,7 +66,7 @@ export function LiveBrainPage({
   onSelectionChange: (workspaceId: string | null, environmentId: string | null) => void;
 }) {
   const primary = usePrimaryEnvironmentId();
-  const { environments } = useEnvironments();
+  const { environments, isReady } = useEnvironments();
   // An explicit environment must never silently resolve to a different brain host.
   const environmentId = selectedEnvironmentId
     ? (environments.find((entry) => entry.environmentId === selectedEnvironmentId)?.environmentId ??
@@ -73,6 +76,10 @@ export function LiveBrainPage({
     <BrainController
       key={environmentId ?? "disconnected"}
       environmentId={environmentId}
+      environmentsReady={isReady}
+      connection={
+        environments.find((entry) => entry.environmentId === environmentId)?.connection ?? null
+      }
       selectedWorkspaceId={selectedWorkspaceId}
       onSelectionChange={onSelectionChange}
       environmentSelector={
@@ -92,16 +99,23 @@ export function LiveBrainPage({
 
 function BrainController({
   environmentId,
+  environmentsReady,
+  connection,
   selectedWorkspaceId,
   onSelectionChange,
   environmentSelector,
 }: {
   environmentId: EnvironmentId | null;
+  environmentsReady: boolean;
+  connection: EnvironmentConnectionPresentation | null;
   selectedWorkspaceId: string | null;
   onSelectionChange: (workspaceId: string | null, environmentId: string | null) => void;
   environmentSelector: React.ReactNode;
 }) {
   const execute = useAtomCommand(brainCommand, { reportFailure: false });
+  const prepared = usePreparedConnection(environmentId);
+  const canRequest =
+    environmentsReady && connection?.phase === "connected" && Option.isSome(prepared);
   const [state, setState] = useState<BrainState | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
@@ -118,7 +132,7 @@ function BrainController({
 
   const send = useCallback(
     async (input: BrainCommand, background = false): Promise<BrainResponse | null> => {
-      if (!environmentId) return null;
+      if (!environmentId || !canRequest) return null;
       while (pending.current) {
         if (background && input.action === "read") return null;
         await pending.current.catch(() => {});
@@ -150,7 +164,7 @@ function BrainController({
         if (mounted.current && !background) setBusy(false);
       }
     },
-    [environmentId, execute],
+    [environmentId, execute, canRequest],
   );
 
   useEffect(() => {
@@ -174,11 +188,37 @@ function BrainController({
     if (!selectedWorkspaceId && workspace) onSelectionChange(workspace.id, environmentId);
   }, [environmentId, onSelectionChange, selectedWorkspaceId, workspace]);
 
-  const selectionError = !environmentId
-    ? "Connect to the computer that hosts this brain."
-    : state && selectedWorkspaceId && !workspace
+  const selectionError =
+    state && selectedWorkspaceId && !workspace
       ? "This brain is not available on the selected computer. Choose another brain."
       : null;
+  const connectionNotice = !environmentsReady
+    ? { title: "Opening brain…", description: "Getting your computer connection ready." }
+    : !environmentId
+      ? {
+          title: "Choose a brain computer",
+          description: "Open Brain settings to choose the computer that hosts your brain.",
+        }
+      : connection?.phase === "offline"
+        ? {
+            title: "Brain computer is offline",
+            description: "Your brain will be available when the computer reconnects.",
+          }
+        : connection?.phase === "error"
+          ? {
+              title: "Could not connect to your brain computer",
+              description:
+                connection.error ?? "Check the computer’s connection in Settings → Connections.",
+            }
+          : !canRequest
+            ? {
+                title:
+                  connection?.phase === "reconnecting"
+                    ? "Reconnecting to your brain…"
+                    : "Connecting to your brain…",
+                description: "Your knowledge graph will appear once the connection is ready.",
+              }
+            : null;
   const isIndexing =
     workspace?.sources.some((source) =>
       ["queued", "cloning", "indexing", "embedding"].includes(source.status),
@@ -190,7 +230,8 @@ function BrainController({
         hasBrain={Boolean(workspace)}
         isIndexing={isIndexing}
         loading={!state && Boolean(environmentId) && !error}
-        error={error ?? selectionError}
+        connectionNotice={connectionNotice}
+        error={connectionNotice ? null : (error ?? selectionError)}
         onCreate={() => setCreateOpen(true)}
         indexing={workspace && <BrainIndexing workspace={workspace} send={send} busy={busy} />}
         toolbar={
@@ -222,7 +263,7 @@ function BrainController({
               </Button>
               <Button
                 variant="outline"
-                disabled={!state || busy}
+                disabled={!state || !canRequest || busy}
                 onClick={() => setCreateOpen(true)}
               >
                 <PlusIcon size={14} />


### PR DESCRIPTION
## What Changed

The Brain page now waits for the computer connection before requesting data and shows connecting, loading, offline, or connection failure feedback. “Create your first brain” appears only after a successful empty response. Loaded knowledge stays visible during reconnection, and reads resume when the connection is ready.

## Why

Opening Brain during connection startup briefly showed a red “Connect to a computer” error alongside “Create your first brain.” The page requested data before the connection was ready and treated the missing response as an empty brain list.

## Validation

- Seven focused regression tests pass, covering startup, disconnected states, remote host selection, read failure recovery, and reconnection.
- Web typecheck and formatting checks pass.
- Targeted lint reports one warning in the existing polling effect.
- Applies to the shared web/desktop Brain page; no mobile, provider, or wire-contract changes.

## UI Changes

Screenshots omitted at the developer’s explicit request. Browser verification was not run.

Model: GPT-6. Harness: Codex.
