### PR TITLE
fix(web): require brains during onboarding

### DIFF
--- a/apps/web/src/components/brain/BrainControls.tsx
+++ b/apps/web/src/components/brain/BrainControls.tsx
@@ -71,14 +71,16 @@ export function CreateBrainDialog({
   state,
   send,
   onCreated,
+  initialName = "",
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   state: BrainState | null;
   send: SendBrainCommand;
   onCreated: (id: string) => void;
+  initialName?: string;
 }) {
-  const [name, setName] = useState("");
+  const [name, setName] = useState(initialName);
   const [cli, setCli] = useState<BrainCli | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
@@ -95,7 +97,7 @@ export function CreateBrainDialog({
       }
       onCreated(result.createdWorkspaceId);
       onOpenChange(false);
-      setName("");
+      setName(initialName);
     } finally {
       setBusy(false);
     }

--- a/apps/web/src/components/brain/useProjectBrainChoice.test.tsx
+++ b/apps/web/src/components/brain/useProjectBrainChoice.test.tsx
@@ -1,0 +1,161 @@
+import { EnvironmentId, type BrainState } from "@t3tools/contracts";
+import React from "react";
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, expect, it, vi } from "vite-plus/test";
+
+const state = vi.hoisted(() => ({ execute: vi.fn() }));
+
+vi.mock("../../state/brain", () => ({ brainCommand: "brainCommand" }));
+vi.mock("../../state/use-atom-command", () => ({ useAtomCommand: () => state.execute }));
+vi.mock("./BrainIcon", () => ({ BrainIcon: () => null }));
+vi.mock("../ui/button", () => ({ Button: "button" }));
+vi.mock("../ui/input", () => ({ Input: "input" }));
+vi.mock("../ui/select", () => ({
+  Select: "div",
+  SelectTrigger: "button",
+  SelectValue: "span",
+  SelectPopup: "div",
+  SelectItem: "div",
+}));
+vi.mock("../ui/dialog", () => ({
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div>{children}</div> : null,
+  DialogPopup: "div",
+  DialogHeader: "div",
+  DialogTitle: "h2",
+  DialogDescription: "p",
+  DialogPanel: "div",
+  DialogFooter: "div",
+}));
+
+import { useProjectBrainChoice } from "./useProjectBrainChoice";
+
+const environmentId = EnvironmentId.make("local");
+let renderer: ReactTestRenderer | undefined;
+
+function brainState(workspaces: BrainState["workspaces"]): BrainState {
+  return {
+    database: { status: "ready", message: "" },
+    embeddings: { status: "ready", message: "" },
+    github: { connected: false, login: "", message: "" },
+    clis: [
+      { id: "claude", installed: true },
+      { id: "codex", installed: false },
+      { id: "opencode", installed: false },
+    ],
+    workspaces,
+  };
+}
+
+function text(node: ReactTestInstance | string): string {
+  return typeof node === "string" ? node : node.children.map(text).join("");
+}
+
+function findButton(label: string) {
+  const found = renderer!.root.findAllByType("button").find((node) => text(node) === label);
+  if (!found) throw new Error(`Missing button: ${label}`);
+  return found;
+}
+
+function Harness() {
+  const { chooseBrain, brainChoiceDialog } = useProjectBrainChoice({ required: true });
+  const [choice, setChoice] = React.useState<string | null>(null);
+  return (
+    <>
+      <button
+        onClick={() => {
+          void chooseBrain(environmentId, "Acme project").then((next) =>
+            setChoice(next?.workspaceId ?? null),
+          );
+        }}
+      >
+        Start
+      </button>
+      <output>{choice ?? "pending"}</output>
+      {brainChoiceDialog}
+    </>
+  );
+}
+
+async function start() {
+  await act(async () => findButton("Start").props.onClick());
+  await act(async () => {});
+}
+
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  state.execute.mockReset();
+});
+
+afterEach(async () => {
+  await act(async () => renderer?.unmount());
+  renderer = undefined;
+  vi.unstubAllGlobals();
+});
+
+it("requires an existing brain and defaults to the first available one", async () => {
+  state.execute.mockResolvedValue({
+    _tag: "Success",
+    value: {
+      state: brainState([
+        {
+          id: "brain-1",
+          name: "Team brain",
+          cli: "claude",
+          sources: [],
+          knowledge: { entities: [], edges: [], memories: [] },
+        },
+      ]),
+      error: null,
+      createdWorkspaceId: null,
+    },
+  });
+  await act(async () => {
+    renderer = create(<Harness />);
+  });
+
+  await start();
+
+  expect(text(renderer!.root)).not.toContain("Continue without a brain");
+  expect(text(renderer!.root)).not.toContain("No brain");
+  await act(async () => findButton("Connect brain").props.onClick());
+  expect(text(renderer!.root)).toContain("brain-1");
+});
+
+it("opens a one-action creation flow and connects the new brain", async () => {
+  state.execute
+    .mockResolvedValueOnce({
+      _tag: "Success",
+      value: { state: brainState([]), error: null, createdWorkspaceId: null },
+    })
+    .mockResolvedValueOnce({
+      _tag: "Success",
+      value: {
+        state: brainState([]),
+        error: null,
+        createdWorkspaceId: "brain-created",
+      },
+    });
+  await act(async () => {
+    renderer = create(<Harness />);
+  });
+
+  await start();
+
+  expect(text(renderer!.root)).toContain("Create a brain");
+  expect(
+    renderer!.root.findAllByType("input").find((node) => node.props.value !== undefined)?.props
+      .value,
+  ).toBe("My brain");
+  const form = renderer!.root.findByType("form");
+  await act(async () => {
+    form.props.onSubmit({ preventDefault: vi.fn() });
+  });
+  await act(async () => {});
+
+  expect(state.execute).toHaveBeenLastCalledWith({
+    environmentId,
+    input: { action: "create", name: "My brain", cli: "claude" },
+  });
+  expect(text(renderer!.root)).toContain("brain-created");
+});

