### PR TITLE
fix(desktop): include Brain dependencies in release builds

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -44,6 +44,8 @@
   },
   "devDependencies": {
     "@effect/vitest": "catalog:",
+    "@flow/brain-graph-gateway": "workspace:*",
+    "@flow/brain-orchestrator": "workspace:*",
     "@t3tools/contracts": "workspace:*",
     "@t3tools/shared": "workspace:*",
     "@t3tools/tailscale": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -535,6 +535,12 @@ importers:
         specifier: ^3.4.0
         version: 3.4.0
     devDependencies:
+      '@flow/brain-graph-gateway':
+        specifier: workspace:*
+        version: link:../../flow-t3/shared/graph-gateway
+      '@flow/brain-orchestrator':
+        specifier: workspace:*
+        version: link:../../flow-t3/shared/orchestrator
       '@effect/vitest':
         specifier: 4.0.0-beta.103
         version: 4.0.0-beta.103(patch_hash=a16b1e870d8c29e4a98b17cc4c638a4ff471753d8ca3487f78a22b759caf951b)(effect@4.0.0-beta.103(patch_hash=af36b7948b6f9c56623074662b51dade5699880c1a7c71245de73e13c3185fb6))

--- a/scripts/brain-package.test.ts
+++ b/scripts/brain-package.test.ts
@@ -1,0 +1,55 @@
+import { createPackage } from "@electron/asar";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+import { verifyPackagedBundleIsSelfContained } from "./build-desktop-artifact.ts";
+
+const packagedFixture = Effect.fn("packagedFixture")(function* (includeDependency: boolean) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const root = yield* fs.makeTempDirectoryScoped({ prefix: "flow-brain-package-test-" });
+  const app = path.join(root, "app");
+  const dist = path.join(app, "apps/server/dist");
+  yield* fs.makeDirectory(dist, { recursive: true });
+  yield* fs.writeFileString(path.join(dist, "bin.mjs"), 'console.log("1.0.0");');
+  yield* fs.writeFileString(
+    path.join(dist, "brain-runtime.mjs"),
+    'import "flow-test-catalog-dependency"; if (!process.argv.includes("--catalog")) process.exit(2);',
+  );
+  if (includeDependency) {
+    const dependency = path.join(app, "node_modules/flow-test-catalog-dependency");
+    yield* fs.makeDirectory(dependency, { recursive: true });
+    yield* fs.writeFileString(
+      path.join(dependency, "package.json"),
+      '{"name":"flow-test-catalog-dependency","type":"module","exports":"./index.js"}',
+    );
+    yield* fs.writeFileString(path.join(dependency, "index.js"), "export const tools = [];");
+  }
+  const archive = path.join(root, "app.asar");
+  yield* Effect.promise(() => createPackage(app, archive));
+  return archive;
+});
+
+it.layer(NodeServices.layer)("packaged Brain startup", (it) => {
+  it.effect("rejects a missing worker dependency even when the server version check passes", () =>
+    Effect.gen(function* () {
+      const asarPath = yield* packagedFixture(false);
+      const error = yield* verifyPackagedBundleIsSelfContained({ asarPath, verbose: false }).pipe(
+        Effect.flip,
+      );
+      assert.equal(error._tag, "BundleNotSelfContainedError");
+      assert.include(error.message, "flow-test-catalog-dependency");
+      assert.include(error.message, "brain-runtime.mjs --catalog");
+    }).pipe(Effect.scoped),
+  );
+
+  it.effect("loads the catalog using only dependencies inside the packaged archive", () =>
+    Effect.gen(function* () {
+      const asarPath = yield* packagedFixture(true);
+      yield* verifyPackagedBundleIsSelfContained({ asarPath, verbose: false });
+    }).pipe(Effect.scoped),
+  );
+});

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -166,6 +166,10 @@ const makeWindowsPayloadFixture = Effect.fn("test.makeWindowsPayloadFixture")(fu
   yield* fs.makeDirectory(path.dirname(serverEntryPath), { recursive: true });
   yield* fs.makeDirectory(path.dirname(nativePath), { recursive: true });
   yield* fs.writeFileString(serverEntryPath, input.serverEntrySource ?? "console.log('server');\n");
+  yield* fs.writeFileString(
+    path.join(sourceDir, "apps/server/dist/brain-runtime.mjs"),
+    "export {};\n",
+  );
   yield* fs.writeFileString(nativePath, "native-binary");
 
   const generatedAsarPath = path.join(tempDir, WINDOWS_SERVER_ASAR_RESOURCE);

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -599,7 +599,7 @@ export class BundleNotSelfContainedError extends Schema.TaggedErrorClass<BundleN
   { exitCode: Schema.Number, output: Schema.String },
 ) {
   override get message(): string {
-    return `The packaged server bundle could not load from the isolated, extracted sidecar (exit ${this.exitCode}). Anything it imports that is neither a Node built-in nor in the selected runtime-external closure is unavailable to both backends. Output:
+    return `The packaged server bundle could not load from the isolated, extracted archive (exit ${this.exitCode}). Anything it imports that is neither a Node built-in nor in the selected runtime-external closure is unavailable to the packaged runtime. Output:
 ${this.output}`;
   }
 }
@@ -2046,7 +2046,7 @@ export const copyDirectoryPreservingSymlinks = Effect.fn("copyDirectoryPreservin
   },
 );
 
-const verifyPackagedBundleIsSelfContained = Effect.fn("verifyPackagedBundleIsSelfContained")(
+export const verifyPackagedBundleIsSelfContained = Effect.fn("verifyPackagedBundleIsSelfContained")(
   function* (input: { readonly asarPath: string; readonly verbose: boolean }) {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
@@ -2081,64 +2081,72 @@ const verifyPackagedBundleIsSelfContained = Effect.fn("verifyPackagedBundleIsSel
       }
     }
 
-    const entryPoint = path.join(probeApp, "apps/server/dist/bin.mjs");
-    if (!(yield* fs.exists(entryPoint).pipe(Effect.orElseSucceed(() => false)))) {
-      return yield* new BundleNotSelfContainedError({
-        exitCode: -1,
-        output: `Expected the server entry at ${entryPoint}.`,
-      });
-    }
+    // The Brain worker is a separate entry point: loading bin.mjs cannot catch
+    // missing dependencies in its catalog, which blocks desktop startup.
+    for (const [entry, argument] of [
+      ["bin.mjs", "--version"],
+      ["brain-runtime.mjs", "--catalog"],
+    ] as const) {
+      const entryPoint = path.join(probeApp, "apps/server/dist", entry);
+      if (!(yield* fs.exists(entryPoint).pipe(Effect.orElseSucceed(() => false)))) {
+        return yield* new BundleNotSelfContainedError({
+          exitCode: -1,
+          output: `Expected the server entry at ${entryPoint}.`,
+        });
+      }
 
-    // --version exercises the eagerly loaded module graph, which is where a
-    // missing dependency shows up, without starting a server or touching disk
-    // state. It does not cover lazily imported externals: node-pty is checked
-    // by the WSL preflight probe at runtime, while ffi-rs, @ff-labs/fff-node
-    // and the bun adapters are covered by the shared runtime-external closure
-    // and emitted-bundle checks.
-    yield* runCommand(
-      ChildProcess.make(
-        process.execPath,
-        // --no-global-search-paths because clearing NODE_PATH is not enough:
-        // CommonJS resolution still falls back to $HOME/.node_modules,
-        // $HOME/.node_libraries and the install prefix, so a globally installed
-        // copy of a missing dependency would quietly satisfy this check.
-        ["--no-global-search-paths", entryPoint, "--version"],
+      // --version exercises the eagerly loaded module graph, which is where a
+      // missing dependency shows up, without starting a server or touching disk
+      // state. It does not cover lazily imported externals: node-pty is checked
+      // by the WSL preflight probe at runtime, while ffi-rs, @ff-labs/fff-node
+      // and the bun adapters are covered by the shared runtime-external closure
+      // and emitted-bundle checks.
+      yield* runCommand(
+        ChildProcess.make(
+          process.execPath,
+          // --no-global-search-paths because clearing NODE_PATH is not enough:
+          // CommonJS resolution still falls back to $HOME/.node_modules,
+          // $HOME/.node_libraries and the install prefix, so a globally installed
+          // copy of a missing dependency would quietly satisfy this check.
+          ["--no-global-search-paths", entryPoint, argument],
+          {
+            cwd: probeApp,
+            stdout: "pipe",
+            stderr: "pipe",
+            // NODE_PATH would let a createRequire call inside the bundle resolve
+            // a missing external from outside the packaged tree, which is the
+            // whole thing this is trying to rule out.
+            env: { ...process.env, NODE_PATH: "", NODE_OPTIONS: "" },
+          },
+        ),
         {
-          cwd: probeApp,
-          stdout: "pipe",
-          stderr: "pipe",
-          // NODE_PATH would let a createRequire call inside the bundle resolve
-          // a missing external from outside the packaged tree, which is the
-          // whole thing this is trying to rule out.
-          env: { ...process.env, NODE_PATH: "" },
+          label: `packaged runtime self-containment check (node ${entry} ${argument})`,
+          verbose: input.verbose,
         },
-      ),
-      {
-        label: "server sidecar self-containment check (node bin.mjs --version)",
-        verbose: input.verbose,
-      },
-    ).pipe(
-      // Printing a version should be immediate. A regression that blocks (on
-      // stdin, a port, a lock) would otherwise hang release CI until the job
-      // times out with nothing useful in the log.
-      Effect.timeout(BUNDLE_SELF_CHECK_TIMEOUT),
-      Effect.catchTags({
-        TimeoutError: () =>
-          Effect.fail(
-            new BundleNotSelfContainedError({
-              exitCode: -1,
-              output: `The packaged bundle did not print its version within ${Duration.toSeconds(BUNDLE_SELF_CHECK_TIMEOUT)}s; it is hanging rather than failing to resolve.`,
-            }),
-          ),
-        BuildCommandFailedError: (error) =>
-          Effect.fail(
-            new BundleNotSelfContainedError({
-              exitCode: error.exitCode,
-              output: `${error.stderrTail ?? ""}${error.stdoutTail ?? ""}`.trim(),
-            }),
-          ),
-      }),
-    );
+      ).pipe(
+        // Printing a version should be immediate. A regression that blocks (on
+        // stdin, a port, a lock) would otherwise hang release CI until the job
+        // times out with nothing useful in the log.
+        Effect.timeout(BUNDLE_SELF_CHECK_TIMEOUT),
+        Effect.catchTags({
+          TimeoutError: () =>
+            Effect.fail(
+              new BundleNotSelfContainedError({
+                exitCode: -1,
+                output: `The packaged ${entry} ${argument} check did not finish within ${Duration.toSeconds(BUNDLE_SELF_CHECK_TIMEOUT)}s; it is hanging rather than failing to resolve.`,
+              }),
+            ),
+          BuildCommandFailedError: (error) =>
+            Effect.fail(
+              new BundleNotSelfContainedError({
+                exitCode: error.exitCode,
+                output:
+                  `${entry} ${argument}: ${error.stderrTail ?? ""}${error.stdoutTail ?? ""}`.trim(),
+              }),
+            ),
+        }),
+      );
+    }
   },
 );
 
@@ -3850,6 +3858,28 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
       }),
       verbose: options.verbose,
     });
+  }
+
+  if (options.platform !== "win") {
+    const productName = resolveDesktopProductName(appVersion);
+    const packagedDirectories = yield* fs.readDirectory(stageDistDir);
+    const archives: string[] = [];
+    for (const directory of packagedDirectories) {
+      const archive =
+        options.platform === "mac"
+          ? path.join(stageDistDir, directory, `${productName}.app`, "Contents/Resources/app.asar")
+          : path.join(stageDistDir, directory, "resources/app.asar");
+      if (yield* fs.exists(archive)) archives.push(archive);
+    }
+    if (archives.length === 0) {
+      return yield* new BundleNotSelfContainedError({
+        exitCode: -1,
+        output: `No packaged app.asar found in ${stageDistDir}.`,
+      });
+    }
+    for (const asarPath of archives) {
+      yield* verifyPackagedBundleIsSelfContained({ asarPath, verbose: options.verbose });
+    }
   }
 
   const stageEntries = yield* fs.readDirectory(stageDistDir);


### PR DESCRIPTION
Flow’s DMG can hang before opening a window because the filtered release install omits the Brain worker’s dependencies. Declare both Brain build packages in the server workspace and check the packaged worker’s catalog alongside the server entry point on macOS, Linux, and Windows.

Validation: 70 focused packaging tests pass on main-v2. The new check rejected the original broken DMG; a worker rebuilt with the corrected filtered install passed using only the original DMG’s packaged dependencies.

Only the packaging fix is included. This PR does not publish a release.

Model and harness: GPT-6, Codex desktop.
