### PR TITLE
feat(desktop): ship signed Flow releases

### DIFF
--- a/.github/workflows/flow-desktop-release.yml
+++ b/.github/workflows/flow-desktop-release.yml
@@ -1,0 +1,314 @@
+name: Flow Desktop Release
+
+on:
+  push:
+    tags:
+      - "flow-desktop-v*.*.*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Desktop version to publish (for example 0.1.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: flow-desktop-release
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    name: Resolve release
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+      tag: ${{ steps.release.outputs.tag }}
+    steps:
+      - id: release
+        name: Validate version
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+            version="${GITHUB_REF_NAME#flow-desktop-v}"
+          else
+            version="${INPUT_VERSION#v}"
+          fi
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Version must be X.Y.Z; received '$version'." >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=flow-desktop-v$version" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build ${{ matrix.label }}
+    needs: preflight
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: macOS arm64
+            runner: macos-15
+            platform: mac
+            target: dmg
+            arch: arm64
+            rust_target: aarch64-apple-darwin
+          - label: macOS x64
+            runner: macos-15
+            platform: mac
+            target: dmg
+            arch: x64
+            rust_target: x86_64-apple-darwin
+          - label: Linux x64
+            runner: ubuntu-24.04
+            platform: linux
+            target: AppImage
+            arch: x64
+            rust_target: x86_64-unknown-linux-gnu
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            /*
+            !/.repos/
+          sparse-checkout-cone-mode: false
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version-file: package.json
+          cache: true
+          run-install: false
+
+      - name: Install desktop dependencies
+        run: vp install --filter=@t3tools/desktop... --filter=t3... --filter=@t3tools/scripts...
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust_target }}
+
+      - name: Install Linux build libraries
+        if: matrix.platform == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsecret-1-dev pkg-config imagemagick
+
+      - name: Configure public application services
+        shell: bash
+        env:
+          CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
+          CLERK_JWT_TEMPLATE: ${{ vars.CLERK_JWT_TEMPLATE }}
+          CLERK_CLI_OAUTH_CLIENT_ID: ${{ vars.CLERK_CLI_OAUTH_CLIENT_ID }}
+          RELAY_URL: ${{ vars.RELAY_URL }}
+        run: |
+          set -euo pipefail
+          : > .env
+          [[ -z "$CLERK_PUBLISHABLE_KEY" ]] || printf 'T3CODE_CLERK_PUBLISHABLE_KEY=%s\n' "$CLERK_PUBLISHABLE_KEY" >> .env
+          [[ -z "$CLERK_JWT_TEMPLATE" ]] || printf 'T3CODE_CLERK_JWT_TEMPLATE=%s\n' "$CLERK_JWT_TEMPLATE" >> .env
+          [[ -z "$CLERK_CLI_OAUTH_CLIENT_ID" ]] || printf 'T3CODE_CLERK_CLI_OAUTH_CLIENT_ID=%s\n' "$CLERK_CLI_OAUTH_CLIENT_ID" >> .env
+          [[ -z "$RELAY_URL" ]] || printf 'T3CODE_RELAY_URL=%s\n' "$RELAY_URL" >> .env
+
+      - name: Set release version
+        run: node scripts/update-release-package-versions.ts "${{ needs.preflight.outputs.version }}"
+
+      - name: Prepare Apple credentials
+        if: matrix.platform == 'mac'
+        shell: bash
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_API_KEY_VALUE: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_ID_VALUE: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          MACOS_PROVISIONING_PROFILE_VALUE: ${{ secrets.MACOS_PROVISIONING_PROFILE }}
+          APPLE_TEAM_ID_VALUE: ${{ vars.APPLE_TEAM_ID }}
+          PASSKEY_RP_DOMAINS: ${{ vars.CLERK_PASSKEY_RP_DOMAINS }}
+        run: |
+          set -euo pipefail
+          required=(CSC_LINK CSC_KEY_PASSWORD APPLE_API_KEY_VALUE APPLE_API_KEY_ID_VALUE APPLE_API_ISSUER)
+          for name in "${required[@]}"; do
+            if [[ -z "${!name:-}" ]]; then
+              echo "Missing required Apple release credential: $name" >&2
+              exit 1
+            fi
+          done
+
+          key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID_VALUE}.p8"
+          printf '%s' "$APPLE_API_KEY_VALUE" > "$key_path"
+          chmod 600 "$key_path"
+          echo "APPLE_API_KEY=$key_path" >> "$GITHUB_ENV"
+          echo "APPLE_API_KEY_ID=$APPLE_API_KEY_ID_VALUE" >> "$GITHUB_ENV"
+
+          if [[ -n "$PASSKEY_RP_DOMAINS" ]]; then
+            if [[ -z "$APPLE_TEAM_ID_VALUE" || -z "$MACOS_PROVISIONING_PROFILE_VALUE" ]]; then
+              echo "Passkey domains require APPLE_TEAM_ID and MACOS_PROVISIONING_PROFILE." >&2
+              exit 1
+            fi
+            profile_path="$RUNNER_TEMP/Flow.provisionprofile"
+            printf '%s' "$MACOS_PROVISIONING_PROFILE_VALUE" | base64 -D > "$profile_path"
+            security cms -D -i "$profile_path" >/dev/null
+            echo "T3CODE_APPLE_TEAM_ID=$APPLE_TEAM_ID_VALUE" >> "$GITHUB_ENV"
+            echo "T3CODE_MACOS_PROVISIONING_PROFILE=$profile_path" >> "$GITHUB_ENV"
+            echo "T3CODE_CLERK_PASSKEY_RP_DOMAINS=$PASSKEY_RP_DOMAINS" >> "$GITHUB_ENV"
+          fi
+
+      - id: build
+        name: Build desktop artifact
+        shell: bash
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          T3CODE_DESKTOP_UPDATE_URL: https://github.com/${{ github.repository }}/releases/download/flow-desktop-latest
+        run: |
+          set -euo pipefail
+          args=(
+            --platform "${{ matrix.platform }}"
+            --target "${{ matrix.target }}"
+            --arch "${{ matrix.arch }}"
+            --build-version "${{ needs.preflight.outputs.version }}"
+            --verbose
+          )
+          [[ "${{ matrix.platform }}" != "mac" ]] || args+=(--signed)
+          vp run dist:desktop:artifact "${args[@]}"
+
+      - name: Notarize and validate macOS distribution files
+        if: matrix.platform == 'mac'
+        shell: bash
+        env:
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          dmgs=(release/*.dmg)
+          zips=(release/*.zip)
+          (( ${#dmgs[@]} == 1 && ${#zips[@]} == 1 )) || {
+            echo "Expected one DMG and one ZIP." >&2
+            exit 1
+          }
+
+          for artifact in "${dmgs[0]}" "${zips[0]}"; do
+            xcrun notarytool submit "$artifact" \
+              --key "$APPLE_API_KEY" \
+              --key-id "$APPLE_API_KEY_ID" \
+              --issuer "$APPLE_API_ISSUER" \
+              --wait
+          done
+
+          xcrun stapler staple "${dmgs[0]}"
+          xcrun stapler validate "${dmgs[0]}"
+
+          zip_dir="$RUNNER_TEMP/flow-zip"
+          ditto -x -k "${zips[0]}" "$zip_dir"
+          zip_app="$(find "$zip_dir" -maxdepth 1 -type d -name 'Flow.app' -print -quit)"
+          [[ -n "$zip_app" ]] || { echo "Flow.app is missing from ZIP." >&2; exit 1; }
+          codesign --verify --deep --strict --verbose=2 "$zip_app"
+          spctl --assess --type execute --verbose=4 "$zip_app"
+          xcrun stapler validate "$zip_app"
+
+          mount_dir="$RUNNER_TEMP/flow-dmg"
+          mkdir -p "$mount_dir"
+          device="$(hdiutil attach "${dmgs[0]}" -nobrowse -readonly -mountpoint "$mount_dir" | awk 'NR == 1 {print $1}')"
+          trap 'hdiutil detach "$device" >/dev/null' EXIT
+          codesign --verify --deep --strict --verbose=2 "$mount_dir/Flow.app"
+          spctl --assess --type execute --verbose=4 "$mount_dir/Flow.app"
+
+      - name: Collect release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir release-publish
+          find release -maxdepth 1 -type f \( \
+            -name '*.dmg' -o -name '*.zip' -o -name '*.AppImage' -o \
+            -name '*.blockmap' -o -name '*.yml' \
+          \) -exec cp {} release-publish/ \;
+          if [[ "${{ matrix.platform }}" == "mac" && "${{ matrix.arch }}" == "x64" ]]; then
+            for manifest in release-publish/*-mac.yml; do
+              mv "$manifest" "${manifest%.yml}-x64.yml"
+            done
+          fi
+          [[ -n "$(find release-publish -type f -print -quit)" ]] || exit 1
+
+      - name: Upload release assets
+        uses: actions/upload-artifact@v7
+        with:
+          name: flow-desktop-${{ matrix.platform }}-${{ matrix.arch }}
+          path: release-publish/*
+          if-no-files-found: error
+
+  publish:
+    name: Publish desktop release
+    needs: [preflight, build]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout release scripts
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: scripts
+
+      - name: Download release assets
+        uses: actions/download-artifact@v8
+        with:
+          pattern: flow-desktop-*
+          merge-multiple: true
+          path: release-assets
+
+      - name: Merge macOS updater manifests
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          for x64_manifest in release-assets/*-mac-x64.yml; do
+            arm64_manifest="${x64_manifest%-x64.yml}.yml"
+            [[ -f "$arm64_manifest" ]] || { echo "Missing arm64 macOS manifest." >&2; exit 1; }
+            node scripts/merge-update-manifests.ts --platform mac "$arm64_manifest" "$x64_manifest"
+            rm "$x64_manifest"
+          done
+          (cd release-assets && sha256sum * > SHA256SUMS)
+
+      - name: Publish versioned and rolling releases
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.preflight.outputs.tag }}
+          RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          set -euo pipefail
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists." >&2
+            exit 1
+          fi
+          gh release create "$RELEASE_TAG" release-assets/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title "Flow $RELEASE_VERSION" \
+            --generate-notes \
+            --latest=false
+
+          rolling_tag=flow-desktop-latest
+          if ! gh release view "$rolling_tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create "$rolling_tag" \
+              --repo "$GITHUB_REPOSITORY" \
+              --target "$GITHUB_SHA" \
+              --prerelease \
+              --title "Latest Flow desktop update" \
+              --notes "Rolling update feed for the latest signed Flow desktop release."
+          fi
+          gh release view "$rolling_tag" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name' |
+            while read -r asset; do
+              gh release delete-asset "$rolling_tag" "$asset" --repo "$GITHUB_REPOSITORY" --yes
+            done
+          gh release upload "$rolling_tag" release-assets/* --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/flow-desktop-release.yml
+++ b/.github/workflows/flow-desktop-release.yml
@@ -207,6 +207,7 @@ jobs:
 
           xcrun stapler staple "${dmgs[0]}"
           xcrun stapler validate "${dmgs[0]}"
+          node scripts/refresh-update-manifest.ts release/latest-mac.yml release macOS
 
           zip_dir="$RUNNER_TEMP/flow-zip"
           ditto -x -k "${zips[0]}" "$zip_dir"
@@ -257,7 +258,19 @@ jobs:
       - name: Checkout release scripts
         uses: actions/checkout@v6
         with:
-          sparse-checkout: scripts
+          sparse-checkout: |
+            /*
+            !/.repos/
+          sparse-checkout-cone-mode: false
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version-file: package.json
+          cache: true
+          run-install: |
+            args:
+              - --filter=@t3tools/scripts...
 
       - name: Download release assets
         uses: actions/download-artifact@v8

--- a/.github/workflows/flow-desktop-release.yml
+++ b/.github/workflows/flow-desktop-release.yml
@@ -218,8 +218,8 @@ jobs:
 
           mount_dir="$RUNNER_TEMP/flow-dmg"
           mkdir -p "$mount_dir"
-          device="$(hdiutil attach "${dmgs[0]}" -nobrowse -readonly -mountpoint "$mount_dir" | awk 'NR == 1 {print $1}')"
-          trap 'hdiutil detach "$device" >/dev/null' EXIT
+          hdiutil attach "${dmgs[0]}" -nobrowse -readonly -mountpoint "$mount_dir" >/dev/null
+          trap 'hdiutil detach "$mount_dir" >/dev/null 2>&1 || true' EXIT
           codesign --verify --deep --strict --verbose=2 "$mount_dir/Flow.app"
           spctl --assess --type execute --verbose=4 "$mount_dir/Flow.app"
 

--- a/README.md
+++ b/README.md
@@ -1,161 +1,144 @@
-# Flow
+<div align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="./apps/web/public/brand-wordmark-on-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="./apps/web/public/brand-wordmark-on-light.svg">
+    <img alt="Flow" src="./apps/web/public/brand-wordmark-on-light.svg" width="180">
+  </picture>
 
-This branch establishes Flow's agent workspace on the T3 Code foundation. It is
-an independent fork, with T3's original Git history retained. The web and desktop
-interface includes a local Brain backed by native FalkorDB. Open **Brain** in the
-sidebar, use the selector and **New brain** inside that page, and choose Claude Code,
-Codex, or OpenCode as its default indexing CLI. Connect GitHub repositories or a
-local Git folder through the source cards. Public repositories
-work without GitHub sign-in; private repositories use the selected computer's
-existing GitHub CLI sign-in (managed in Settings → Source control).
+  <h3>Coding harness with a brain.</h3>
 
-Indexing uses Flow's original graph-builder instructions and graph gateway,
-including provenance, duplicate detection, usage contracts, cross-repository
-links, and incremental Git updates. Builders write directly to FalkorDB as they
-explore; the graph and per-repository activity logs refresh every two seconds
-while the page is visible. The selected CLI uses its existing credentials and
-Flow's indexing model defaults (overridable with GRAPH_BUILDER_MODEL).
-Session capture feeds Flow's original checkpoint and memory pipeline.
-Linear/Fireflies/notes/Slack workers and cloud Brain migration remain deferred. Older prototype graphs are retained for reference;
-reindex their sources to build them with the full Flow pipeline.
+  <p>Run your coding agents. Flow remembers the work.</p>
+</div>
 
-When adding a project in the web or desktop UI, choose its brain (or create one).
-The repository is registered as a source automatically. Change the connection
-in **Brain → Projects**; disconnecting a project retains the old brain's source.
-Agent sessions receive Flow's original instructions and full `orient` result,
-then use the original graph, memory and source tools for retrieval. Session
-restart, compaction and Brain changes refresh orientation; no per-turn memory
-injection is added. Mobile project creation does not yet have a Brain picker.
+Flow is an open-source workspace for coding agents. Start a task with the provider
+you already use, and Flow captures the session into a project Brain: a searchable
+knowledge graph, retained conversation notes, living documentation, and reusable
+skills that improve as the project evolves.
 
-The root contains T3's web, desktop, mobile, and server applications. The existing
-Flow implementation is preserved under [`flow/`](flow/README.md) as a migration
-reference. The active shared Brain packages live under
-[`flow-t3/shared/`](flow-t3/README.md); public cloud interfaces live under
-`flow-t3/cloud/`. T3 builds from the shared packages without requiring the Flow CLI.
+You keep coding while Flow maintains the context agents usually lose between
+sessions. When another agent picks up the work, it can orient itself from the same
+Brain instead of asking you to explain the codebase and its decisions again.
 
-The first integration target is the complete free local developer setup. A
-workspace has one brain, initially running locally; a future cloud migration
-will transfer its data and change its endpoint. Agent execution location is
-independent of brain location.
+## Download
 
-The intended local experience is to launch the app and create projects in the UI,
-without running `flow up`. Local workspaces in one app server share an app-managed FalkorDB instance with
-separate workspace graphs and one lazily loaded embedding model. No Docker or
-`flow up` is used. Native FalkorDB binaries support Apple Silicon macOS 15+ and Linux
-x64; other platforms are not supported by this native integration yet. On macOS,
-the app downloads a checksum-verified upstream binary bundle with its native
-libraries (no Homebrew or Python interpreter required). The graph
-storage directory is derived from the installation home under `~/.flow-brain/`
-(to keep Unix socket paths short); workspace settings and model files are kept
-in that installation’s `userdata/brain/`. The UI uses the selected computer’s
-authenticated connection. Moving a brain independently to a remote backend is
-still a future integration.
+| Platform                  | Availability                                                                                                                                                          |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| macOS 15+ · Apple Silicon | **[Download Flow 0.1.2 (.dmg)](https://github.com/samyakkkk/flow/releases/download/flow-desktop-v0.1.2/Flow-0.1.2-arm64.dmg)** · signed, notarized, and auto-updating |
+| macOS · Intel             | Coming soon                                                                                                                                                           |
+| Linux · x64               | [Install from source](./docs/user/install.md#install-from-a-checkout) · Ubuntu 24.04 or compatible                                                                    |
+| Windows                   | Planned                                                                                                                                                               |
 
-This branch does not migrate installed data, configure Flow Cloud, or change
-existing installations. Use the Flow installation instructions below to run
-this fork. See [NOTICE.md](NOTICE.md) for attribution and license boundaries.
+See the [Flow 0.1.2 release](https://github.com/samyakkkk/flow/releases/tag/flow-desktop-v0.1.2)
+for checksums and updater assets. The macOS app checks for updates automatically;
+installing from source requires manual updates.
 
-## Upstream T3 Code
+## Why Flow
 
-T3 Code is an "agent harness control surface". It enables control of the agents on your machine with a best-in-class mobile app ([iOS](https://apps.apple.com/us/app/t3-code-remote-claude-more/id6787819824), [Android](https://play.google.com/store/apps/details?id=com.t3tools.t3code)), [web app](https://app.t3.codes) and [Electron-based desktop app](https://t3.codes).
+Most coding harnesses remember a chat. Flow builds project knowledge from the work
+inside every chat.
 
-Works with your subscriptions on Claude Code, Codex, Cursor, Grok Build, OpenCode, and Google Antigravity. If they're set up on your computer, T3 Code can control them.
+- **Bring your own agent.** Use Codex, Claude Code, Cursor, Grok Build, OpenCode,
+  or Google Antigravity with the accounts and subscriptions already configured on
+  your machine.
+- **One Brain per workspace.** Flow indexes your repositories into a graph of
+  services, capabilities, APIs, resources, and the relationships between them.
+- **Context that survives sessions.** Each agent can orient itself, search the
+  graph, retrieve past decisions, and follow the evidence back to code.
+- **Auto-Docs and Auto-Skills.** Flow turns work into maintained documentation and
+  reusable procedures. You do not have to keep rewriting project instructions or
+  manually curate a folder of skills.
+- **Parallel work without losing control.** Run multiple threads and worktrees,
+  inspect diffs, use integrated terminals, and restore checkpointed workspace
+  state.
+- **Local by default.** Your projects, provider credentials, agent processes, and
+  local Brain stay on the machine that owns the workspace.
+- **Remote ready.** Connect from another browser, desktop, or phone while execution
+  remains on the host machine.
 
-## "Wait, what are you selling me?"
+## How the Brain works
 
-Nothing. We built T3 Code because we wanted the best possible development experience with agents. We were inspired by existing solutions like the Codex desktop app, Conductor, Claude Desktop and Cursor Glass, but none met our bar.
-
-We wanted something performant, remote-ready, and truly open. If we ever go the wrong direction, we want you to have everything you need to fork and build the editor that you want.
-
-## Installation
-
-Install Flow on an Apple Silicon Mac running macOS 15 or newer:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/samyakkkk/flow/release/install.sh | bash
-open "$HOME/Applications/Flow.app"
+```mermaid
+flowchart LR
+    A[Agent sessions] --> B[Flow Brain]
+    R[Repositories] --> B
+    B --> G[Knowledge graph]
+    B --> N[Conversation notes]
+    B --> D[Auto-Docs]
+    B --> S[Auto-Skills]
+    G --> C[Better context for every agent]
+    N --> C
+    D --> C
+    S --> C
 ```
 
-The installer downloads a ready-built app with its own Node runtime, server,
-web interface, and native Brain libraries. No Node, npm, Homebrew, Docker, or
-local build is required. Open **Flow** from your Applications folder whenever
-you want to use it; its interface opens in your browser. You can drag its icon
-to the Dock. Configure your provider and Brain in the app.
+Flow passively captures the evidence already produced during a coding session. It
+uses that evidence to keep conversation notes, project knowledge, documentation,
+and skills current. Agents consult the Brain before working and can trace recalled
+context back to its source instead of relying on a loose prompt summary.
 
-The `flow` terminal command is also installed in `~/.local/bin`. See the
-[source-checkout instructions](./docs/user/install.md#install-from-a-checkout)
-for development and Linux installations.
+The local app manages the Brain runtime for you. There is no separate `flow up`
+lifecycle to operate, and creating another project does not start another database
+or load another embedding model.
 
-The installer follows published browser releases. Pushes to the `release` branch
-build and publish the next version after release checks pass.
+## Coming soon
 
-### Updates
+- Shared team Brains, so knowledge follows the project across teammates
+- Linear integration for issues, decisions, and delivery context
+- Slack integration for searchable conversations and shared project context
+- Native installers for macOS Intel and Linux x64
 
-Flow checks for updates in the background at startup and every six hours while
-running. Updates are downloaded and verified in a separate directory. When one is ready, the sidebar
-shows **Update ready · Restart to update**. Confirm the restart to apply it; the
-page reloads when Flow reconnects. Running sessions are not restarted without
-your action. A prepared update also takes effect when you next start the stopped
-app. Use `flow update` to prepare an update immediately, or `flow update --check`
-to check without downloading it.
+## Get started
 
-See [installation and provider setup](./docs/user/install.md) and
-[updating Flow](./docs/user/updating.md) for details. The upstream `npx t3`
-package and T3 desktop downloads install upstream T3 Code.
+1. Install Flow and open the app.
+2. Add a local project.
+3. Choose or create its Brain.
+4. Select a coding provider and start a thread.
 
-## Some notes
+The Brain indexes the repository and grows as you work. Open **Brain** in the
+sidebar to explore its **Knowledge Graph**, **Auto-Skills**, and retained context.
 
-We are very very early in this project. Expect bugs.
+Flow works with:
 
-We are (mostly) not accepting contributions yet. Small fixes may be considered. Big features will not be.
+| Provider    | Setup                                                                                       |
+| ----------- | ------------------------------------------------------------------------------------------- |
+| Codex       | [Install Codex CLI](https://developers.openai.com/codex/cli), then run `codex login`        |
+| Claude Code | [Install Claude Code](https://claude.com/product/claude-code), then run `claude auth login` |
+| Cursor      | [Install Cursor CLI](https://cursor.com/cli), then run `agent login`                        |
+| Grok Build  | [Install Grok Build CLI](https://x.ai/cli), then run `grok login`                           |
+| OpenCode    | [Install OpenCode](https://opencode.ai), then run `opencode auth login`                     |
+| Antigravity | Install and sign in with Google from Flow's provider settings                               |
+
+Provider CLIs run on the environment that owns the project. See
+[installation and provider setup](./docs/user/install.md) for binary paths,
+multiple accounts, and remote environments.
 
 ## Documentation
 
-Full docs live in [docs/](./docs). There's no docs site yet.
-
-- [Install and first run](./docs/user/install.md)
+- [Browser app and source installation](./docs/user/install.md)
+- [Working with threads](./docs/user/thread-sidebar.md)
 - [Permission modes](./docs/user/permission-modes.md)
 - [Keyboard shortcuts](./docs/user/keybindings.md)
-- [Project settings](./docs/user/project-settings.md)
-- [Remote access from a phone or another machine](./docs/user/remote-access.md)
-- [Keeping app and server in sync](./docs/user/updating.md)
+- [Project settings and Brain](./docs/user/project-settings.md)
+- [Remote access](./docs/user/remote-access.md)
+- [Updating Flow](./docs/user/updating.md)
 - [Source control integrations](./docs/user/source-control.md)
-- Multiple accounts: [Codex](./docs/user/providers-codex.md) · [Claude](./docs/user/providers-claude.md)
-- [Run T3 Code as a background service](./docs/user/background-service.md)
 
-Building from source? Start at [docs/internals/overview.md](./docs/internals/overview.md).
+Building from source? Start with the [development guide](./docs/operations/development.md)
+and read [CONTRIBUTING.md](./CONTRIBUTING.md).
 
-Publishing Flow? Use the repository's [$deploy-flow skill](./.agents/skills/deploy-flow/SKILL.md)
-and [browser release guide](./docs/operations/release.md#flow-browser-releases).
+## Project status
 
-## If you REALLY want to contribute still.... read this first
+Flow is early. Expect rough edges and frequent changes. Small fixes are welcome;
+please report problems and propose changes in
+[GitHub Issues](https://github.com/samyakkkk/flow/issues).
 
-### Install `vp`
+## Built on T3 Code
 
-T3 Code uses Vite+ so you'll need to install the global `vp` command-line tool.
+Flow uses the open-source [T3 Code](https://github.com/pingdotgg/t3code) agent
+harness as its interface and runtime foundation. T3's original Git history and
+license notices are preserved. Flow's active Brain packages live under
+[`flow-t3/shared/`](./flow-t3/README.md), while the original Flow implementation is
+kept under [`flow/`](./flow/README.md) as a historical reference.
 
-#### macOS / Linux
-
-```bash
-curl -fsSL https://vite.plus | bash
-```
-
-#### Windows
-
-```bash
-irm https://vite.plus/ps1 | iex
-```
-
-Checkout their getting started guide for more information: https://viteplus.dev/guide/
-
-### Install dependencies
-
-```bash
-vp i
-```
-
-Read [CONTRIBUTING.md](./CONTRIBUTING.md) before reporting a bug or opening a PR.
-
-Have a feature request? Start an [Ideas discussion](https://github.com/pingdotgg/t3code/discussions/categories/ideas).
-
-Need support? Join the [Discord](https://discord.gg/jn4EGJjrvv).
+See [NOTICE.md](./NOTICE.md) and [LICENSE](./LICENSE) for attribution and license
+details.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -37,5 +37,5 @@
     "tailwindcss": "^4.0.0",
     "vite-plus": "catalog:"
   },
-  "productName": "Flow (Alpha)"
+  "productName": "Flow"
 }

--- a/apps/desktop/scripts/electron-launcher.mjs
+++ b/apps/desktop/scripts/electron-launcher.mjs
@@ -16,11 +16,11 @@ const repoRoot = NodePath.resolve(desktopDir, "..", "..");
 const devBundleIdSuffix = NodePath.basename(repoRoot)
   .toLowerCase()
   .replaceAll(/[^a-z0-9]+/g, "");
-export const APP_DISPLAY_NAME = isDevelopment ? `${BRAND.name} (Dev)` : `${BRAND.name} (Alpha)`;
+export const APP_DISPLAY_NAME = isDevelopment ? `${BRAND.name} (Dev)` : BRAND.name;
 export const APP_BUNDLE_ID = isDevelopment
-  ? `com.t3tools.t3code.dev.${devBundleIdSuffix || "local"}`
-  : "com.t3tools.t3code";
-const APP_PROTOCOL_SCHEMES = isDevelopment ? ["t3code-dev"] : ["t3code"];
+  ? `com.flow.desktop.dev.${devBundleIdSuffix || "local"}`
+  : "com.flow.desktop";
+const APP_PROTOCOL_SCHEMES = isDevelopment ? ["flow-dev"] : ["flow"];
 const LAUNCHER_VERSION = 15;
 const developmentMacIconPngPath = NodePath.join(repoRoot, "assets", "brand", "icon.png");
 const productionMacIconPngPath = developmentMacIconPngPath;

--- a/apps/desktop/scripts/electron-launcher.test.mjs
+++ b/apps/desktop/scripts/electron-launcher.test.mjs
@@ -85,9 +85,9 @@ describe("electron development launcher", () => {
     const production = resolveMacLauncherIconPaths("/runtime", false);
 
     // The source icons are real repo paths, joined for the host.
-    assert.match(development.sourceIconPath, /assets[\\/]dev[\\/]blueprint-macos-1024\.png$/);
+    assert.match(development.sourceIconPath, /assets[\\/]brand[\\/]icon\.png$/);
     assert.equal(development.generatedIconPath, "/runtime/icon-dev.icns");
-    assert.match(production.sourceIconPath, /assets[\\/]prod[\\/]black-macos-1024\.png$/);
+    assert.match(production.sourceIconPath, /assets[\\/]brand[\\/]icon\.png$/);
     assert.equal(production.generatedIconPath, "/runtime/icon-prod.icns");
   });
 });

--- a/apps/desktop/src/app/DesktopClerk.test.ts
+++ b/apps/desktop/src/app/DesktopClerk.test.ts
@@ -80,7 +80,7 @@ describe("DesktopClerk", () => {
           {
             storage: storageAdapter,
             passkeys: true,
-            renderer: { scheme: "t3code-dev", host: "app" },
+            renderer: { scheme: "flow-dev", host: "app" },
           },
         ],
       ]);

--- a/apps/desktop/src/app/DesktopEarlyElectronStartup.test.ts
+++ b/apps/desktop/src/app/DesktopEarlyElectronStartup.test.ts
@@ -81,7 +81,7 @@ describe("DesktopEarlyElectronStartup", () => {
     });
 
     assert.deepEqual(options, {
-      linuxWmClass: "t3code-dev",
+      linuxWmClass: "flow-dev",
       passwordStore: "gnome-libsecret",
     });
   });

--- a/apps/desktop/src/app/DesktopEarlyElectronStartup.ts
+++ b/apps/desktop/src/app/DesktopEarlyElectronStartup.ts
@@ -81,7 +81,7 @@ export function resolveEarlyLinuxElectronOptions(
 ): EarlyLinuxElectronOptions {
   const preference = resolveEarlyLinuxPasswordStorePreference(input);
   return {
-    linuxWmClass: isDevelopmentEnvironment(input.env) ? "t3code-dev" : "t3code",
+    linuxWmClass: isDevelopmentEnvironment(input.env) ? "flow-dev" : "flow",
     passwordStore: resolveLinuxPasswordStoreSwitch({
       preference,
       env: input.env,

--- a/apps/desktop/src/app/DesktopEnvironment.test.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.test.ts
@@ -73,8 +73,8 @@ describe("DesktopEnvironment", () => {
       assert.equal(environment.serverRoot, "/repo");
       assert.equal(environment.backendEntryPath, "/repo/apps/server/dist/bin.mjs");
       assert.equal(environment.backendCwd, "/repo");
-      assert.equal(environment.appUserModelId, "com.t3tools.t3code.dev");
-      assert.equal(environment.linuxWmClass, "t3code-dev");
+      assert.equal(environment.appUserModelId, "com.flow.desktop.dev");
+      assert.equal(environment.linuxWmClass, "flow-dev");
       assert.deepEqual(
         Option.map(environment.devServerUrl, (url) => url.href),
         Option.some("http://localhost:5173/"),
@@ -140,12 +140,12 @@ describe("DesktopEnvironment", () => {
       const environment = yield* makeEnvironment(
         {},
         {
-          T3CODE_DESKTOP_APP_USER_MODEL_ID: " com.t3tools.t3code.dev.local ",
+          T3CODE_DESKTOP_APP_USER_MODEL_ID: " com.flow.desktop.dev.local ",
           VITE_DEV_SERVER_URL: "http://localhost:5173",
         },
       );
 
-      assert.equal(environment.appUserModelId, "com.t3tools.t3code.dev.local");
+      assert.equal(environment.appUserModelId, "com.flow.desktop.dev.local");
     }),
   );
 

--- a/apps/desktop/src/app/DesktopEnvironment.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.ts
@@ -96,7 +96,7 @@ function resolveDesktopAppStageLabel(input: {
     return "Dev";
   }
 
-  return isNightlyDesktopVersion(input.appVersion) ? "Nightly" : "Alpha";
+  return isNightlyDesktopVersion(input.appVersion) ? "Nightly" : "Latest";
 }
 
 function resolveDesktopAppBranding(input: {
@@ -107,7 +107,7 @@ function resolveDesktopAppBranding(input: {
   return {
     baseName: APP_BASE_NAME,
     stageLabel,
-    displayName: `${APP_BASE_NAME} (${stageLabel})`,
+    displayName: stageLabel === "Latest" ? APP_BASE_NAME : `${APP_BASE_NAME} (${stageLabel})`,
   };
 }
 
@@ -225,10 +225,10 @@ const make = Effect.fn("desktop.environment.make")(function* (
     branding,
     displayName,
     appUserModelId: Option.getOrElse(config.appUserModelIdOverride, () =>
-      isDevelopment ? "com.t3tools.t3code.dev" : "com.t3tools.t3code",
+      isDevelopment ? "com.flow.desktop.dev" : "com.flow.desktop",
     ),
-    linuxDesktopEntryName: isDevelopment ? "t3code-dev.desktop" : "t3code.desktop",
-    linuxWmClass: isDevelopment ? "t3code-dev" : "t3code",
+    linuxDesktopEntryName: isDevelopment ? "flow-dev.desktop" : "flow.desktop",
+    linuxWmClass: isDevelopment ? "flow-dev" : "flow",
     linuxApplicationsDir,
     appImagePath: config.appImagePath,
     userDataDirName,

--- a/apps/desktop/src/app/DesktopLinuxUrlHandler.test.ts
+++ b/apps/desktop/src/app/DesktopLinuxUrlHandler.test.ts
@@ -22,8 +22,8 @@ const makeEnvironment = (overrides: Record<string, unknown> = {}) =>
     platform: "linux",
     isPackaged: true,
     isDevelopment: false,
-    displayName: "T3 Code (Alpha)",
-    linuxWmClass: "t3code",
+    displayName: "Flow",
+    linuxWmClass: "flow",
     linuxApplicationsDir: "/home/alice/.local/share/applications",
     appImagePath: Option.some("/home/alice/Applications/T3-Code.AppImage"),
     path: { join: (...parts: ReadonlyArray<string>) => parts.join("/") },
@@ -107,7 +107,7 @@ describe("DesktopLinuxUrlHandler", () => {
     const entry = DesktopLinuxUrlHandler.renderUrlHandlerDesktopEntry({
       displayName: "T3 Code (Nightly)",
       execTarget: '/home/al ice/Apps/T3 "100%" $HOME\\x.AppImage',
-      scheme: "t3code",
+      scheme: "flow",
     });
 
     assert.include(entry, "[Desktop Entry]");
@@ -121,33 +121,33 @@ describe("DesktopLinuxUrlHandler", () => {
     );
     assert.include(entry, "NoDisplay=true");
     assert.notInclude(entry, "StartupWMClass=");
-    assert.include(entry, "MimeType=x-scheme-handler/t3code;");
+    assert.include(entry, "MimeType=x-scheme-handler/flow;");
   });
 
   it("carries structured context on registration errors", () => {
     const writeError = new DesktopLinuxUrlHandler.DesktopLinuxUrlHandlerRegistrationError({
       step: "write-desktop-entry",
-      scheme: "t3code",
-      desktopEntryPath: "/home/alice/.local/share/applications/t3code-url-handler.desktop",
+      scheme: "flow",
+      desktopEntryPath: "/home/alice/.local/share/applications/flow-url-handler.desktop",
       cause: new Error("boom"),
     });
     assert.equal(
       writeError.message,
-      "Failed to register the t3code:// URL handler (step: write-desktop-entry).",
+      "Failed to register the flow:// URL handler (step: write-desktop-entry).",
     );
     assert.equal(
       writeError.desktopEntryPath,
-      "/home/alice/.local/share/applications/t3code-url-handler.desktop",
+      "/home/alice/.local/share/applications/flow-url-handler.desktop",
     );
 
     const exitError = new DesktopLinuxUrlHandler.DesktopLinuxUrlHandlerRegistrationError({
       step: "set-default-handler",
-      scheme: "t3code",
+      scheme: "flow",
       exitCode: 4,
     });
     assert.equal(
       exitError.message,
-      "Failed to register the t3code:// URL handler (step: set-default-handler, xdg-mime exit code 4).",
+      "Failed to register the flow:// URL handler (step: set-default-handler, xdg-mime exit code 4).",
     );
   });
 
@@ -161,17 +161,17 @@ describe("DesktopLinuxUrlHandler", () => {
       assert.equal(recorded.files.length, 1);
       assert.equal(
         recorded.files[0]?.path,
-        "/home/alice/.local/share/applications/t3code-url-handler.desktop",
+        "/home/alice/.local/share/applications/flow-url-handler.desktop",
       );
       assert.include(
         recorded.files[0]?.content,
         'Exec="/home/alice/Applications/T3-Code.AppImage" %U',
       );
-      assert.include(recorded.files[0]?.content, "MimeType=x-scheme-handler/t3code;");
+      assert.include(recorded.files[0]?.content, "MimeType=x-scheme-handler/flow;");
       assert.deepEqual(recorded.commands, [
         {
           command: "xdg-mime",
-          args: ["default", "t3code-url-handler.desktop", "x-scheme-handler/t3code"],
+          args: ["default", "flow-url-handler.desktop", "x-scheme-handler/flow"],
         },
       ]);
     });
@@ -218,7 +218,7 @@ describe("DesktopLinuxUrlHandler", () => {
           module: "FileSystem",
           method: "writeFileString",
           description: "read-only filesystem",
-          pathOrDescriptor: "/home/alice/.local/share/applications/t3code-url-handler.desktop",
+          pathOrDescriptor: "/home/alice/.local/share/applications/flow-url-handler.desktop",
         }),
       });
 

--- a/apps/desktop/src/app/DesktopLinuxUrlHandler.ts
+++ b/apps/desktop/src/app/DesktopLinuxUrlHandler.ts
@@ -20,7 +20,7 @@ import { makeComponentLogger } from "./DesktopObservability.ts";
 // our own handler entry pointing at the current AppImage and claim the
 // scheme default via xdg-mime, exactly what the file manager's "set as
 // default" checkbox would record in mimeapps.list.
-export const URL_HANDLER_DESKTOP_ENTRY_NAME = "t3code-url-handler.desktop";
+export const URL_HANDLER_DESKTOP_ENTRY_NAME = "flow-url-handler.desktop";
 
 const { logInfo, logWarning } = makeComponentLogger("desktop-linux-url-handler");
 

--- a/apps/desktop/src/electron/ElectronProtocol.test.ts
+++ b/apps/desktop/src/electron/ElectronProtocol.test.ts
@@ -35,7 +35,7 @@ describe("ElectronProtocol", () => {
         Effect.gen(function* () {
           const protocol = yield* ElectronProtocol.ElectronProtocol;
           yield* protocol.registerDesktopProtocol({
-            scheme: "t3code-dev",
+            scheme: "flow-dev",
             targetOrigin: new URL("http://127.0.0.1:3773/"),
             backendOrigin: new URL("http://127.0.0.1:3774/"),
             clerkFrontendApiHostname: "clerk.t3.codes",
@@ -44,11 +44,11 @@ describe("ElectronProtocol", () => {
 
           const response = yield* Effect.promise(() =>
             handler!(
-              new Request("t3code-dev://app/api/health?verbose=1", {
+              new Request("flow-dev://app/api/health?verbose=1", {
                 headers: {
                   accept: "application/json",
-                  origin: "t3code-dev://app",
-                  referer: "t3code-dev://app/",
+                  origin: "flow-dev://app",
+                  referer: "flow-dev://app/",
                   "sec-fetch-site": "same-origin",
                 },
               }),
@@ -65,18 +65,18 @@ describe("ElectronProtocol", () => {
           );
           assert.include(
             response.headers.get("content-security-policy") ?? "",
-            "img-src 'self' t3code-dev: blob: data: http: https:",
+            "img-src 'self' flow-dev: blob: data: http: https:",
           );
           assert.include(
             response.headers.get("content-security-policy") ?? "",
-            "font-src 'self' t3code-dev: data:",
+            "font-src 'self' flow-dev: data:",
           );
         }),
       );
 
       assert.deepEqual(
         handleMock.mock.calls.map((call) => call[0]),
-        ["t3code-dev"],
+        ["flow-dev"],
       );
       assert.equal(netFetchMock.mock.calls[0]?.[0], "http://127.0.0.1:3773/api/health?verbose=1");
       const forwardedHeaders = new Headers(netFetchMock.mock.calls[0]?.[1]?.headers);
@@ -84,7 +84,7 @@ describe("ElectronProtocol", () => {
       assert.isNull(forwardedHeaders.get("origin"));
       assert.isNull(forwardedHeaders.get("referer"));
       assert.isNull(forwardedHeaders.get("sec-fetch-site"));
-      assert.deepEqual(unhandleMock.mock.calls, [["t3code-dev"]]);
+      assert.deepEqual(unhandleMock.mock.calls, [["flow-dev"]]);
     }).pipe(Effect.provide(ElectronProtocol.layer)),
   );
 
@@ -104,7 +104,7 @@ describe("ElectronProtocol", () => {
             backendOrigin: new URL("http://127.0.0.1:3773/"),
             clerkFrontendApiHostname: undefined,
           });
-          return yield* Effect.promise(() => handler!(new Request("t3code://other/")));
+          return yield* Effect.promise(() => handler!(new Request("flow://other/")));
         }),
       );
 
@@ -127,12 +127,12 @@ describe("ElectronProtocol", () => {
         Effect.gen(function* () {
           const protocol = yield* ElectronProtocol.ElectronProtocol;
           yield* protocol.registerDesktopProtocol({
-            scheme: "t3code-dev",
+            scheme: "flow-dev",
             targetOrigin: new URL("http://127.0.0.1:5733/"),
             backendOrigin: new URL("http://127.0.0.1:3773/"),
             clerkFrontendApiHostname: undefined,
           });
-          return yield* Effect.promise(() => handler!(new Request("t3code-dev://app/")));
+          return yield* Effect.promise(() => handler!(new Request("flow-dev://app/")));
         }),
       );
 
@@ -151,7 +151,7 @@ describe("ElectronProtocol", () => {
       const protocol = yield* ElectronProtocol.ElectronProtocol;
       const error = yield* Effect.scoped(
         protocol.registerDesktopProtocol({
-          scheme: "t3code-dev",
+          scheme: "flow-dev",
           targetOrigin: new URL("http://127.0.0.1:3773/"),
           backendOrigin: new URL("http://127.0.0.1:3774/"),
           clerkFrontendApiHostname: undefined,
@@ -159,9 +159,9 @@ describe("ElectronProtocol", () => {
       ).pipe(Effect.flip);
 
       assert.instanceOf(error, ElectronProtocol.ElectronProtocolRegistrationError);
-      assert.equal(error.scheme, "t3code-dev");
+      assert.equal(error.scheme, "flow-dev");
       assert.strictEqual(error.cause, cause);
-      assert.equal(error.message, 'Failed to register Electron protocol scheme "t3code-dev".');
+      assert.equal(error.message, 'Failed to register Electron protocol scheme "flow-dev".');
     }).pipe(Effect.provide(ElectronProtocol.layer)),
   );
 

--- a/apps/desktop/src/electron/ElectronProtocol.ts
+++ b/apps/desktop/src/electron/ElectronProtocol.ts
@@ -9,8 +9,8 @@ import * as Scope from "effect/Scope";
 import * as Electron from "electron";
 
 export const DESKTOP_HOST = "app";
-export const DESKTOP_PRODUCTION_SCHEME = "t3code";
-export const DESKTOP_DEVELOPMENT_SCHEME = "t3code-dev";
+export const DESKTOP_PRODUCTION_SCHEME = "flow";
+export const DESKTOP_DEVELOPMENT_SCHEME = "flow-dev";
 
 export function getDesktopScheme(isDevelopment: boolean): string {
   return isDevelopment ? DESKTOP_DEVELOPMENT_SCHEME : DESKTOP_PRODUCTION_SCHEME;

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -66,7 +66,7 @@ function makeFakeBrowserWindow() {
   let zoomLevel = 0;
   const webContents = {
     copyImageAt: vi.fn(),
-    getURL: vi.fn(() => "t3code-dev://app/"),
+    getURL: vi.fn(() => "flow-dev://app/"),
     getZoomLevel: vi.fn(() => zoomLevel),
     setZoomLevel: vi.fn((level: number) => {
       zoomLevel = level;
@@ -439,19 +439,19 @@ describe("DesktopWindow", () => {
   it("recognizes only same-origin renderer navigations", () => {
     assert.isTrue(
       DesktopWindow.isSameOriginRendererNavigation({
-        applicationUrl: "t3code://app/",
-        navigationUrl: "t3code://app/settings/connections",
+        applicationUrl: "flow://app/",
+        navigationUrl: "flow://app/settings/connections",
       }),
     );
     assert.isFalse(
       DesktopWindow.isSameOriginRendererNavigation({
-        applicationUrl: "t3code://app/",
+        applicationUrl: "flow://app/",
         navigationUrl: "https://accounts.microsoft.com/oauth",
       }),
     );
     assert.isFalse(
       DesktopWindow.isSameOriginRendererNavigation({
-        applicationUrl: "t3code://app/",
+        applicationUrl: "flow://app/",
         navigationUrl: "not a url",
       }),
     );
@@ -484,7 +484,7 @@ describe("DesktopWindow", () => {
         assert.isTrue(createdWindowOptions[0]?.disableAutoHideCursor);
         assert.isFalse(createdWindowOptions[0]?.webPreferences?.backgroundThrottling);
         assert.deepEqual(fakeWindow.setAutoHideCursor.mock.calls, [[false]]);
-        assert.deepEqual(fakeWindow.loadURL.mock.calls[0], ["t3code-dev://app/"]);
+        assert.deepEqual(fakeWindow.loadURL.mock.calls[0], ["flow-dev://app/"]);
         assert.equal(fakeWindow.openDevTools.mock.calls.length, 1);
       }).pipe(Effect.provide(layer));
     }),
@@ -1073,17 +1073,14 @@ describe("DesktopWindow", () => {
           return yield* Effect.die("renderer load listeners were not registered");
         }
 
-        didFailLoad({}, -9, "ERR_UNEXPECTED", "t3code-dev://app/", true);
+        didFailLoad({}, -9, "ERR_UNEXPECTED", "flow-dev://app/", true);
         assert.equal(fakeWindow.loadURL.mock.calls.length, 1);
 
         yield* TestClock.adjust(100);
-        assert.deepEqual(fakeWindow.loadURL.mock.calls, [
-          ["t3code-dev://app/"],
-          ["t3code-dev://app/"],
-        ]);
+        assert.deepEqual(fakeWindow.loadURL.mock.calls, [["flow-dev://app/"], ["flow-dev://app/"]]);
         assert.equal(fakeWindow.reload.mock.calls.length, 0);
 
-        didFailLoad({}, -9, "ERR_UNEXPECTED", "t3code-dev://app/", true);
+        didFailLoad({}, -9, "ERR_UNEXPECTED", "flow-dev://app/", true);
         didFinishLoad();
         yield* TestClock.adjust(250);
         assert.equal(fakeWindow.loadURL.mock.calls.length, 2);
@@ -1095,23 +1092,23 @@ describe("DesktopWindow", () => {
   it("retries only transient failures for the development renderer", () => {
     assert.isTrue(
       DesktopWindow.isRetryableDevelopmentRendererLoadFailure({
-        applicationUrl: "t3code-dev://app/",
+        applicationUrl: "flow-dev://app/",
         errorCode: -102,
         isMainFrame: true,
-        validatedUrl: "t3code-dev://app/",
+        validatedUrl: "flow-dev://app/",
       }),
     );
     assert.isFalse(
       DesktopWindow.isRetryableDevelopmentRendererLoadFailure({
-        applicationUrl: "t3code-dev://app/",
+        applicationUrl: "flow-dev://app/",
         errorCode: -3,
         isMainFrame: true,
-        validatedUrl: "t3code-dev://app/",
+        validatedUrl: "flow-dev://app/",
       }),
     );
     assert.isFalse(
       DesktopWindow.isRetryableDevelopmentRendererLoadFailure({
-        applicationUrl: "t3code-dev://app/",
+        applicationUrl: "flow-dev://app/",
         errorCode: -102,
         isMainFrame: true,
         validatedUrl: "https://example.com/",

--- a/apps/web/src/branding.ts
+++ b/apps/web/src/branding.ts
@@ -21,7 +21,7 @@ export const APP_BASE_NAME = injectedDesktopAppBranding?.baseName ?? BRAND.name;
 export const APP_STAGE_LABEL =
   injectedDesktopAppBranding?.stageLabel ??
   HOSTED_APP_CHANNEL_LABEL ??
-  (import.meta.env.DEV ? "Dev" : "Alpha");
+  (import.meta.env.DEV ? "Dev" : "Latest");
 export const APP_DISPLAY_NAME =
   injectedDesktopAppBranding?.displayName ??
   formatAppDisplayName({ baseName: APP_BASE_NAME, stageLabel: APP_STAGE_LABEL });

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -169,7 +169,7 @@ export type DesktopUpdateStatus =
 export type DesktopRuntimeArch = "arm64" | "x64" | "other";
 export type DesktopTheme = "light" | "dark" | "system";
 export type DesktopUpdateChannel = "latest" | "nightly";
-export type DesktopAppStageLabel = "Alpha" | "Dev" | "Nightly";
+export type DesktopAppStageLabel = "Latest" | "Dev" | "Nightly";
 
 export const DesktopUpdateStatusSchema = Schema.Literals([
   "disabled",
@@ -184,7 +184,7 @@ export const DesktopUpdateStatusSchema = Schema.Literals([
 export const DesktopRuntimeArchSchema = Schema.Literals(["arm64", "x64", "other"]);
 export const DesktopThemeSchema = Schema.Literals(["light", "dark", "system"]);
 export const DesktopUpdateChannelSchema = Schema.Literals(["latest", "nightly"]);
-export const DesktopAppStageLabelSchema = Schema.Literals(["Alpha", "Dev", "Nightly"]);
+export const DesktopAppStageLabelSchema = Schema.Literals(["Latest", "Dev", "Nightly"]);
 
 export interface DesktopAppBranding {
   baseName: string;

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -45,6 +45,7 @@ import {
   resolveClerkPasskeyNativeArtifacts,
   resolveMacPasskeySigningConfiguration,
   resolveDesktopRuntimeDependencies,
+  omitWorkspaceDependencies,
   resolveMacStageDependencies,
   resolveFffNativeDependencies,
   resolveBuildOptions,
@@ -409,6 +410,20 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
       {
         "@effect/platform-node": "4.0.0-beta.59",
         effect: "4.0.0-beta.59",
+      },
+    );
+  });
+
+  it("omits bundled workspace packages from standalone server dependencies", () => {
+    assert.deepStrictEqual(
+      omitWorkspaceDependencies({
+        "@flow/brain-runtime": "workspace:*",
+        falkordblite: "0.3.0",
+        effect: "4.0.0-beta.103",
+      }),
+      {
+        falkordblite: "0.3.0",
+        effect: "4.0.0-beta.103",
       },
     );
   });

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -261,7 +261,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
   });
 
   it("switches desktop packaging product names to nightly for nightly builds", () => {
-    assert.equal(resolveDesktopProductName("0.0.17"), `${BRAND.name} (Alpha)`);
+    assert.equal(resolveDesktopProductName("0.0.17"), BRAND.name);
     assert.equal(
       resolveDesktopProductName("0.0.17-nightly.20260413.42"),
       `${BRAND.name} (Nightly)`,
@@ -326,6 +326,28 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         channel: "nightly",
       });
     }),
+  );
+
+  it.effect("prefers an isolated generic desktop update feed", () =>
+    Effect.gen(function* () {
+      const config = yield* resolveGitHubPublishConfig("latest");
+      assert.deepStrictEqual(config, {
+        provider: "generic",
+        url: "https://github.com/samyakkkk/flow/releases/download/flow-desktop-latest",
+      });
+    }).pipe(
+      Effect.provide(
+        ConfigProvider.layer(
+          ConfigProvider.fromEnv({
+            env: {
+              T3CODE_DESKTOP_UPDATE_URL:
+                "https://github.com/samyakkkk/flow/releases/download/flow-desktop-latest/",
+              GITHUB_REPOSITORY: "samyakkkk/flow",
+            },
+          }),
+        ),
+      ),
+    ),
   );
 
   it.effect("omits update feeds for pull request preview builds", () =>
@@ -662,7 +684,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         "**/node_modules/.bin/**",
       ]);
       assert.deepStrictEqual(mac.dmg, {
-        title: `${BRAND.name} (Alpha) 1.2.3 Installer`,
+        title: `${BRAND.name} 1.2.3 Installer`,
         background: "dmg/dmg-background-latest.png",
         window: { width: 540, height: 412 },
         contents: [
@@ -673,9 +695,9 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         iconTextSize: 12,
       });
       // Linux must register the renderer schemes so the generated .desktop
-      // entry advertises MimeType=x-scheme-handler/t3code; for OAuth deep links.
+      // entry advertises MimeType=x-scheme-handler/flow; for OAuth deep links.
       assert.deepStrictEqual((linux.linux as Record<string, unknown>).protocols, [
-        { name: `${BRAND.name}`, schemes: ["t3code", "t3code-dev"] },
+        { name: `${BRAND.name}`, schemes: ["flow", "flow-dev"] },
       ]);
       assert.deepStrictEqual(mac.files, [...DESKTOP_FILE_EXCLUSIONS, ...MAC_FILE_EXCLUSIONS]);
       assert.notProperty(mac.mac as Record<string, unknown>, "sign");
@@ -1591,7 +1613,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
     });
 
     assert.deepStrictEqual(configuration, {
-      appId: "com.t3tools.t3code",
+      appId: "com.flow.desktop",
       teamId: "ABC1234567",
       rpDomains: ["example.clerk.accounts.dev"],
       provisioningProfilePath: "/tmp/t3code.provisionprofile",
@@ -1611,7 +1633,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
       "clerk.example.com",
       "example.clerk.accounts.dev",
     ]);
-    assert.include(entitlements, "<string>ABC1234567.com.t3tools.t3code</string>");
+    assert.include(entitlements, "<string>ABC1234567.com.flow.desktop</string>");
     assert.include(entitlements, "<string>webcredentials:clerk.example.com</string>");
     assert.include(entitlements, "<string>webcredentials:example.clerk.accounts.dev</string>");
     assert.include(entitlements, "<key>com.apple.security.cs.allow-jit</key>");
@@ -1706,12 +1728,12 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
       });
 
       const mac = config.mac as Record<string, unknown>;
-      assert.equal(config.appId, "com.t3tools.t3code");
+      assert.equal(config.appId, "com.flow.desktop");
       assert.equal(mac.entitlements, "/tmp/entitlements.mac.plist");
       assert.equal(mac.provisioningProfile, "/tmp/t3code.provisionprofile");
       assert.match(String(mac.sign), /[\\/]scripts[\\/]sign-macos\.ts$/);
       assert.deepStrictEqual(mac.protocols, [
-        { name: `${BRAND.name}`, schemes: ["t3code", "t3code-dev"] },
+        { name: `${BRAND.name}`, schemes: ["flow", "flow-dev"] },
       ]);
     }).pipe(Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} })))),
   );

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -2489,6 +2489,16 @@ export function resolveDesktopRuntimeDependencies(
   return resolveCatalogDependencies(runtimeDependencies, catalog, "apps/desktop");
 }
 
+export function omitWorkspaceDependencies(
+  dependencies: Record<string, string>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(dependencies).filter(
+      ([, dependencySpec]) => !dependencySpec.startsWith("workspace:"),
+    ),
+  );
+}
+
 export const resolveGitHubPublishConfig = Effect.fn("resolveGitHubPublishConfig")(function* (
   updateChannel: "latest" | "nightly",
 ) {
@@ -3655,7 +3665,7 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
             fffNodeVersion: serverPackageJson.dependencies["@ff-labs/fff-node"],
           })
         : {
-            ...resolvedServerDependencies,
+            ...omitWorkspaceDependencies(resolvedServerDependencies),
             ...resolvedDesktopRuntimeDependencies,
             ...resolveFffNativeDependencies(
               options.platform,

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -56,7 +56,7 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 const LINUX_ICON_SIZES = [16, 22, 24, 32, 48, 64, 128, 256, 512] as const;
 checkBranding();
 
-const DESKTOP_APP_ID = "com.t3tools.t3code";
+const DESKTOP_APP_ID = "com.flow.desktop";
 const APPLE_TEAM_ID_PATTERN = /^[A-Z0-9]{10}$/u;
 
 const BuildPlatform = Schema.Literals(["mac", "linux", "win"]);
@@ -2493,9 +2493,14 @@ export const resolveGitHubPublishConfig = Effect.fn("resolveGitHubPublishConfig"
   updateChannel: "latest" | "nightly",
 ) {
   const env = yield* Config.all({
+    updateUrl: Config.string("T3CODE_DESKTOP_UPDATE_URL").pipe(Config.option),
     updateRepository: Config.string("T3CODE_DESKTOP_UPDATE_REPOSITORY").pipe(Config.option),
     githubRepository: Config.string("GITHUB_REPOSITORY").pipe(Config.option),
   });
+  const updateUrl = Option.getOrUndefined(env.updateUrl)?.trim();
+  if (updateUrl) {
+    return { provider: "generic", url: new URL(updateUrl).href.replace(/\/$/u, "") };
+  }
   const rawRepo = (
     Option.getOrUndefined(env.updateRepository)?.trim() ||
     Option.getOrUndefined(env.githubRepository)?.trim() ||
@@ -2563,7 +2568,7 @@ export function resolvePackageManagerUserAgent(packageManager: string): string {
 export function resolveDesktopProductName(version: string): string {
   return resolveDesktopUpdateChannel(version) === "nightly"
     ? `${BRAND.name} (Nightly)`
-    : `${BRAND.name} (Alpha)`;
+    : BRAND.name;
 }
 
 export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
@@ -2633,7 +2638,7 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
       protocols: [
         {
           name: BRAND.name,
-          schemes: ["t3code", "t3code-dev"],
+          schemes: ["flow", "flow-dev"],
         },
       ],
       ...(signed ? { sign: path.join(repoRoot, "scripts/sign-macos.ts") } : {}),
@@ -2672,21 +2677,21 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
   if (platform === "linux") {
     buildConfig.linux = {
       target: [target],
-      executableName: "t3code",
+      executableName: "flow",
       icon: "icons",
       category: "Development",
       // electron-builder turns these into MimeType=x-scheme-handler/<scheme>;
       // in the .desktop entry (Exec already gets %U), so browsers can hand
-      // t3code:// OAuth callbacks to the app.
+      // flow:// OAuth callbacks to the app.
       protocols: [
         {
           name: BRAND.name,
-          schemes: ["t3code", "t3code-dev"],
+          schemes: ["flow", "flow-dev"],
         },
       ],
       desktop: {
         entry: {
-          StartupWMClass: "t3code",
+          StartupWMClass: "flow",
         },
       },
     };
@@ -3600,10 +3605,16 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
   const stageProdResourcesDir = path.join(stageAppDir, "apps/desktop/prod-resources");
   yield* fs.copy(stageResourcesDir, stageProdResourcesDir);
 
+  const repoEnv = loadRepoEnv({ repoRoot });
+  const hasExplicitMacPasskeyConfiguration = [
+    repoEnv.T3CODE_APPLE_TEAM_ID,
+    repoEnv.T3CODE_MACOS_PROVISIONING_PROFILE,
+    repoEnv.T3CODE_CLERK_PASSKEY_RP_DOMAINS,
+  ].some((value) => value?.trim());
   const configuredMacPasskeySigning =
-    options.platform === "mac" && options.signed
+    options.platform === "mac" && options.signed && hasExplicitMacPasskeyConfiguration
       ? yield* Effect.try({
-          try: () => resolveMacPasskeySigningConfiguration(loadRepoEnv({ repoRoot })),
+          try: () => resolveMacPasskeySigningConfiguration(repoEnv),
           catch: MacPasskeySigningConfigurationResolutionError.fromCause,
         })
       : undefined;
@@ -3661,14 +3672,14 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
       ? path.join(stageAppDir, WINDOWS_SERVER_RESOURCE_SOURCE_DIR, WINDOWS_SERVER_ASAR_RESOURCE)
       : undefined;
   const stagePackageJson: StagePackageJson = {
-    name: "t3code",
+    name: "flow-desktop",
     version: appVersion,
     buildVersion: appVersion,
     t3codeCommitHash: commitHash,
     private: true,
     packageManager: rootPackageJson.packageManager,
     description: `${BRAND.name} desktop build`,
-    author: "T3 Tools",
+    author: "Flow",
     main: "apps/desktop/dist-electron/main.cjs",
     build: yield* createBuildConfig(
       options.platform,

--- a/scripts/configure-branding.mjs
+++ b/scripts/configure-branding.mjs
@@ -108,7 +108,7 @@ const desktopPackage = JSON.parse(
 );
 outputs.set(
   "apps/desktop/package.json",
-  JSON.stringify({ ...desktopPackage, productName: `${config.name} (Alpha)` }, null, 2) + "\n",
+  JSON.stringify({ ...desktopPackage, productName: config.name }, null, 2) + "\n",
 );
 outputs.set(
   "assets/brand/fingerprint",

--- a/scripts/flow-release.mjs
+++ b/scripts/flow-release.mjs
@@ -94,11 +94,25 @@ async function download(url, fetcher = fetch, timeout = 120000) {
 }
 
 export async function latestRelease(fetcher = fetch) {
-  return validateRelease(
-    await (
-      await download(`https://api.github.com/repos/${repository}/releases/latest`, fetcher)
-    ).json(),
+  const releases = await (
+    await download(`https://api.github.com/repos/${repository}/releases?per_page=100`, fetcher)
+  ).json();
+  if (!Array.isArray(releases)) throw Error("GitHub returned an invalid Flow release feed.");
+
+  const stableBrowserReleases = releases.filter(
+    (release) =>
+      release &&
+      tagPattern.test(release.tag_name) &&
+      release.draft !== true &&
+      release.prerelease !== true,
   );
+  const latest = stableBrowserReleases.reduce(
+    (selected, release) =>
+      selected === undefined || newerTag(release.tag_name, selected.tag_name) ? release : selected,
+    undefined,
+  );
+  if (!latest) throw Error("No stable Flow browser release (flow-vX.Y.Z) is available.");
+  return validateRelease(latest);
 }
 
 export function verifyArchive(bytes, checksum, name = assetName) {

--- a/scripts/flow-release.test.mjs
+++ b/scripts/flow-release.test.mjs
@@ -74,6 +74,23 @@ test("release lookup reports unavailable or rate-limited feeds", async () => {
   }
 });
 
+test("release lookup ignores desktop releases and selects the newest browser version", async () => {
+  const result = await latestRelease(
+    async () =>
+      new Response(
+        JSON.stringify([
+          { ...release("flow-desktop-v9.0.0"), tag_name: "flow-desktop-v9.0.0" },
+          release("flow-v1.9.0"),
+          release("flow-v1.10.0"),
+          { ...release("flow-v2.0.0"), prerelease: true },
+        ]),
+        { headers: { "Content-Type": "application/json" } },
+      ),
+  );
+
+  assert.equal(result.tag, "flow-v1.10.0");
+});
+
 async function fixture(t) {
   const root = await fs.realpath(await fs.mkdtemp(join(tmpdir(), "flow-release-test-")));
   t.after(() => fs.rm(root, { recursive: true, force: true }));

--- a/scripts/refresh-update-manifest.test.ts
+++ b/scripts/refresh-update-manifest.test.ts
@@ -1,0 +1,46 @@
+import * as NodeCrypto from "node:crypto";
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+
+import { assert, it } from "@effect/vitest";
+
+import { parseUpdateManifest } from "./lib/update-manifest.ts";
+import { refreshUpdateManifestArtifacts } from "./refresh-update-manifest.ts";
+
+it("refreshes updater metadata after a distribution artifact changes", () => {
+  const dir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "flow-update-manifest-"));
+  const manifestPath = NodePath.join(dir, "latest-mac.yml");
+  const artifactName = "Flow-0.1.2-arm64.dmg";
+  const finalBytes = Buffer.from("stapled-dmg-bytes");
+  NodeFS.writeFileSync(NodePath.join(dir, artifactName), finalBytes);
+  NodeFS.writeFileSync(
+    manifestPath,
+    `version: 0.1.2
+files:
+  - url: ${artifactName}
+    sha512: stale
+    size: 1
+releaseDate: '2026-09-11T16:08:34.626Z'
+`,
+  );
+
+  refreshUpdateManifestArtifacts({
+    manifestPath,
+    artifactsDir: dir,
+    platformLabel: "macOS",
+  });
+
+  const refreshed = parseUpdateManifest(
+    NodeFS.readFileSync(manifestPath, "utf8"),
+    manifestPath,
+    "macOS",
+  );
+  assert.deepStrictEqual(refreshed.files, [
+    {
+      url: artifactName,
+      sha512: NodeCrypto.createHash("sha512").update(finalBytes).digest("base64"),
+      size: finalBytes.length,
+    },
+  ]);
+});

--- a/scripts/refresh-update-manifest.ts
+++ b/scripts/refresh-update-manifest.ts
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+import * as NodeCrypto from "node:crypto";
+import * as NodeFS from "node:fs";
+import * as NodePath from "node:path";
+
+import {
+  parseUpdateManifest,
+  serializeUpdateManifest,
+  type UpdateManifestFile,
+} from "./lib/update-manifest.ts";
+
+export function refreshUpdateManifestArtifacts(input: {
+  readonly manifestPath: string;
+  readonly artifactsDir: string;
+  readonly platformLabel: string;
+}): void {
+  const manifest = parseUpdateManifest(
+    NodeFS.readFileSync(input.manifestPath, "utf8"),
+    input.manifestPath,
+    input.platformLabel,
+  );
+  const artifactsDir = NodePath.resolve(input.artifactsDir);
+  const files = manifest.files.map((entry): UpdateManifestFile => {
+    if (NodePath.basename(entry.url) !== entry.url) {
+      throw new Error(`Update manifest artifact must be a file name: ${entry.url}`);
+    }
+    const bytes = NodeFS.readFileSync(NodePath.join(artifactsDir, entry.url));
+    return {
+      ...entry,
+      sha512: NodeCrypto.createHash("sha512").update(bytes).digest("base64"),
+      size: bytes.length,
+    };
+  });
+
+  NodeFS.writeFileSync(
+    input.manifestPath,
+    serializeUpdateManifest({ ...manifest, files }, { platformLabel: input.platformLabel }),
+  );
+}
+
+if (import.meta.main) {
+  const [manifestPath, artifactsDir, platformLabel = "desktop"] = process.argv.slice(2);
+  if (!manifestPath || !artifactsDir) {
+    throw new Error(
+      "Usage: refresh-update-manifest.ts <manifest-path> <artifacts-dir> [platform-label]",
+    );
+  }
+  refreshUpdateManifestArtifacts({ manifestPath, artifactsDir, platformLabel });
+}


### PR DESCRIPTION
## What Changed

Flow now has an independent desktop release path triggered by `flow-desktop-vX.Y.Z` tags or manual workflow dispatch. The workflow builds macOS arm64, macOS x64, and Linux x64 artifacts; signs, notarizes, staples, and validates the Mac app; refreshes updater metadata after stapling; and publishes separate versioned and rolling desktop releases.

The desktop identity is now Flow throughout: stable builds display as `Flow`, use `com.flow.desktop`, register `flow://` and `flow-dev://`, and use Flow-owned Linux executable and desktop identifiers. Packaging also stages the local Brain runtime without leaking workspace dependency specifiers into the distributable.

The README now presents Flow as “Coding harness with a brain,” explains the knowledge graph, retained context, Auto-Docs and Auto-Skills, documents the shipped harness features, and links directly to the signed Apple Silicon DMG. Team sharing, Linear, Slack, Intel installers, and native Linux installers are clearly marked as coming soon.

## Why

The imported desktop still carried upstream T3 identity and had no Flow-owned signing, notarization, publication, or updater channel. A direct-distribution build also needs its updater manifest generated from the final stapled bytes; otherwise Gatekeeper-valid artifacts can have stale hashes and sizes.

This creates one reviewable path from a Flow desktop version to signed public artifacts while keeping desktop releases separate from the existing browser release feed.

## UI Changes

Stable builds now show `Flow` instead of `Flow (Alpha)`. The README has been rewritten around the current product. No layout or interaction behavior changed.

## Validation

- Focused desktop identity, packaging, release, and updater-manifest tests passed during implementation.
- Nine focused release/manifest tests and workflow YAML parsing passed after the final publication fixes.
- Flow 0.1.2 arm64 passed Developer ID signature verification, Apple notarization, stapler validation, and Gatekeeper assessment.
- The immutable `flow-desktop-v0.1.2` release and rolling `flow-desktop-latest` feed contain the verified arm64 assets with matching sizes and SHA-256 digests; anonymous DMG and update-manifest downloads succeed.
- The README passes `git diff --check`, all 19 local references resolve, GitHub's Markdown renderer accepts it, and its public DMG link returns HTTP 200.

The final workflow fixes have focused coverage but have not yet been exercised by a later version tag end to end. The 0.1.2 arm64 release was recovered from successful retained build artifacts and published after exact artifact verification.

## Checklist

- [x] This PR is focused on Flow desktop distribution and its public release documentation
- [x] I explained what changed and why
- [ ] I included before/after screenshots for the stable app-name change
- [x] No animation or interaction changes require video evidence

Created with GPT-5.6 Sol using the Codex harness in Flow.
