### PR TITLE
feat(telemetry): measure Flow Brain adoption

### DIFF
--- a/apps/server/src/brain/BrainRuntime.integration.test.ts
+++ b/apps/server/src/brain/BrainRuntime.integration.test.ts
@@ -124,10 +124,17 @@ describe("native brain persistence", () => {
         yield* Effect.promise(async () => {
           const directory = await NodeFSP.mkdtemp("/tmp/flow-brain-test-");
           directories.push(directory);
+          const analyticsEvents: Array<{
+            event: string;
+            properties: Readonly<Record<string, string | number | boolean>>;
+          }> = [];
           const runtime = new BrainRuntime(NodePath.join(directory, "state"), {
             databasePath: NodePath.join(directory, "db"),
             platform,
             architecture,
+            recordAnalytics: async (event, properties) => {
+              analyticsEvents.push({ event, properties });
+            },
           });
           runtimes.push(runtime);
           await runtime.initialize();
@@ -258,6 +265,38 @@ describe("native brain persistence", () => {
           expect((await runtime.state()).workspaces[1]!.sources[0]!.status).toBe("cancelled");
           expect((await runtime.state()).workspaces[0]!.sources[0]!.status).toBe("error");
           expect((await runtime.state()).workspaces[0]!.knowledge.entities).toHaveLength(3);
+          expect(analyticsEvents).toEqual([
+            expect.objectContaining({
+              event: "brain.source.indexed",
+              properties: expect.objectContaining({
+                success: true,
+                cancelled: false,
+                incremental: false,
+                sourceType: "github",
+                cli: "claude",
+              }),
+            }),
+            expect.objectContaining({
+              event: "brain.source.indexed",
+              properties: expect.objectContaining({
+                success: false,
+                cancelled: false,
+                incremental: true,
+                sourceType: "github",
+                cli: "claude",
+              }),
+            }),
+            expect.objectContaining({
+              event: "brain.source.indexed",
+              properties: expect.objectContaining({
+                success: false,
+                cancelled: true,
+                incremental: false,
+                sourceType: "github",
+                cli: "codex",
+              }),
+            }),
+          ]);
           await runtime.close();
           runtimes.pop();
           // A full Brain read now also loads its conversation documents, so

--- a/apps/server/src/brain/BrainRuntime.ts
+++ b/apps/server/src/brain/BrainRuntime.ts
@@ -37,6 +37,11 @@ type Workspace = {
   sources: Source[];
   projectIds: ProjectId[];
 };
+type BrainAnalyticsProperties = Readonly<Record<string, string | number | boolean>>;
+type BrainAnalyticsRecorder = (
+  event: string,
+  properties: BrainAnalyticsProperties,
+) => Promise<void>;
 const decodeWorkspaces = Schema.decodeUnknownSync(Schema.Array(WorkspaceSchema));
 const decodeStoredKnowledge = Schema.decodeUnknownSync(WorkspaceSchema.fields.knowledge);
 const decodeGithubRepositories = Schema.decodeUnknownSync(
@@ -95,6 +100,7 @@ export class BrainRuntime {
   readonly directory: string;
   readonly host: { platform: NodeJS.Platform; architecture: NodeJS.Architecture };
   private readonly runCurator: BrainCuratorRunner | undefined;
+  private readonly recordAnalytics: BrainAnalyticsRecorder | undefined;
   constructor(
     directory: string,
     options: {
@@ -102,12 +108,14 @@ export class BrainRuntime {
       platform: NodeJS.Platform;
       architecture: NodeJS.Architecture;
       runCurator?: BrainCuratorRunner;
+      recordAnalytics?: BrainAnalyticsRecorder;
     },
   ) {
     this.directory = directory;
     this.projectBindings = new ProjectBrainBindings(directory);
     this.host = options;
     this.runCurator = options.runCurator;
+    this.recordAnalytics = options.recordAnalytics;
     // FalkorDBLite requires a <104-byte Unix socket path on macOS. Worktree
     // paths routinely exceed that. Stable hashed storage also isolates dev homes.
     this.databasePath =
@@ -118,6 +126,9 @@ export class BrainRuntime {
         NodeCrypto.createHash("sha256").update(directory).digest("hex").slice(0, 12),
       );
     this.embeddings = new BrainEmbeddings(NodePath.join(directory, "models"));
+  }
+  private async recordMetric(event: string, properties: BrainAnalyticsProperties) {
+    await this.recordAnalytics?.(event, properties).catch(() => {});
   }
   async initialize() {
     await this.projectBindings.initialize();
@@ -609,9 +620,29 @@ export class BrainRuntime {
     }
     this.queue = this.queue
       .then(async () => {
+        const startedAt = Date.now();
+        const incremental = Boolean(source.lastFlowCommit);
         try {
-          if (!controller.signal.aborted)
+          if (!controller.signal.aborted) {
             await this.index(workspace, source, cli, controller.signal);
+            await this.recordMetric("brain.source.indexed", {
+              success: true,
+              cancelled: false,
+              incremental,
+              sourceType: source.localPath ? "local" : "github",
+              cli,
+              durationMs: Date.now() - startedAt,
+            });
+          } else {
+            await this.recordMetric("brain.source.indexed", {
+              success: false,
+              cancelled: true,
+              incremental,
+              sourceType: source.localPath ? "local" : "github",
+              cli,
+              durationMs: Date.now() - startedAt,
+            });
+          }
         } catch (error) {
           source.status = this.closed
             ? "queued"
@@ -624,6 +655,14 @@ export class BrainRuntime {
               ? error.message
               : "Indexing failed. Retry to continue.";
           await this.save();
+          await this.recordMetric("brain.source.indexed", {
+            success: false,
+            cancelled: controller.signal.aborted,
+            incremental,
+            sourceType: source.localPath ? "local" : "github",
+            cli,
+            durationMs: Date.now() - startedAt,
+          });
         } finally {
           this.jobs.delete(source.id);
           if (source.reindexRequested && !this.closed && source.status !== "cancelled") {

--- a/apps/server/src/brain/BrainService.ts
+++ b/apps/server/src/brain/BrainService.ts
@@ -6,6 +6,7 @@ import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import { ServerConfig } from "../config.ts";
+import { AnalyticsService } from "../telemetry/AnalyticsService.ts";
 import { SharedBrainRuntime, serveSharedBrain, type BrainClient } from "./shared-runtime.ts";
 import { BrainRuntime } from "./BrainRuntime.ts";
 import { makeBrainCurator } from "./curator.ts";
@@ -28,6 +29,9 @@ export class BrainService extends Context.Service<
       const platform = yield* HostProcessPlatform;
       const architecture = yield* HostProcessArchitecture;
       const projections = yield* ProjectionSnapshotQuery;
+      const analytics = yield* AnalyticsService;
+      const context = yield* Effect.context<Effect.Services<ReturnType<typeof analytics.record>>>();
+      const run = Effect.runPromiseWith(context);
       const registerProjects = (runtime: BrainClient) =>
         Effect.gen(function* () {
           const snapshot = yield* projections
@@ -61,6 +65,7 @@ export class BrainService extends Context.Service<
         platform,
         architecture,
         runCurator,
+        recordAnalytics: (event, properties) => run(analytics.record(event, properties)),
       });
       yield* Effect.addFinalizer(() => Effect.promise(() => runtime.close()));
       yield* Effect.tryPromise({

--- a/apps/server/src/brain/curator-runner.test.ts
+++ b/apps/server/src/brain/curator-runner.test.ts
@@ -7,6 +7,7 @@ import * as Stream from "effect/Stream";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { ServerSettingsService } from "../serverSettings.ts";
 import { ServerConfig } from "../config.ts";
+import { AnalyticsService } from "../telemetry/AnalyticsService.ts";
 import { OpenCodeRuntimeLive } from "../provider/opencodeRuntime.ts";
 import { makeBrainCurator } from "./curator.ts";
 import type { BrainCuratorRun } from "@flow/brain-runtime";
@@ -97,7 +98,11 @@ it.effect(
           expect(starts).toEqual(["codex", "claude"]);
         }).pipe(
           Effect.provide(
-            Layer.mergeAll(ServerSettingsService.layerTest(), OpenCodeRuntimeLive).pipe(
+            Layer.mergeAll(
+              ServerSettingsService.layerTest(),
+              OpenCodeRuntimeLive,
+              AnalyticsService.layerTest,
+            ).pipe(
               Layer.provideMerge(ServerConfig.layerTest("/tmp", "/tmp")),
               Layer.provideMerge(NodeServices.layer),
             ),

--- a/apps/server/src/brain/curator.ts
+++ b/apps/server/src/brain/curator.ts
@@ -38,6 +38,7 @@ import type { ProviderAdapterShape } from "../provider/Services/ProviderAdapter.
 import type { ProviderAdapterError } from "../provider/Errors.ts";
 import { makeClaudeAdapter } from "../provider/Layers/ClaudeAdapter.ts";
 import { makeOpenCodeAdapter } from "../provider/Layers/OpenCodeAdapter.ts";
+import { AnalyticsService } from "../telemetry/AnalyticsService.ts";
 import { prepareOpenCodeCurator } from "./curator-opencode.ts";
 
 const decodeCodex = Schema.decodeUnknownEffect(CodexSettings);
@@ -305,6 +306,7 @@ const makeWorker = (request: BrainCuratorRun, settings: ServerSettings) =>
 
 /** Dedicated instances of T3's adapter; no orchestration thread or native event log. */
 export const makeBrainCurator = Effect.gen(function* () {
+  const analytics = yield* AnalyticsService;
   const context = yield* Effect.context<
     Effect.Services<ReturnType<typeof makeWorker>> | ServerSettingsService
   >();
@@ -337,10 +339,19 @@ export const makeBrainCurator = Effect.gen(function* () {
         throw error;
       }
     });
-    if (!entry) return { requiresContext: true };
+    if (!entry) {
+      await run(
+        analytics.record("brain.curation.completed", {
+          success: true,
+          renewed: request.renew,
+          requiresContext: true,
+        }),
+      ).catch(() => {});
+      return { requiresContext: true };
+    }
     const { worker } = entry;
     try {
-      return await run(
+      const result = await run(
         Effect.gen(function* () {
           worker.pending = yield* Deferred.make<BrainCuratorResult, CuratorError>();
           worker.assistantCharacters = 0;
@@ -352,7 +363,28 @@ export const makeBrainCurator = Effect.gen(function* () {
           return yield* Deferred.await(worker.pending);
         }).pipe(Effect.timeout("4 minutes")),
       );
+      await run(
+        analytics.record("brain.curation.completed", {
+          success: true,
+          renewed: request.renew,
+          requiresContext: false,
+          assistantCharacters: result.assistantCharacters,
+          ...(result.inputTokens === undefined ? {} : { inputTokens: result.inputTokens }),
+          ...(result.cachedInputTokens === undefined
+            ? {}
+            : { cachedInputTokens: result.cachedInputTokens }),
+          ...(result.outputTokens === undefined ? {} : { outputTokens: result.outputTokens }),
+        }),
+      ).catch(() => {});
+      return result;
     } catch (error) {
+      await run(
+        analytics.record("brain.curation.completed", {
+          success: false,
+          renewed: request.renew,
+          requiresContext: false,
+        }),
+      ).catch(() => {});
       await workers.discard(sessionKey);
       throw error;
     } finally {

--- a/apps/server/src/brain/http.ts
+++ b/apps/server/src/brain/http.ts
@@ -14,6 +14,20 @@ import {
 import { ServerSettingsService } from "../serverSettings.ts";
 import { BrainService } from "./BrainService.ts";
 import { ProjectionSnapshotQuery } from "../orchestration/Services/ProjectionSnapshotQuery.ts";
+import { AnalyticsService } from "../telemetry/AnalyticsService.ts";
+
+const ANALYTICS_COMMANDS = new Set([
+  "start",
+  "refreshGithub",
+  "bindProject",
+  "create",
+  "configure",
+  "import",
+  "reindex",
+  "importFolder",
+  "removeSource",
+  "cancel",
+]);
 
 export const brainHttpApiLayer = HttpApiBuilder.group(
   EnvironmentHttpApi,
@@ -22,6 +36,7 @@ export const brainHttpApiLayer = HttpApiBuilder.group(
     const service = yield* BrainService;
     const projections = yield* ProjectionSnapshotQuery;
     const settings = yield* ServerSettingsService;
+    const analytics = yield* AnalyticsService;
     return handlers.handle(
       "request",
       Effect.fn("environment.brain.request")(function* (args) {
@@ -134,6 +149,28 @@ export const brainHttpApiLayer = HttpApiBuilder.group(
               ),
             })
             .pipe(Effect.catch((error) => failEnvironmentInternal("internal_error", error)));
+        }
+        if (ANALYTICS_COMMANDS.has(command.action)) {
+          yield* analytics.record("brain.command.completed", {
+            action: command.action,
+            success: response.error === null,
+            ...(command.action === "create" || command.action === "configure"
+              ? { cli: command.cli }
+              : {}),
+            ...(command.action === "bindProject"
+              ? { connected: command.workspaceId !== null }
+              : {}),
+            workspaceCount: response.state.workspaces.length,
+            sourceCount: response.state.workspaces.reduce(
+              (total, workspace) => total + workspace.sources.length,
+              0,
+            ),
+            indexedSourceCount: response.state.workspaces.reduce(
+              (total, workspace) =>
+                total + workspace.sources.filter((source) => source.status === "ready").length,
+              0,
+            ),
+          });
         }
         return response;
       }),

--- a/apps/server/src/brain/mcp.test.ts
+++ b/apps/server/src/brain/mcp.test.ts
@@ -16,6 +16,7 @@ import type { BrainRuntime } from "./BrainRuntime.ts";
 import { BrainToolkitRegistrationLive } from "./mcp.ts";
 import { McpInvocationContext } from "../mcp/McpInvocationContext.ts";
 import { ProjectionSnapshotQuery } from "../orchestration/Services/ProjectionSnapshotQuery.ts";
+import * as AnalyticsService from "../telemetry/AnalyticsService.ts";
 
 const encodeToolResult = Schema.encodeEffect(McpSchema.CallToolResult);
 const client = McpSchema.McpServerClient.of({
@@ -44,6 +45,10 @@ it.effect(
     Effect.scoped(
       Effect.gen(function* () {
         const readProjects: string[] = [];
+        const analyticsEvents: Array<{
+          event: string;
+          properties?: Readonly<Record<string, unknown>>;
+        }> = [];
         const runtime = {
           chatMemories: async (id: ProjectId, session: string) => {
             expect(id).toBe(projectId);
@@ -71,6 +76,21 @@ it.effect(
           Layer.provideMerge(McpServer.McpServer.layer),
           Layer.provideMerge(Layer.succeed(BrainService, { ready: Effect.succeed(runtime) })),
           Layer.provideMerge(Layer.succeed(ProjectionSnapshotQuery, projections)),
+          Layer.provideMerge(
+            Layer.succeed(
+              AnalyticsService.AnalyticsService,
+              AnalyticsService.AnalyticsService.of({
+                record: (event, properties) =>
+                  Effect.sync(() =>
+                    analyticsEvents.push({
+                      event,
+                      ...(properties === undefined ? {} : { properties }),
+                    }),
+                  ),
+                flush: Effect.void,
+              }),
+            ),
+          ),
         );
         yield* Effect.gen(function* () {
           const server = yield* McpServer.McpServer;
@@ -114,6 +134,24 @@ it.effect(
           );
           expect(denied.isError).toBe(true);
           expect(readProjects).toEqual([projectId]);
+          expect(analyticsEvents).toEqual([
+            {
+              event: "brain.tool.completed",
+              properties: { tool: "search_knowledge", success: true },
+            },
+            {
+              event: "brain.tool.completed",
+              properties: { tool: "get_chat_memories", success: true },
+            },
+            {
+              event: "brain.tool.completed",
+              properties: { tool: "get_chat_memories", success: false },
+            },
+            {
+              event: "brain.tool.completed",
+              properties: { tool: "search_knowledge", success: false },
+            },
+          ]);
         }).pipe(Effect.provide(layer));
       }),
     ),

--- a/apps/server/src/brain/mcp.ts
+++ b/apps/server/src/brain/mcp.ts
@@ -9,6 +9,7 @@ import { McpInvocationContext } from "../mcp/McpInvocationContext.ts";
 import { ProjectionSnapshotQuery } from "../orchestration/Services/ProjectionSnapshotQuery.ts";
 import { BrainService } from "./BrainService.ts";
 import { originalBrainTools } from "./session-worker.ts";
+import { AnalyticsService } from "../telemetry/AnalyticsService.ts";
 
 const encodeChatMemories = Schema.encodeEffect(Schema.fromJsonString(ChatMemoryList));
 
@@ -19,6 +20,7 @@ export const BrainToolkitRegistrationLive = Layer.effectDiscard(
     const registry = yield* McpServer.McpServer;
     const service = yield* BrainService;
     const projections = yield* ProjectionSnapshotQuery;
+    const analytics = yield* AnalyticsService;
     const tools = yield* Effect.promise(originalBrainTools);
     const chatMemoryTool = {
       name: "get_chat_memories",
@@ -74,6 +76,12 @@ export const BrainToolkitRegistrationLive = Layer.effectDiscard(
                 error instanceof Error ? error.message : "The connected brain is unavailable.",
             });
           }).pipe(
+            Effect.tap(() =>
+              analytics.record("brain.tool.completed", { tool: tool.name, success: true }),
+            ),
+            Effect.tapError(() =>
+              analytics.record("brain.tool.completed", { tool: tool.name, success: false }),
+            ),
             Effect.catch((error) =>
               Effect.succeed(
                 new McpSchema.CallToolResult({

--- a/apps/server/src/telemetry/AnalyticsService.test.ts
+++ b/apps/server/src/telemetry/AnalyticsService.test.ts
@@ -16,6 +16,7 @@ import * as AnalyticsService from "./AnalyticsService.ts";
 interface RecordedBatchRequest {
   readonly path: string;
   readonly body: {
+    readonly api_key?: string;
     readonly batch?: ReadonlyArray<{
       readonly event?: string;
       readonly properties?: {
@@ -32,6 +33,7 @@ interface RecordedBatchRequest {
 }
 
 interface RecordedBatchBody {
+  readonly api_key?: string;
   readonly batch: ReadonlyArray<{
     readonly event?: string;
     readonly properties?: {
@@ -58,7 +60,6 @@ it.layer(NodeServices.layer)("AnalyticsService test", (it) => {
       const configLayer = ConfigProvider.layer(
         ConfigProvider.fromUnknown({
           T3CODE_TELEMETRY_ENABLED: true,
-          T3CODE_POSTHOG_KEY: "phc_test_key",
           T3CODE_POSTHOG_HOST: "http://localhost",
           T3CODE_TELEMETRY_FLUSH_BATCH_SIZE: 20,
         }),
@@ -109,6 +110,12 @@ it.layer(NodeServices.layer)("AnalyticsService test", (it) => {
           Array.isArray(request.body?.batch),
       );
       assert.equal(batchRequests.length, 3);
+      assert.equal(
+        batchRequests.every(
+          (request) => request.body.api_key === "phc_A9NCvdsZWDbNgoDNeku45iBArjCjHFobPyBw2XqRgfB8",
+        ),
+        true,
+      );
       assert.equal(
         batchRequests.every(
           (request) => request.path.endsWith("/batch/") || request.path.endsWith("/batch"),

--- a/apps/server/src/telemetry/AnalyticsService.ts
+++ b/apps/server/src/telemetry/AnalyticsService.ts
@@ -31,7 +31,7 @@ interface BufferedAnalyticsEvent {
 
 const TelemetryEnvConfig = Config.all({
   posthogKey: Config.string("T3CODE_POSTHOG_KEY").pipe(
-    Config.withDefault("phc_XOWci4oZP4VvLiEyrFqkFjP4CZn55mjYYBMREK5Wd6m"),
+    Config.withDefault("phc_A9NCvdsZWDbNgoDNeku45iBArjCjHFobPyBw2XqRgfB8"),
   ),
   posthogHost: Config.string("T3CODE_POSTHOG_HOST").pipe(
     Config.withDefault("https://us.i.posthog.com"),

--- a/docs/internals/product-analytics.md
+++ b/docs/internals/product-analytics.md
@@ -47,3 +47,10 @@ Keep analytics payloads to product metadata and normalized measurements. Do not
 send prompts, authentication material, raw provider payloads, user-assigned device
 names, or conversation identifiers. Client metadata is best effort; invalid values
 must not reject a connection. PostHog person profiles remain disabled.
+
+Brain analytics use four event families. `brain.command.completed` measures setup and configuration
+operations after the server has processed them. Imports and reindexes are asynchronous, so use
+`brain.source.indexed` for their actual outcomes and duration. `brain.tool.completed` measures
+successful and failed agent consultations by fixed tool name. `brain.curation.completed` measures
+background extraction runs, context renewals, and available token totals. These events never include
+workspace, repository, source, chat, or document identifiers, nor tool arguments or extracted text.

--- a/docs/user/telemetry.md
+++ b/docs/user/telemetry.md
@@ -1,8 +1,9 @@
 # Product usage data
 
-The T3 Code server sends product usage events to PostHog, associated with a hashed account or
+The Flow server sends product usage events to Flow's PostHog project, associated with a hashed account or
 installation identifier. Events include the provider, model, reasoning effort, permission mode,
-turn result, duration, and main-agent token totals when available.
+turn result, duration, and main-agent token totals when available. Flow also records Brain setup,
+repository indexing outcomes, anonymous tool usage, and background curation health.
 
 Events do not include prompts, responses, file contents, authentication tokens, conversation IDs,
 raw provider events, or child-agent output. Child-agent token use is excluded from the totals.


### PR DESCRIPTION
Flow's T3 server still sent its default anonymous analytics to the upstream T3 PostHog project, and Brain adoption and health were invisible. This routes the default stream to Flow's existing PostHog project and adds privacy-safe events for Brain setup, indexing, agent consultation, and passive curation.

## What changed

- use Flow's PostHog project key by default while retaining the existing environment override and telemetry opt-out
- record `brain.command.completed`, `brain.source.indexed`, `brain.tool.completed`, and `brain.curation.completed`
- restrict Brain event properties to fixed enums, booleans, counts, durations, and token totals; exclude repository names, paths, prompts, queries, identifiers, tool arguments, and extracted content
- document the event semantics, including the distinction between accepted indexing commands and completed background indexing

## Validation

- `./node_modules/.bin/vp run --filter t3 typecheck`
- targeted lint for the ten changed TypeScript files
- 7 focused telemetry/Brain test files: 10 tests passed
- existing server analytics integration test: 1 passed, 179 skipped

Created with gpt-5.6-sol via the Codex harness in Flow.