--- a/apps/web/src/components/brain/useProjectBrainChoice.tsx
+++ b/apps/web/src/components/brain/useProjectBrainChoice.tsx
@@ -17,7 +17,7 @@ import {
 
 type Choice = { workspaceId: string | null } | null;
 /** One confirmation for every folder/clone entry point, before project creation. */
-export function useProjectBrainChoice() {
+export function useProjectBrainChoice({ required = false }: { required?: boolean } = {}) {
   const execute = useAtomCommand(brainCommand, { reportFailure: false });
   const [target, setTarget] = useState<{ environmentId: EnvironmentId; title: string } | null>(
     null,
@@ -42,9 +42,10 @@ export function useProjectBrainChoice() {
       resolver.current?.(null);
       const request = ++generation.current;
       setTarget({ environmentId, title });
-      setSelected("none");
+      setSelected(required ? "" : "none");
       setState(null);
       setError("");
+      setCreateOpen(false);
       setLoading(true);
       void execute({
         environmentId,
@@ -54,21 +55,25 @@ export function useProjectBrainChoice() {
         setLoading(false);
         if (result._tag === "Success" && !result.value.error) {
           setState(result.value.state);
-          if (projectId)
-            setSelected(
-              result.value.state.workspaces.find((brain) => brain.projectIds?.includes(projectId))
-                ?.id ?? "none",
-            );
+          const boundBrain = projectId
+            ? result.value.state.workspaces.find((brain) => brain.projectIds?.includes(projectId))
+            : undefined;
+          setSelected(
+            boundBrain?.id ?? result.value.state.workspaces[0]?.id ?? (required ? "" : "none"),
+          );
+          if (required && result.value.state.workspaces.length === 0) setCreateOpen(true);
         } else
           setError(
-            "Could not load brains from this computer. You can retry, or continue without a brain.",
+            required
+              ? "Could not load brains from this computer. Retry to continue setting up this project."
+              : "Could not load brains from this computer. You can retry, or continue without a brain.",
           );
       });
       return new Promise((resolve) => {
         resolver.current = resolve;
       });
     },
-    [execute],
+    [execute, required],
   );
   const finish = (choice: Choice) => {
     generation.current++;
@@ -94,10 +99,11 @@ export function useProjectBrainChoice() {
       >
         <DialogPopup className="max-w-md">
           <DialogHeader>
-            <DialogTitle>Connect project to a brain</DialogTitle>
+            <DialogTitle>{required ? "Choose a brain" : "Connect project to a brain"}</DialogTitle>
             <DialogDescription>
               {target?.title} will use the selected brain for knowledge, and its repository will be
-              added as a source. You can also continue without a brain and connect one later.
+              added as a source.
+              {!required ? " You can also continue without a brain and connect one later." : null}
             </DialogDescription>
           </DialogHeader>
           <DialogPanel className="space-y-4">
@@ -107,7 +113,7 @@ export function useProjectBrainChoice() {
                 value={selected}
                 disabled={loading}
                 options={[
-                  { value: "none", label: "No brain" },
+                  ...(!required ? [{ value: "none", label: "No brain" }] : []),
                   ...(state?.workspaces ?? []).map((brain) => ({
                     value: brain.id,
                     label: brain.name,
@@ -149,10 +155,10 @@ export function useProjectBrainChoice() {
               Cancel
             </Button>
             <Button
-              disabled={loading}
+              disabled={loading || (required && !selected)}
               onClick={() => finish({ workspaceId: selected === "none" ? null : selected })}
             >
-              {selected === "none" ? "Continue without a brain" : "Connect brain"}
+              {!required && selected === "none" ? "Continue without a brain" : "Connect brain"}
             </Button>
           </DialogFooter>
         </DialogPopup>
@@ -162,7 +168,11 @@ export function useProjectBrainChoice() {
         onOpenChange={setCreateOpen}
         state={state}
         send={send}
-        onCreated={setSelected}
+        initialName={required ? "My brain" : ""}
+        onCreated={(id) => {
+          if (required) finish({ workspaceId: id });
+          else setSelected(id);
+        }}
       />
     </>
   );

--- a/apps/web/src/components/onboarding/WelcomeWizard.tsx
+++ b/apps/web/src/components/onboarding/WelcomeWizard.tsx
@@ -961,7 +961,7 @@ function ImportStep({
   const { environments } = useEnvironments();
   const createProject = useAtomCommand(projectEnvironment.create, { reportFailure: false });
   const connectBrain = useAtomCommand(brainCommand, { reportFailure: false });
-  const { chooseBrain, brainChoiceDialog } = useProjectBrainChoice();
+  const { chooseBrain, brainChoiceDialog } = useProjectBrainChoice({ required: true });
   const importThreads = useAtomCommand(agentSessionImport, { reportFailure: false });
   const projects = useProjects();
   const [selectedPaths, setSelectedPaths] = useState<ReadonlySet<string> | null>(null);
@@ -974,6 +974,7 @@ function ImportStep({
   const projectAttemptsRef = useRef(
     new Map<string, { readonly projectId: ProjectId; readonly commandId: CommandId }>(),
   );
+  const brainChoicesRef = useRef(new Map<EnvironmentId, string>());
   const importGenerationRef = useRef(0);
 
   // Ignore command completions after leaving the import step.
@@ -1067,10 +1068,19 @@ function ImportStep({
       }
       if (importedProjects.has(candidate.key)) continue;
       let projectId = resolveOnboardingProjectId(readProjects(), environmentId, candidate);
-      const brainChoice = await chooseBrain(environmentId, candidate.title, projectId ?? undefined);
-      if (!brainChoice) {
-        setIsImporting(false);
-        return;
+      let workspaceId = brainChoicesRef.current.get(environmentId);
+      if (workspaceId === undefined) {
+        const brainChoice = await chooseBrain(
+          environmentId,
+          candidate.title,
+          projectId ?? undefined,
+        );
+        if (!brainChoice?.workspaceId) {
+          setIsImporting(false);
+          return;
+        }
+        workspaceId = brainChoice.workspaceId;
+        brainChoicesRef.current.set(environmentId, workspaceId);
       }
       if (importGeneration !== importGenerationRef.current) return;
       if (projectId === null) {
@@ -1113,12 +1123,12 @@ function ImportStep({
       {
         const connection = await connectBrain({
           environmentId,
-          input: { action: "bindProject", projectId, workspaceId: brainChoice.workspaceId },
+          input: { action: "bindProject", projectId, workspaceId },
         });
         if (connection._tag === "Failure" || connection.value.error) {
           setIsImporting(false);
           setImportError(
-            "Project saved, but its brain could not be connected. Retry or connect it from the Brain page.",
+            "Project saved, but its brain could not be connected. Retry to finish setup.",
           );
           return;
         }


### PR DESCRIPTION
New users could import projects while explicitly choosing no Brain, leaving onboarding complete without the knowledge layer Flow depends on.

This makes the onboarding project-import path require a Brain. An existing Brain is selected by default; when none exists, Flow immediately opens a prefilled creation dialog with the first installed CLI selected. The resulting Brain is connected in the same action and reused for every selected project on that computer.

Validation:
- 22 focused Vite+ tests pass
- @t3tools/web typecheck passes
- Targeted lint passes (pre-existing WelcomeWizard warnings only)
- Integrated before/after browser pass against isolated worktree state

Visual comparison is attached in the first PR comment.

Built with Codex (gpt-5.6-sol) in Flow.